### PR TITLE
Make the command-line interface behave more like `tsc -b`

### DIFF
--- a/Dockerfile.autoindex
+++ b/Dockerfile.autoindex
@@ -10,7 +10,7 @@ COPY --from=src-cli /usr/bin/src /usr/bin
 
 RUN curl -Lo /usr/bin/lsif-typed https://github.com/sourcegraph/lsif-typescript/releases/download/v0.1.13/lsif-typed && chmod +x /usr/bin/lsif-typed
 
-RUN echo 'lsif-typescript "$@" --noProgressBar && lsif-typed dump.lsif-typed > dump.lsif' > /usr/bin/lsif-typescript-autoindex && chmod +x /usr/bin/lsif-typescript-autoindex
+RUN echo 'lsif-typescript "$@" --no-progress-bar && lsif-typed dump.lsif-typed > dump.lsif' > /usr/bin/lsif-typescript-autoindex && chmod +x /usr/bin/lsif-typescript-autoindex
 
 RUN npm install --global n@latest @sourcegraph/lsif-typescript@latest
 

--- a/package.json
+++ b/package.json
@@ -33,11 +33,11 @@
   },
   "homepage": "https://github.com/sourcegraph/lsif-typescript#readme",
   "dependencies": {
+    "commander": "^9.1.0",
     "google-protobuf": "^3.19.3",
     "pretty-ms": "^7.0.1",
     "progress": "^2.0.3",
-    "typescript": "^4.5.4",
-    "yargs": "^17.3.1"
+    "typescript": "^4.5.4"
   },
   "devDependencies": {
     "@sourcegraph/eslint-config": "0.27.0",
@@ -48,7 +48,6 @@
     "@types/node": "17.0.14",
     "@types/pretty-ms": "^5.0.1",
     "@types/progress": "^2.0.5",
-    "@types/yargs": "17.0.9",
     "@typescript-eslint/eslint-plugin": "^5.14.0",
     "@typescript-eslint/parser": "^5.14.0",
     "diff": "^5.0.0",

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -8,7 +8,7 @@ import { test } from 'uvu'
 
 import { Input } from './Input'
 import * as lsif from './lsif'
-import { index as lsifIndex, listYarnWorkspaces } from './main'
+import { indexCommand } from './main'
 import { Range } from './Range'
 
 const lsiftyped = lsif.lib.codeintel.lsiftyped
@@ -45,37 +45,20 @@ for (const snapshotDirectory of snapshotDirectories) {
     const packageJson = JSON.parse(
       fs.readFileSync(packageJsonPath).toString()
     ) as PackageJson
-    const index = new lsif.lib.codeintel.lsiftyped.Index()
-    const projects: string[] = packageJson.workspaces
-      ? listYarnWorkspaces(inputRoot)
-      : [inputRoot]
-    for (const projectRoot of projects) {
-      const documentCountBeforeProject = index.documents.length
-      lsifIndex({
-        workspaceRoot: inputRoot,
-        projectRoot,
-        projectDisplayName: projectRoot,
-        noProgressBar: true,
-        inferTSConfig: false,
-        writeIndex: partialIndex => {
-          if (partialIndex.metadata) {
-            index.metadata = partialIndex.metadata
-          }
-          for (const document of partialIndex.documents) {
-            index.documents.push(document)
-          }
-        },
-      })
-      const documentCountAfterProject = index.documents.length
-      if (documentCountAfterProject === documentCountBeforeProject) {
-        throw new Error(`no indexed documents in project ${projectRoot}`)
-      }
-    }
-    fs.mkdirSync(outputRoot, { recursive: true })
-    fs.writeFileSync(
-      path.join(outputRoot, 'dump.lsif-typed'),
-      index.serializeBinary()
+    const output = path.join(inputRoot, 'dump.lsif-typed')
+    indexCommand([], {
+      cwd: inputRoot,
+      inferTsconfig: false,
+      output,
+      yarnWorkspaces: Boolean(packageJson.workspaces),
+      progressBar: false,
+      indexedProjects: new Set(),
+    })
+    const index = lsif.lib.codeintel.lsiftyped.Index.deserializeBinary(
+      fs.readFileSync(path.join(inputRoot, 'dump.lsif-typed'))
     )
+    fs.mkdirSync(outputRoot, { recursive: true })
+    fs.renameSync(output, path.join(outputRoot, 'dump.lsif-typed'))
     if (index.documents.length === 0) {
       throw new Error('empty LSIF index')
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -459,17 +459,17 @@
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"
   integrity sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==
 
-"@types/yargs@17.0.9", "@types/yargs@^17.0.0":
-  version "17.0.9"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.9.tgz#f1f931a4e5ae2c0134dea10f501088636a50b46a"
-  integrity sha512-Ci8+4/DOtkHRylcisKmVMtmVO5g7weUVCKcsu1sJvF1bn0wExTmbHmhFKj7AnEm0de800iovGhdSKzYnzbaHpg==
-  dependencies:
-    "@types/yargs-parser" "*"
-
 "@types/yargs@^15.0.0":
   version "15.0.14"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.14.tgz#26d821ddb89e70492160b66d10a0eb6df8f6fb06"
   integrity sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==
+  dependencies:
+    "@types/yargs-parser" "*"
+
+"@types/yargs@^17.0.0":
+  version "17.0.9"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.9.tgz#f1f931a4e5ae2c0134dea10f501088636a50b46a"
+  integrity sha512-Ci8+4/DOtkHRylcisKmVMtmVO5g7weUVCKcsu1sJvF1bn0wExTmbHmhFKj7AnEm0de800iovGhdSKzYnzbaHpg==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -890,6 +890,11 @@ color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+commander@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.1.0.tgz#a6b263b2327f2e188c6402c42623327909f2dbec"
+  integrity sha512-i0/MaqBtdbnJ4XQs4Pmyb+oFQl+q0lsAmokVUH92SlSw4fkeAcG3bVon+Qt7hmtF+u3Het6o4VgrcY3qAoEB6w==
 
 comment-parser@^0.7.6:
   version "0.7.6"
@@ -2805,7 +2810,7 @@ yargs-parser@^21.0.0:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.0.1.tgz#0267f286c877a4f0f728fceb6f8a3e4cb95c6e35"
   integrity sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==
 
-yargs@^17.0.0, yargs@^17.3.1:
+yargs@^17.0.0:
   version "17.3.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.3.1.tgz#da56b28f32e2fd45aefb402ed9c26f42be4c07b9"
   integrity sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==


### PR DESCRIPTION
Previously, lsif-typescript had unexpected behavior for how it
interpreted command-line flags. For example, it was not possible to
pass it a custom tsconfig.json path. It was also not possible to provide
a list of tsconfig.json files, it was only possible to index a list of
projects when using Yarn workspaces. On top of this, if you passed
incorrectly typed command-line flags then they got silently ignored due
to the parser we were using (yargs).

This commit fixes most of these quirks:

- lsif-typescript index now accepts a repeated list of tsconfig
  references, using the same syntax as `tsc -b`.
- lsif-typescript now reports errors for incorrect command-line flags.
- reused logic between cli code and test code around how to expand yarn workspaces

Fixes #48

### Test plan

See updated test suite.
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
