### PR TITLE
Add support for accessors.

### DIFF
--- a/snapshots/input/syntax/src/accessors.ts
+++ b/snapshots/input/syntax/src/accessors.ts
@@ -1,0 +1,51 @@
+class C {
+  _length: number = 0;
+  get length(): number {
+    return this._length;
+  }
+  set length(value: number) {
+    this._length = value;
+  }
+
+  _capacity: number = 0
+  get capacity(): number {
+    return this._capacity
+  }
+}
+
+export class D {
+    _length: number = 0;
+    public get length(): number {
+      return this._length;
+    }
+    public set length(value: number) {
+      this._length = value;
+    }
+
+    _capacity: number = 0
+    public get capacity(): number {
+      return this._capacity;
+    }
+    private set capacity(value: number) {
+      this._capacity = value;
+    }
+    public unsafeSetCapacity(value: number): void {
+      this.capacity = value
+    }
+}
+
+function g(_: number): void {}
+
+function f() {
+  const c = new C()
+  c.length = 10
+  g(c.length)
+  g(c.capacity)
+  g(c.length)
+
+  const d = new D()
+  d.length = 0
+  g(d.length)
+  g(d.capacity)
+  g(D.length)
+}

--- a/snapshots/input/syntax/tsconfig.json
+++ b/snapshots/input/syntax/tsconfig.json
@@ -1,3 +1,5 @@
 {
-  "compilerOptions": {}
+  "compilerOptions": {
+    "target": "ES5"
+  }
 }

--- a/snapshots/output/syntax/src/accessors.ts
+++ b/snapshots/output/syntax/src/accessors.ts
@@ -1,0 +1,123 @@
+  class C {
+//      ^ reference syntax 1.0.0 src/`accessors.ts`/C#
+    _length: number = 0;
+//  ^^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/C#_length.
+    get length(): number {
+//      ^^^^^^ reference local 0
+//      ^^^^^^ reference local 1
+      return this._length;
+//                ^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/C#_length.
+    }
+    set length(value: number) {
+//      ^^^^^^ reference local 0
+//      ^^^^^^ reference local 1
+//             ^^^^^ definition local 2
+      this._length = value;
+//         ^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/C#_length.
+//                   ^^^^^ reference local 2
+    }
+  
+    _capacity: number = 0
+//  ^^^^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/C#_capacity.
+    get capacity(): number {
+//      ^^^^^^^^ reference local 3
+      return this._capacity
+//                ^^^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/C#_capacity.
+    }
+  }
+  
+  export class D {
+//             ^ reference syntax 1.0.0 src/`accessors.ts`/D#
+      _length: number = 0;
+//    ^^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#_length.
+      public get length(): number {
+//               ^^^^^^ reference local 4
+//               ^^^^^^ reference local 5
+        return this._length;
+//                  ^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/D#_length.
+      }
+      public set length(value: number) {
+//               ^^^^^^ reference local 4
+//               ^^^^^^ reference local 5
+//                      ^^^^^ definition local 6
+        this._length = value;
+//           ^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/D#_length.
+//                     ^^^^^ reference local 6
+      }
+  
+      _capacity: number = 0
+//    ^^^^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#_capacity.
+      public get capacity(): number {
+//               ^^^^^^^^ reference local 7
+//               ^^^^^^^^ reference local 8
+        return this._capacity;
+//                  ^^^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/D#_capacity.
+      }
+      private set capacity(value: number) {
+//                ^^^^^^^^ reference local 7
+//                ^^^^^^^^ reference local 8
+//                         ^^^^^ definition local 9
+        this._capacity = value;
+//           ^^^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/D#_capacity.
+//                       ^^^^^ reference local 9
+      }
+      public unsafeSetCapacity(value: number): void {
+//           ^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#unsafeSetCapacity().
+//                             ^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#unsafeSetCapacity().(value)
+        this.capacity = value
+//           ^^^^^^^^ reference local 7
+//           ^^^^^^^^ reference local 8
+//                      ^^^^^ reference syntax 1.0.0 src/`accessors.ts`/D#unsafeSetCapacity().(value)
+      }
+  }
+  
+  function g(_: number): void {}
+//         ^ definition syntax 1.0.0 src/`accessors.ts`/g().
+//           ^ definition syntax 1.0.0 src/`accessors.ts`/g().(_)
+  
+  function f() {
+//         ^ definition syntax 1.0.0 src/`accessors.ts`/f().
+    const c = new C()
+//        ^ definition local 12
+//                ^ reference syntax 1.0.0 src/`accessors.ts`/C#
+    c.length = 10
+//  ^ reference local 12
+//    ^^^^^^ reference local 0
+//    ^^^^^^ reference local 1
+    g(c.length)
+//  ^ reference syntax 1.0.0 src/`accessors.ts`/g().
+//    ^ reference local 12
+//      ^^^^^^ reference local 0
+//      ^^^^^^ reference local 1
+    g(c.capacity)
+//  ^ reference syntax 1.0.0 src/`accessors.ts`/g().
+//    ^ reference local 12
+//      ^^^^^^^^ reference local 3
+    g(c.length)
+//  ^ reference syntax 1.0.0 src/`accessors.ts`/g().
+//    ^ reference local 12
+//      ^^^^^^ reference local 0
+//      ^^^^^^ reference local 1
+  
+    const d = new D()
+//        ^ definition local 15
+//                ^ reference syntax 1.0.0 src/`accessors.ts`/D#
+    d.length = 0
+//  ^ reference local 15
+//    ^^^^^^ reference local 4
+//    ^^^^^^ reference local 5
+    g(d.length)
+//  ^ reference syntax 1.0.0 src/`accessors.ts`/g().
+//    ^ reference local 15
+//      ^^^^^^ reference local 4
+//      ^^^^^^ reference local 5
+    g(d.capacity)
+//  ^ reference syntax 1.0.0 src/`accessors.ts`/g().
+//    ^ reference local 15
+//      ^^^^^^^^ reference local 7
+//      ^^^^^^^^ reference local 8
+    g(D.length)
+//  ^ reference syntax 1.0.0 src/`accessors.ts`/g().
+//    ^ reference syntax 1.0.0 src/`accessors.ts`/D#
+//      ^^^^^^ reference typescript 4.6.2 lib/`lib.es5.d.ts`/Function#length.
+  }

