### PR TITLE
Stop indexing JS with `--inferTSConfig`

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -157,10 +157,7 @@ export function index(options: Options): void {
     }
     if (!ts.sys.fileExists(tsconfigFileName)) {
       if (options.inferTSConfig) {
-        fs.writeFileSync(
-          tsconfigFileName,
-          '{"compilerOptions":{"allowJs":true}}'
-        )
+        fs.writeFileSync(tsconfigFileName, '{}')
       } else {
         console.error(`- ${options.projectDisplayName} (missing tsconfig.json)`)
         return


### PR DESCRIPTION
This behavior was dramatically slowing down the indexing of npm package
repos for questionable value. If the user wants to index JS code then
they can add that config to their `tsconfig.json` file. This flag was
added specifically for npm package repos.

Fixes #38 

### Test plan

Manually tested by indexing the `npm/typescript` package repo, which timed out before due to the large amount of typescript it contains.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
