### PR TITLE
ci: Fix bot name/email.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,8 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: Setup git env
         run: |
-          git config --global user.email "bot@sourcegraph.org"
-          git config --global user.name "Sourcegraph Bot"
+          git config --global user.email "sourcegraph-bot-github@sourcegraph.com"
+          git config --global user.name "sourcegraph-bot"
       - uses: actions/checkout@v2
       - name: Get the tag version
         run: echo "NEW_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV


### PR DESCRIPTION
We want to allowlist the bot to publish releases (see the admin settings
of this repo), so it needs to be able to make commits without making
a PR.

A release for v0.1.15 failed because the bot didn't have access.
https://github.com/sourcegraph/lsif-typescript/runs/5995710337?check_suite_focus=true

### Test plan

n/a