--- a/snapshots/output/syntax/src/accessors.ts
+++ b/snapshots/output/syntax/src/accessors.ts
@@ -3,14 +3,12 @@
     _length: number = 0;
 //  ^^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/C#_length.
     get length(): number {
-//      ^^^^^^ reference local 0
-//      ^^^^^^ reference local 1
+//      ^^^^^^ definition local 0
       return this._length;
 //                ^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/C#_length.
     }
     set length(value: number) {
-//      ^^^^^^ reference local 0
-//      ^^^^^^ reference local 1
+//      ^^^^^^ definition local 0
 //             ^^^^^ definition local 2
       this._length = value;
 //         ^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/C#_length.

--- a/snapshots/output/syntax/src/accessors.ts
+++ b/snapshots/output/syntax/src/accessors.ts
@@ -3,22 +3,22 @@
     _length: number = 0;
 //  ^^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/C#_length.
     get length(): number {
-//      ^^^^^^ definition local 0
+//      ^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/C#`<get>length`().
       return this._length;
 //                ^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/C#_length.
     }
     set length(value: number) {
-//      ^^^^^^ definition local 0
-//             ^^^^^ definition local 2
+//      ^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/C#`<get>length`().
+//             ^^^^^ definition syntax 1.0.0 src/`accessors.ts`/C#`<set>length`().(value)
       this._length = value;
 //         ^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/C#_length.
-//                   ^^^^^ reference local 2
+//                   ^^^^^ reference syntax 1.0.0 src/`accessors.ts`/C#`<set>length`().(value)
     }
   
     _capacity: number = 0
 //  ^^^^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/C#_capacity.
     get capacity(): number {
-//      ^^^^^^^^ reference local 3
+//      ^^^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/C#`<get>capacity`().
       return this._capacity
 //                ^^^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/C#_capacity.
     }
@@ -29,42 +29,38 @@
       _length: number = 0;
 //    ^^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#_length.
       public get length(): number {
-//               ^^^^^^ reference local 4
-//               ^^^^^^ reference local 5
+//               ^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#`<get>length`().
         return this._length;
 //                  ^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/D#_length.
       }
       public set length(value: number) {
-//               ^^^^^^ reference local 4
-//               ^^^^^^ reference local 5
-//                      ^^^^^ definition local 6
+//               ^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#`<get>length`().
+//                      ^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#`<set>length`().(value)
         this._length = value;
 //           ^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/D#_length.
-//                     ^^^^^ reference local 6
+//                     ^^^^^ reference syntax 1.0.0 src/`accessors.ts`/D#`<set>length`().(value)
       }
   
       _capacity: number = 0
 //    ^^^^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#_capacity.
       public get capacity(): number {
-//               ^^^^^^^^ reference local 7
-//               ^^^^^^^^ reference local 8
+//               ^^^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#`<get>capacity`().
         return this._capacity;
 //                  ^^^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/D#_capacity.
       }
       private set capacity(value: number) {
-//                ^^^^^^^^ reference local 7
-//                ^^^^^^^^ reference local 8
-//                         ^^^^^ definition local 9
+//                ^^^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#`<get>capacity`().
+//                         ^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#`<set>capacity`().(value)
         this._capacity = value;
 //           ^^^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/D#_capacity.
-//                       ^^^^^ reference local 9
+//                       ^^^^^ reference syntax 1.0.0 src/`accessors.ts`/D#`<set>capacity`().(value)
       }
       public unsafeSetCapacity(value: number): void {
 //           ^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#unsafeSetCapacity().
 //                             ^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#unsafeSetCapacity().(value)
         this.capacity = value
-//           ^^^^^^^^ reference local 7
-//           ^^^^^^^^ reference local 8
+//           ^^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/D#`<get>capacity`().
+//           ^^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/D#`<set>capacity`().
 //                      ^^^^^ reference syntax 1.0.0 src/`accessors.ts`/D#unsafeSetCapacity().(value)
       }
   }
