### PR TITLE
fix: Use allowJS in --infer-tsconfig.

### DIFF
--- a/snapshots/input/pure-js/package.json
+++ b/snapshots/input/pure-js/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "pure-js",
+  "version": "1.0.0",
+  "description": "Example TS/JS project",
+  "main": "src/main.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "private": true
+}

--- a/snapshots/input/pure-js/src/main.js
+++ b/snapshots/input/pure-js/src/main.js
@@ -1,0 +1,46 @@
+function fib(n) {
+  if (n <= 1) {
+    return 0;
+  }
+  return fib(n - 1) + fib(n - 2);
+}
+
+function print_fib(a) {
+  console.log(fib(a));
+}
+
+var y = "Hello";
+function capture() {
+  return y;
+}
+const capture_lambda = () => { return y; };
+
+for (var i = 0; i <= 10; i++) {
+}
+
+for (const x of [1, 2, 3]) {
+}
+
+var a = 0;
+var a = 1;
+print_fib(a);
+
+function forever() { return forever(); }
+
+function use_before_def() {
+  print_fib(n);
+  var n = 10;
+
+  if (forever()) {
+    var m = 10;
+  }
+  print_fib(m);
+}
+
+function var_function_scope() {
+  var k = 0;
+  if (forever()) {
+    var k = 1;
+  }
+  print_fib(k);
+}

