### PR TITLE
chore: Add generated .lsif-typed files to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist
 node_modules
 .eslintcache
 yarn-error.log
+snapshots/output/**/*.lsif-typed


### PR DESCRIPTION
Running `npm run update-snapshots` also puts `.lsif-typed` files under `snapshots/outputs`,
but those aren't intended to be checked in.

### Test plan

n/a