@@ -76,44 +72,44 @@
   function f() {
 //         ^ definition syntax 1.0.0 src/`accessors.ts`/f().
     const c = new C()
-//        ^ definition local 12
+//        ^ definition local 2
 //                ^ reference syntax 1.0.0 src/`accessors.ts`/C#
     c.length = 10
-//  ^ reference local 12
-//    ^^^^^^ reference local 0
-//    ^^^^^^ reference local 1
+//  ^ reference local 2
+//    ^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/C#`<get>length`().
+//    ^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/C#`<set>length`().
     g(c.length)
 //  ^ reference syntax 1.0.0 src/`accessors.ts`/g().
-//    ^ reference local 12
-//      ^^^^^^ reference local 0
-//      ^^^^^^ reference local 1
+//    ^ reference local 2
+//      ^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/C#`<get>length`().
+//      ^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/C#`<set>length`().
     g(c.capacity)
 //  ^ reference syntax 1.0.0 src/`accessors.ts`/g().
-//    ^ reference local 12
-//      ^^^^^^^^ reference local 3
+//    ^ reference local 2
+//      ^^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/C#`<get>capacity`().
     g(c.length)
 //  ^ reference syntax 1.0.0 src/`accessors.ts`/g().
-//    ^ reference local 12
-//      ^^^^^^ reference local 0
-//      ^^^^^^ reference local 1
+//    ^ reference local 2
+//      ^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/C#`<get>length`().
+//      ^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/C#`<set>length`().
   
     const d = new D()
-//        ^ definition local 15
+//        ^ definition local 5
 //                ^ reference syntax 1.0.0 src/`accessors.ts`/D#
     d.length = 0
-//  ^ reference local 15
-//    ^^^^^^ reference local 4
-//    ^^^^^^ reference local 5
+//  ^ reference local 5
+//    ^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/D#`<get>length`().
+//    ^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/D#`<set>length`().
     g(d.length)
 //  ^ reference syntax 1.0.0 src/`accessors.ts`/g().
-//    ^ reference local 15
-//      ^^^^^^ reference local 4
-//      ^^^^^^ reference local 5
+//    ^ reference local 5
+//      ^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/D#`<get>length`().
+//      ^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/D#`<set>length`().
     g(d.capacity)
 //  ^ reference syntax 1.0.0 src/`accessors.ts`/g().
-//    ^ reference local 15
-//      ^^^^^^^^ reference local 7
-//      ^^^^^^^^ reference local 8
+//    ^ reference local 5
+//      ^^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/D#`<get>capacity`().
+//      ^^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/D#`<set>capacity`().
     g(D.length)
 //  ^ reference syntax 1.0.0 src/`accessors.ts`/g().
 //    ^ reference syntax 1.0.0 src/`accessors.ts`/D#

--- a/src/FileIndexer.ts
+++ b/src/FileIndexer.ts
@@ -156,6 +156,7 @@ export class FileIndexer {
       ts.isEnumDeclaration(node) ||
       ts.isVariableDeclaration(node) ||
       ts.isPropertyDeclaration(node) ||
+      ts.isAccessor(node) ||
       ts.isMethodSignature(node) ||
       ts.isMethodDeclaration(node) ||
       ts.isPropertySignature(node) ||

--- a/src/FileIndexer.ts
+++ b/src/FileIndexer.ts
@@ -305,6 +305,10 @@ export class FileIndexer {
     ) {
       return termDescriptor(node.name.getText())
     }
+    if (ts.isAccessor(node)) {
+      const prefix = ts.isGetAccessor(node) ? '<get>' : '<set>'
+      return methodDescriptor(prefix + node.name.getText())
+    }
     if (ts.isModuleDeclaration(node)) {
       return packageDescriptor(node.name.getText())
     }


### PR DESCRIPTION
Fixes issue #54. The PR is relatively small, but it would probably be easier to review it commit-by-commit.

- [x] TODO: Test that go-to-definition and find references work in the local Sourcegraph instance, after uploading an index generated by `lsif-typescript` from this branch. It works! 
![Find references for a getter](https://user-images.githubusercontent.com/93103176/162796722-a26b3682-c114-4223-ad96-a990c8207f41.png)

### Test plan

Added automated tests.