--- a/snapshots/output/pure-js/src/main.js
+++ b/snapshots/output/pure-js/src/main.js
@@ -1,0 +1,95 @@
+  function fib(n) {
+//         ^^^ definition pure-js 1.0.0 src/`main.js`/fib().
+//             ^ definition pure-js 1.0.0 src/`main.js`/fib().(n)
+    if (n <= 1) {
+//      ^ reference pure-js 1.0.0 src/`main.js`/fib().(n)
+      return 0;
+    }
+    return fib(n - 1) + fib(n - 2);
+//         ^^^ reference pure-js 1.0.0 src/`main.js`/fib().
+//             ^ reference pure-js 1.0.0 src/`main.js`/fib().(n)
+//                      ^^^ reference pure-js 1.0.0 src/`main.js`/fib().
+//                          ^ reference pure-js 1.0.0 src/`main.js`/fib().(n)
+  }
+  
+  function print_fib(a) {
+//         ^^^^^^^^^ definition pure-js 1.0.0 src/`main.js`/print_fib().
+//                   ^ definition pure-js 1.0.0 src/`main.js`/print_fib().(a)
+    console.log(fib(a));
+//  ^^^^^^^ reference typescript 4.6.2 lib/`lib.dom.d.ts`/console.
+//  ^^^^^^^ reference @types/node 17.0.14 `globals.d.ts`/console.
+//  ^^^^^^^ reference @types/node 17.0.14 `console.d.ts`/`'node:console'`/global/console/
+//  ^^^^^^^ reference @types/node 17.0.14 `console.d.ts`/`'node:console'`/global/console.
+//          ^^^ reference typescript 4.6.2 lib/`lib.dom.d.ts`/Console#log().
+//          ^^^ reference @types/node 17.0.14 `console.d.ts`/`'node:console'`/global/Console#log().
+//              ^^^ reference pure-js 1.0.0 src/`main.js`/fib().
+//                  ^ reference pure-js 1.0.0 src/`main.js`/print_fib().(a)
+  }
+  
+  var y = "Hello";
+//    ^ definition pure-js 1.0.0 src/`main.js`/y.
+  function capture() {
+//         ^^^^^^^ definition pure-js 1.0.0 src/`main.js`/capture().
+    return y;
+//         ^ reference pure-js 1.0.0 src/`main.js`/y.
+  }
+  const capture_lambda = () => { return y; };
+//      ^^^^^^^^^^^^^^ definition pure-js 1.0.0 src/`main.js`/capture_lambda.
+//                                      ^ reference pure-js 1.0.0 src/`main.js`/y.
+  
+  for (var i = 0; i <= 10; i++) {
+//         ^ definition local 2
+//                ^ reference local 2
+//                         ^ reference local 2
+  }
+  
+  for (const x of [1, 2, 3]) {
+//           ^ definition local 5
+  }
+  
+  var a = 0;
+//    ^ definition pure-js 1.0.0 src/`main.js`/a.
+  var a = 1;
+//    ^ definition pure-js 1.0.0 src/`main.js`/a.
+  print_fib(a);
+//^^^^^^^^^ reference pure-js 1.0.0 src/`main.js`/print_fib().
+//          ^ reference pure-js 1.0.0 src/`main.js`/a.
+//          ^ reference pure-js 1.0.0 src/`main.js`/a.
+  
+  function forever() { return forever(); }
+//         ^^^^^^^ definition pure-js 1.0.0 src/`main.js`/forever().
+//                            ^^^^^^^ reference pure-js 1.0.0 src/`main.js`/forever().
+  
+  function use_before_def() {
+//         ^^^^^^^^^^^^^^ definition pure-js 1.0.0 src/`main.js`/use_before_def().
+    print_fib(n);
+//  ^^^^^^^^^ reference pure-js 1.0.0 src/`main.js`/print_fib().
+//            ^ reference local 8
+    var n = 10;
+//      ^ definition local 8
+  
+    if (forever()) {
+//      ^^^^^^^ reference pure-js 1.0.0 src/`main.js`/forever().
+      var m = 10;
+//        ^ definition local 11
+    }
+    print_fib(m);
+//  ^^^^^^^^^ reference pure-js 1.0.0 src/`main.js`/print_fib().
+//            ^ reference local 11
+  }
+  
+  function var_function_scope() {
+//         ^^^^^^^^^^^^^^^^^^ definition pure-js 1.0.0 src/`main.js`/var_function_scope().
+    var k = 0;
+//      ^ definition local 14
+    if (forever()) {
+//      ^^^^^^^ reference pure-js 1.0.0 src/`main.js`/forever().
+      var k = 1;
+//        ^ definition local 14
+    }
+    print_fib(k);
+//  ^^^^^^^^^ reference pure-js 1.0.0 src/`main.js`/print_fib().
+//            ^ reference local 14
+//            ^ reference local 17
+  }
+  

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -45,15 +45,20 @@ for (const snapshotDirectory of snapshotDirectories) {
     const packageJson = JSON.parse(
       fs.readFileSync(packageJsonPath).toString()
     ) as PackageJson
+    const tsconfigJsonPath = path.join(inputRoot, 'tsconfig.json')
+    const inferTsconfig = !fs.existsSync(tsconfigJsonPath)
     const output = path.join(inputRoot, 'dump.lsif-typed')
     indexCommand([], {
       cwd: inputRoot,
-      inferTsconfig: false,
+      inferTsconfig,
       output,
       yarnWorkspaces: Boolean(packageJson.workspaces),
       progressBar: false,
       indexedProjects: new Set(),
     })
+    if (inferTsconfig) {
+      fs.rmSync(tsconfigJsonPath)
+    }
     const index = lsif.lib.codeintel.lsiftyped.Index.deserializeBinary(
       fs.readFileSync(path.join(inputRoot, 'dump.lsif-typed'))
     )

--- a/src/main.ts
+++ b/src/main.ts
@@ -146,7 +146,7 @@ function indexSingleProject(options: ProjectOptions): void {
     }
     if (!ts.sys.fileExists(tsconfigFileName)) {
       if (options.inferTsconfig) {
-        fs.writeFileSync(tsconfigFileName, '{}')
+        fs.writeFileSync(tsconfigFileName, '{"compilerOptions":{"allowJs":true}}')
       } else {
         console.error(`- ${options.projectDisplayName} (missing tsconfig.json)`)
         return


### PR DESCRIPTION
lsif-node uses allowJS; however, that was skipped for some reason
in lsif-typescript. Without allowJS, JS files will be excluded
by the TypeScript compiler.

The test is intended for future iteration; and the correctness
of the results doesn't really matter for this PR. The key part
is that we are able to generate LSIF dumps properly for JS.

Fixes issue #81.

### Test plan

Added automated test. Manually tested with [d3-shape](https://github.com/d3/d3-shape).