### PR TITLE
De-alias symbols similar to tsserver's go-to-definition.

### DIFF
--- a/snapshots/input/react/src/MyTSXElement.tsx
+++ b/snapshots/input/react/src/MyTSXElement.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export interface MyProps {}
+
+export const MyTSXElement: React.FunctionComponent<MyProps> = ({}) => (<p></p>)

--- a/snapshots/input/react/src/UseMyTSXElement.tsx
+++ b/snapshots/input/react/src/UseMyTSXElement.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+
+import { MyProps, MyTSXElement } from "./MyTSXElement";
+
+export const _: React.FunctionComponent<MyProps> =
+    ({}) => (<MyTSXElement></MyTSXElement>)

--- a/snapshots/output/react/src/MyTSXElement.tsx
+++ b/snapshots/output/react/src/MyTSXElement.tsx
@@ -1,0 +1,13 @@
+  import React from 'react'
+//       ^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/
+  
+  export interface MyProps {}
+//                 ^^^^^^^ definition react-example 1.0.0 src/`MyTSXElement.tsx`/MyProps#
+  
+  export const MyTSXElement: React.FunctionComponent<MyProps> = ({}) => (<p></p>)
+//             ^^^^^^^^^^^^ definition react-example 1.0.0 src/`MyTSXElement.tsx`/MyTSXElement.
+//                           ^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/
+//                                 ^^^^^^^^^^^^^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/FunctionComponent#
+//                                                   ^^^^^^^ reference react-example 1.0.0 src/`MyTSXElement.tsx`/MyProps#
+//                                                                        ^ reference @types/react 17.0.0 `index.d.ts`/global/JSX/IntrinsicElements#p.
+//                                                                            ^ reference @types/react 17.0.0 `index.d.ts`/global/JSX/IntrinsicElements#p.

--- a/snapshots/output/react/src/UseMyTSXElement.tsx
+++ b/snapshots/output/react/src/UseMyTSXElement.tsx
@@ -2,14 +2,14 @@
 //       ^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/
   
   import { MyProps, MyTSXElement } from "./MyTSXElement";
-//         ^^^^^^^ reference local 0
-//                  ^^^^^^^^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/FunctionComponent#
+//         ^^^^^^^ reference react-example 1.0.0 src/`MyTSXElement.tsx`/MyProps#
+//                  ^^^^^^^^^^^^ reference react-example 1.0.0 src/`MyTSXElement.tsx`/MyTSXElement.
   
   export const _: React.FunctionComponent<MyProps> =
 //             ^ definition react-example 1.0.0 src/`UseMyTSXElement.tsx`/_.
 //                ^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/
 //                      ^^^^^^^^^^^^^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/FunctionComponent#
-//                                        ^^^^^^^ reference local 0
+//                                        ^^^^^^^ reference react-example 1.0.0 src/`MyTSXElement.tsx`/MyProps#
       ({}) => (<MyTSXElement></MyTSXElement>)
-//              ^^^^^^^^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/FunctionComponent#
-//                             ^^^^^^^^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/FunctionComponent#
+//              ^^^^^^^^^^^^ reference react-example 1.0.0 src/`MyTSXElement.tsx`/MyTSXElement.
+//                             ^^^^^^^^^^^^ reference react-example 1.0.0 src/`MyTSXElement.tsx`/MyTSXElement.

--- a/snapshots/output/react/src/UseMyTSXElement.tsx
+++ b/snapshots/output/react/src/UseMyTSXElement.tsx
@@ -1,0 +1,15 @@
+  import React from "react";
+//       ^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/
+  
+  import { MyProps, MyTSXElement } from "./MyTSXElement";
+//         ^^^^^^^ reference local 0
+//                  ^^^^^^^^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/FunctionComponent#
+  
+  export const _: React.FunctionComponent<MyProps> =
+//             ^ definition react-example 1.0.0 src/`UseMyTSXElement.tsx`/_.
+//                ^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/
+//                      ^^^^^^^^^^^^^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/FunctionComponent#
+//                                        ^^^^^^^ reference local 0
+      ({}) => (<MyTSXElement></MyTSXElement>)
+//              ^^^^^^^^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/FunctionComponent#
+//                             ^^^^^^^^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/FunctionComponent#

--- a/src/TypeScriptInternal.ts
+++ b/src/TypeScriptInternal.ts
@@ -1,0 +1,38 @@
+import * as ts from 'typescript'
+
+// Functions in this file are based directly off corresponding functions
+// in the TypeScript codebase.
+
+export function shouldSkipAlias(node: ts.Node): boolean {
+  switch (node.kind) {
+    case ts.SyntaxKind.ImportClause:
+    case ts.SyntaxKind.ImportEqualsDeclaration:
+      // TODO: How do we test this code path?
+      return true;
+    case ts.SyntaxKind.ImportSpecifier:
+      return node.parent.kind === ts.SyntaxKind.NamedImports;
+    case ts.SyntaxKind.BindingElement:
+    case ts.SyntaxKind.VariableDeclaration:
+      // TODO: How do we test this code path?
+      return isInJSFile(node) && isVariableDeclarationInitializedToBareOrAccessedRequire(node);
+    default:
+      return false;
+  }
+}
+
+function isInJSFile(node: ts.Node): boolean {
+  return !!(node.flags & ts.NodeFlags.JavaScriptFile)
+}
+
+function isVariableDeclarationInitializedToBareOrAccessedRequire(node: ts.Node): boolean {
+  if (node.kind === ts.SyntaxKind.BindingElement) {
+    node = node.parent.parent;
+  }
+  return isVariableDeclaration(node) && !!node.initializer;
+  // FIXME: This requires inlining a bunch of more definitions.
+  //       ts.isRequireCall(allowAccessedRequire ? ts.getLeftmostAccessExpression(node.initializer) : node.initializer, /*requireStringLiteralLikeArgument*/ true);
+}
+
+function isVariableDeclaration(node: ts.Node): node is ts.VariableDeclaration {
+  return node.kind === ts.SyntaxKind.VariableDeclaration;
+}


### PR DESCRIPTION
Fixes issue #46.

In the first commit, I've added a generated snapshot to show that we add the
incorrect reference. The fix is implemented in the second commit, where I'm using
logic from tsserver to make sure we de-alias symbols (which appear in the
presence of imports). So the generated snapshots now have the right references.

I've left some TODOs and FIXMEs since there are some edge cases around
JS files and dynamic imports which are handled by tsserver, and handling those
required inlining a bunch of more code. It wasn't super clear to me how all
those edge cases should be tested, so I've avoided inlining those.
I will file a separate follow-up issue to address those TODOs.

### Test plan

Added snapshot tests.