### PR TITLE
Render documentation and relationships in the snapshot tests

### DIFF
--- a/snapshots/output/multi-project/packages/a/src/index.ts
+++ b/snapshots/output/multi-project/packages/a/src/index.ts
@@ -1,7 +1,6 @@
   export function a(): string {
 //                ^ definition @example/a 1.0.0 src/`index.ts`/a().
 //                documentation ```ts\n() => string\n```
-//                documentation 
     return ''
   }
   

--- a/snapshots/output/multi-project/packages/a/src/index.ts
+++ b/snapshots/output/multi-project/packages/a/src/index.ts
@@ -1,5 +1,7 @@
   export function a(): string {
 //                ^ definition @example/a 1.0.0 src/`index.ts`/a().
+//                documentation ```ts\n() => string\n```
+//                documentation 
     return ''
   }
   

--- a/snapshots/output/multi-project/packages/b/src/b.ts
+++ b/snapshots/output/multi-project/packages/b/src/b.ts
@@ -4,7 +4,6 @@
   export function b() {
 //                ^ definition @example/b 1.0.0 src/`b.ts`/b().
 //                documentation ```ts\n() => string\n```
-//                documentation 
     return a()
 //         ^ reference @example/a 1.0.0 src/`index.ts`/a().
   }

--- a/snapshots/output/multi-project/packages/b/src/b.ts
+++ b/snapshots/output/multi-project/packages/b/src/b.ts
@@ -3,6 +3,8 @@
   
   export function b() {
 //                ^ definition @example/b 1.0.0 src/`b.ts`/b().
+//                documentation ```ts\n() => string\n```
+//                documentation 
     return a()
 //         ^ reference @example/a 1.0.0 src/`index.ts`/a().
   }

--- a/snapshots/output/pure-js/src/main.js
+++ b/snapshots/output/pure-js/src/main.js
@@ -1,10 +1,8 @@
   function fib(n) {
 //         ^^^ definition pure-js 1.0.0 src/`main.js`/fib().
 //         documentation ```ts\n(n: any) => any\n```
-//         documentation 
 //             ^ definition pure-js 1.0.0 src/`main.js`/fib().(n)
 //             documentation ```ts\nany\n```
-//             documentation 
     if (n <= 1) {
 //      ^ reference pure-js 1.0.0 src/`main.js`/fib().(n)
       return 0
@@ -19,10 +17,8 @@
   function print_fib(a) {
 //         ^^^^^^^^^ definition pure-js 1.0.0 src/`main.js`/print_fib().
 //         documentation ```ts\n(a: any) => void\n```
-//         documentation 
 //                   ^ definition pure-js 1.0.0 src/`main.js`/print_fib().(a)
 //                   documentation ```ts\nany\n```
-//                   documentation 
     console.log(fib(a))
 //  ^^^^^^^ reference typescript 4.6.2 lib/`lib.dom.d.ts`/console.
 //  ^^^^^^^ reference @types/node 17.0.14 `globals.d.ts`/console.
@@ -37,18 +33,15 @@
   var y = 'Hello'
 //    ^ definition pure-js 1.0.0 src/`main.js`/y.
 //    documentation ```ts\nstring\n```
-//    documentation 
   function capture() {
 //         ^^^^^^^ definition pure-js 1.0.0 src/`main.js`/capture().
 //         documentation ```ts\n() => string\n```
-//         documentation 
     return y
 //         ^ reference pure-js 1.0.0 src/`main.js`/y.
   }
   const capture_lambda = () => {
 //      ^^^^^^^^^^^^^^ definition pure-js 1.0.0 src/`main.js`/capture_lambda.
 //      documentation ```ts\n() => string\n```
-//      documentation 
     return y
 //         ^ reference pure-js 1.0.0 src/`main.js`/y.
   }
@@ -56,24 +49,20 @@
   for (var i = 0; i <= 10; i++) {}
 //         ^ definition local 2
 //         documentation ```ts\nnumber\n```
-//         documentation 
 //                ^ reference local 2
 //                         ^ reference local 2
   
   for (const x of [1, 2, 3]) {
 //           ^ definition local 5
 //           documentation ```ts\nnumber\n```
-//           documentation 
   }
   
   var a = 0
 //    ^ definition pure-js 1.0.0 src/`main.js`/a.
 //    documentation ```ts\nnumber\n```
-//    documentation 
   var a = 1
 //    ^ definition pure-js 1.0.0 src/`main.js`/a.
 //    documentation ```ts\nnumber\n```
-//    documentation 
   print_fib(a)
 //^^^^^^^^^ reference pure-js 1.0.0 src/`main.js`/print_fib().
 //          ^ reference pure-js 1.0.0 src/`main.js`/a.
@@ -82,7 +71,6 @@
   function forever() {
 //         ^^^^^^^ definition pure-js 1.0.0 src/`main.js`/forever().
 //         documentation ```ts\n() => any\n```
-//         documentation 
     return forever()
 //         ^^^^^^^ reference pure-js 1.0.0 src/`main.js`/forever().
   }
@@ -90,21 +78,18 @@
   function use_before_def() {
 //         ^^^^^^^^^^^^^^ definition pure-js 1.0.0 src/`main.js`/use_before_def().
 //         documentation ```ts\n() => void\n```
-//         documentation 
     print_fib(n)
 //  ^^^^^^^^^ reference pure-js 1.0.0 src/`main.js`/print_fib().
 //            ^ reference local 8
     var n = 10
 //      ^ definition local 8
 //      documentation ```ts\nnumber\n```
-//      documentation 
   
     if (forever()) {
 //      ^^^^^^^ reference pure-js 1.0.0 src/`main.js`/forever().
       var m = 10
 //        ^ definition local 11
 //        documentation ```ts\nnumber\n```
-//        documentation 
     }
     print_fib(m)
 //  ^^^^^^^^^ reference pure-js 1.0.0 src/`main.js`/print_fib().
@@ -114,17 +99,14 @@
   function var_function_scope() {
 //         ^^^^^^^^^^^^^^^^^^ definition pure-js 1.0.0 src/`main.js`/var_function_scope().
 //         documentation ```ts\n() => void\n```
-//         documentation 
     var k = 0
 //      ^ definition local 14
 //      documentation ```ts\nnumber\n```
-//      documentation 
     if (forever()) {
 //      ^^^^^^^ reference pure-js 1.0.0 src/`main.js`/forever().
       var k = 1
 //        ^ definition local 14
 //        documentation ```ts\nnumber\n```
-//        documentation 
     }
     print_fib(k)
 //  ^^^^^^^^^ reference pure-js 1.0.0 src/`main.js`/print_fib().

--- a/snapshots/output/pure-js/src/main.js
+++ b/snapshots/output/pure-js/src/main.js
@@ -1,6 +1,10 @@
   function fib(n) {
 //         ^^^ definition pure-js 1.0.0 src/`main.js`/fib().
+//         documentation ```ts\n(n: any) => any\n```
+//         documentation 
 //             ^ definition pure-js 1.0.0 src/`main.js`/fib().(n)
+//             documentation ```ts\nany\n```
+//             documentation 
     if (n <= 1) {
 //      ^ reference pure-js 1.0.0 src/`main.js`/fib().(n)
       return 0
@@ -14,7 +18,11 @@
   
   function print_fib(a) {
 //         ^^^^^^^^^ definition pure-js 1.0.0 src/`main.js`/print_fib().
+//         documentation ```ts\n(a: any) => void\n```
+//         documentation 
 //                   ^ definition pure-js 1.0.0 src/`main.js`/print_fib().(a)
+//                   documentation ```ts\nany\n```
+//                   documentation 
     console.log(fib(a))
 //  ^^^^^^^ reference typescript 4.6.2 lib/`lib.dom.d.ts`/console.
 //  ^^^^^^^ reference @types/node 17.0.14 `globals.d.ts`/console.
@@ -28,30 +36,44 @@
   
   var y = 'Hello'
 //    ^ definition pure-js 1.0.0 src/`main.js`/y.
+//    documentation ```ts\nstring\n```
+//    documentation 
   function capture() {
 //         ^^^^^^^ definition pure-js 1.0.0 src/`main.js`/capture().
+//         documentation ```ts\n() => string\n```
+//         documentation 
     return y
 //         ^ reference pure-js 1.0.0 src/`main.js`/y.
   }
   const capture_lambda = () => {
 //      ^^^^^^^^^^^^^^ definition pure-js 1.0.0 src/`main.js`/capture_lambda.
+//      documentation ```ts\n() => string\n```
+//      documentation 
     return y
 //         ^ reference pure-js 1.0.0 src/`main.js`/y.
   }
   
   for (var i = 0; i <= 10; i++) {}
 //         ^ definition local 2
+//         documentation ```ts\nnumber\n```
+//         documentation 
 //                ^ reference local 2
 //                         ^ reference local 2
   
   for (const x of [1, 2, 3]) {
 //           ^ definition local 5
+//           documentation ```ts\nnumber\n```
+//           documentation 
   }
   
   var a = 0
 //    ^ definition pure-js 1.0.0 src/`main.js`/a.
+//    documentation ```ts\nnumber\n```
+//    documentation 
   var a = 1
 //    ^ definition pure-js 1.0.0 src/`main.js`/a.
+//    documentation ```ts\nnumber\n```
+//    documentation 
   print_fib(a)
 //^^^^^^^^^ reference pure-js 1.0.0 src/`main.js`/print_fib().
 //          ^ reference pure-js 1.0.0 src/`main.js`/a.
@@ -59,22 +81,30 @@
   
   function forever() {
 //         ^^^^^^^ definition pure-js 1.0.0 src/`main.js`/forever().
+//         documentation ```ts\n() => any\n```
+//         documentation 
     return forever()
 //         ^^^^^^^ reference pure-js 1.0.0 src/`main.js`/forever().
   }
   
   function use_before_def() {
 //         ^^^^^^^^^^^^^^ definition pure-js 1.0.0 src/`main.js`/use_before_def().
+//         documentation ```ts\n() => void\n```
+//         documentation 
     print_fib(n)
 //  ^^^^^^^^^ reference pure-js 1.0.0 src/`main.js`/print_fib().
 //            ^ reference local 8
     var n = 10
 //      ^ definition local 8
+//      documentation ```ts\nnumber\n```
+//      documentation 
   
     if (forever()) {
 //      ^^^^^^^ reference pure-js 1.0.0 src/`main.js`/forever().
       var m = 10
 //        ^ definition local 11
+//        documentation ```ts\nnumber\n```
+//        documentation 
     }
     print_fib(m)
 //  ^^^^^^^^^ reference pure-js 1.0.0 src/`main.js`/print_fib().
@@ -83,12 +113,18 @@
   
   function var_function_scope() {
 //         ^^^^^^^^^^^^^^^^^^ definition pure-js 1.0.0 src/`main.js`/var_function_scope().
+//         documentation ```ts\n() => void\n```
+//         documentation 
     var k = 0
 //      ^ definition local 14
+//      documentation ```ts\nnumber\n```
+//      documentation 
     if (forever()) {
 //      ^^^^^^^ reference pure-js 1.0.0 src/`main.js`/forever().
       var k = 1
 //        ^ definition local 14
+//        documentation ```ts\nnumber\n```
+//        documentation 
     }
     print_fib(k)
 //  ^^^^^^^^^ reference pure-js 1.0.0 src/`main.js`/print_fib().

--- a/snapshots/output/react/src/LoaderInput.tsx
+++ b/snapshots/output/react/src/LoaderInput.tsx
@@ -9,11 +9,9 @@
     loading: boolean
 //  ^^^^^^^ definition react-example 1.0.0 src/`LoaderInput.tsx`/Props#loading.
 //  documentation ```ts\nboolean\n```
-//  documentation 
     children: React.ReactNode
 //  ^^^^^^^^ definition react-example 1.0.0 src/`LoaderInput.tsx`/Props#children.
 //  documentation ```ts\nReactNode\n```
-//  documentation 
 //            ^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/
 //                  ^^^^^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/ReactNode#
   }
@@ -21,7 +19,6 @@
   export const LoaderInput: React.FunctionComponent<Props> = ({
 //             ^^^^^^^^^^^ definition react-example 1.0.0 src/`LoaderInput.tsx`/LoaderInput.
 //             documentation ```ts\nFunctionComponent<Props>\n```
-//             documentation 
 //                          ^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/
 //                                ^^^^^^^^^^^^^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/FunctionComponent#
 //                                                  ^^^^^ reference react-example 1.0.0 src/`LoaderInput.tsx`/Props#
@@ -46,13 +43,11 @@
   export const LoaderInput2: React.FunctionComponent<Props> = props => {
 //             ^^^^^^^^^^^^ definition react-example 1.0.0 src/`LoaderInput.tsx`/LoaderInput2.
 //             documentation ```ts\nFunctionComponent<Props>\n```
-//             documentation 
 //                           ^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/
 //                                 ^^^^^^^^^^^^^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/FunctionComponent#
 //                                                   ^^^^^ reference react-example 1.0.0 src/`LoaderInput.tsx`/Props#
 //                                                            ^^^^^ definition local 6
 //                                                            documentation ```ts\nPropsWithChildren<Props>\n```
-//                                                            documentation 
     return <LoaderInput loading={true} key="key" children={props.children} />
 //          ^^^^^^^^^^^ reference react-example 1.0.0 src/`LoaderInput.tsx`/LoaderInput.
 //                      ^^^^^^^ reference react-example 1.0.0 src/`LoaderInput.tsx`/Props#loading.

--- a/snapshots/output/react/src/LoaderInput.tsx
+++ b/snapshots/output/react/src/LoaderInput.tsx
@@ -4,16 +4,24 @@
   /** Takes loading prop, input component as child */
   interface Props {
 //          ^^^^^ definition react-example 1.0.0 src/`LoaderInput.tsx`/Props#
+//          documentation ```ts\nProps\n```
+//          documentation Takes loading prop, input component as child
     loading: boolean
 //  ^^^^^^^ definition react-example 1.0.0 src/`LoaderInput.tsx`/Props#loading.
+//  documentation ```ts\nboolean\n```
+//  documentation 
     children: React.ReactNode
 //  ^^^^^^^^ definition react-example 1.0.0 src/`LoaderInput.tsx`/Props#children.
+//  documentation ```ts\nReactNode\n```
+//  documentation 
 //            ^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/
 //                  ^^^^^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/ReactNode#
   }
   
   export const LoaderInput: React.FunctionComponent<Props> = ({
 //             ^^^^^^^^^^^ definition react-example 1.0.0 src/`LoaderInput.tsx`/LoaderInput.
+//             documentation ```ts\nFunctionComponent<Props>\n```
+//             documentation 
 //                          ^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/
 //                                ^^^^^^^^^^^^^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/FunctionComponent#
 //                                                  ^^^^^ reference react-example 1.0.0 src/`LoaderInput.tsx`/Props#
@@ -37,10 +45,14 @@
   
   export const LoaderInput2: React.FunctionComponent<Props> = props => {
 //             ^^^^^^^^^^^^ definition react-example 1.0.0 src/`LoaderInput.tsx`/LoaderInput2.
+//             documentation ```ts\nFunctionComponent<Props>\n```
+//             documentation 
 //                           ^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/
 //                                 ^^^^^^^^^^^^^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/FunctionComponent#
 //                                                   ^^^^^ reference react-example 1.0.0 src/`LoaderInput.tsx`/Props#
 //                                                            ^^^^^ definition local 6
+//                                                            documentation ```ts\nPropsWithChildren<Props>\n```
+//                                                            documentation 
     return <LoaderInput loading={true} key="key" children={props.children} />
 //          ^^^^^^^^^^^ reference react-example 1.0.0 src/`LoaderInput.tsx`/LoaderInput.
 //                      ^^^^^^^ reference react-example 1.0.0 src/`LoaderInput.tsx`/Props#loading.

--- a/snapshots/output/react/src/MyTSXElement.tsx
+++ b/snapshots/output/react/src/MyTSXElement.tsx
@@ -3,9 +3,13 @@
   
   export interface MyProps {}
 //                 ^^^^^^^ definition react-example 1.0.0 src/`MyTSXElement.tsx`/MyProps#
+//                 documentation ```ts\nMyProps\n```
+//                 documentation 
   
   export const MyTSXElement: React.FunctionComponent<MyProps> = ({}) => (<p></p>)
 //             ^^^^^^^^^^^^ definition react-example 1.0.0 src/`MyTSXElement.tsx`/MyTSXElement.
+//             documentation ```ts\nFunctionComponent<MyProps>\n```
+//             documentation 
 //                           ^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/
 //                                 ^^^^^^^^^^^^^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/FunctionComponent#
 //                                                   ^^^^^^^ reference react-example 1.0.0 src/`MyTSXElement.tsx`/MyProps#

--- a/snapshots/output/react/src/MyTSXElement.tsx
+++ b/snapshots/output/react/src/MyTSXElement.tsx
@@ -4,12 +4,10 @@
   export interface MyProps {}
 //                 ^^^^^^^ definition react-example 1.0.0 src/`MyTSXElement.tsx`/MyProps#
 //                 documentation ```ts\nMyProps\n```
-//                 documentation 
   
   export const MyTSXElement: React.FunctionComponent<MyProps> = ({}) => (<p></p>)
 //             ^^^^^^^^^^^^ definition react-example 1.0.0 src/`MyTSXElement.tsx`/MyTSXElement.
 //             documentation ```ts\nFunctionComponent<MyProps>\n```
-//             documentation 
 //                           ^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/
 //                                 ^^^^^^^^^^^^^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/FunctionComponent#
 //                                                   ^^^^^^^ reference react-example 1.0.0 src/`MyTSXElement.tsx`/MyProps#

--- a/snapshots/output/react/src/UseMyTSXElement.tsx
+++ b/snapshots/output/react/src/UseMyTSXElement.tsx
@@ -7,6 +7,8 @@
   
   export const _: React.FunctionComponent<MyProps> =
 //             ^ definition react-example 1.0.0 src/`UseMyTSXElement.tsx`/_.
+//             documentation ```ts\nFunctionComponent<MyProps>\n```
+//             documentation 
 //                ^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/
 //                      ^^^^^^^^^^^^^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/FunctionComponent#
 //                                        ^^^^^^^ reference react-example 1.0.0 src/`MyTSXElement.tsx`/MyProps#

--- a/snapshots/output/react/src/UseMyTSXElement.tsx
+++ b/snapshots/output/react/src/UseMyTSXElement.tsx
@@ -8,7 +8,6 @@
   export const _: React.FunctionComponent<MyProps> =
 //             ^ definition react-example 1.0.0 src/`UseMyTSXElement.tsx`/_.
 //             documentation ```ts\nFunctionComponent<MyProps>\n```
-//             documentation 
 //                ^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/
 //                      ^^^^^^^^^^^^^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/FunctionComponent#
 //                                        ^^^^^^^ reference react-example 1.0.0 src/`MyTSXElement.tsx`/MyProps#

--- a/snapshots/output/syntax/src/accessors.ts
+++ b/snapshots/output/syntax/src/accessors.ts
@@ -1,25 +1,20 @@
   class C {
 //      ^ definition syntax 1.0.0 src/`accessors.ts`/C#
 //      documentation ```ts\nC\n```
-//      documentation 
     _length: number = 0
 //  ^^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/C#_length.
 //  documentation ```ts\nnumber\n```
-//  documentation 
     get length(): number {
 //      ^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/C#`<get>length`().
 //      documentation ```ts\nnumber\n```
-//      documentation 
       return this._length
 //                ^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/C#_length.
     }
     set length(value: number) {
 //      ^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/C#`<get>length`().
 //      documentation ```ts\nnumber\n```
-//      documentation 
 //             ^^^^^ definition syntax 1.0.0 src/`accessors.ts`/C#`<set>length`().(value)
 //             documentation ```ts\nnumber\n```
-//             documentation 
       this._length = value
 //         ^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/C#_length.
 //                   ^^^^^ reference syntax 1.0.0 src/`accessors.ts`/C#`<set>length`().(value)
@@ -28,11 +23,9 @@
     _capacity: number = 0
 //  ^^^^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/C#_capacity.
 //  documentation ```ts\nnumber\n```
-//  documentation 
     get capacity(): number {
 //      ^^^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/C#`<get>capacity`().
 //      documentation ```ts\nnumber\n```
-//      documentation 
       return this._capacity
 //                ^^^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/C#_capacity.
     }
@@ -41,25 +34,20 @@
   export class D {
 //             ^ definition syntax 1.0.0 src/`accessors.ts`/D#
 //             documentation ```ts\nD\n```
-//             documentation 
     _length: number = 0
 //  ^^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#_length.
 //  documentation ```ts\nnumber\n```
-//  documentation 
     public get length(): number {
 //             ^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#`<get>length`().
 //             documentation ```ts\nnumber\n```
-//             documentation 
       return this._length
 //                ^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/D#_length.
     }
     public set length(value: number) {
 //             ^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#`<get>length`().
 //             documentation ```ts\nnumber\n```
-//             documentation 
 //                    ^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#`<set>length`().(value)
 //                    documentation ```ts\nnumber\n```
-//                    documentation 
       this._length = value
 //         ^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/D#_length.
 //                   ^^^^^ reference syntax 1.0.0 src/`accessors.ts`/D#`<set>length`().(value)
@@ -68,21 +56,17 @@
     _capacity: number = 0
 //  ^^^^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#_capacity.
 //  documentation ```ts\nnumber\n```
-//  documentation 
     public get capacity(): number {
 //             ^^^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#`<get>capacity`().
 //             documentation ```ts\nnumber\n```
-//             documentation 
       return this._capacity
 //                ^^^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/D#_capacity.
     }
     private set capacity(value: number) {
 //              ^^^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#`<get>capacity`().
 //              documentation ```ts\nnumber\n```
-//              documentation 
 //                       ^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#`<set>capacity`().(value)
 //                       documentation ```ts\nnumber\n```
-//                       documentation 
       this._capacity = value
 //         ^^^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/D#_capacity.
 //                     ^^^^^ reference syntax 1.0.0 src/`accessors.ts`/D#`<set>capacity`().(value)
@@ -90,10 +74,8 @@
     public unsafeSetCapacity(value: number): void {
 //         ^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#unsafeSetCapacity().
 //         documentation ```ts\n(value: number) => void\n```
-//         documentation 
 //                           ^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#unsafeSetCapacity().(value)
 //                           documentation ```ts\nnumber\n```
-//                           documentation 
       this.capacity = value
 //         ^^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/D#`<get>capacity`().
 //         ^^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/D#`<set>capacity`().
@@ -104,19 +86,15 @@
   function g(_: number): void {}
 //         ^ definition syntax 1.0.0 src/`accessors.ts`/g().
 //         documentation ```ts\n(_: number) => void\n```
-//         documentation 
 //           ^ definition syntax 1.0.0 src/`accessors.ts`/g().(_)
 //           documentation ```ts\nnumber\n```
-//           documentation 
   
   function f() {
 //         ^ definition syntax 1.0.0 src/`accessors.ts`/f().
 //         documentation ```ts\n() => void\n```
-//         documentation 
     const c = new C()
 //        ^ definition local 2
 //        documentation ```ts\nC\n```
-//        documentation 
 //                ^ reference syntax 1.0.0 src/`accessors.ts`/C#
     c.length = 10
 //  ^ reference local 2
@@ -140,7 +118,6 @@
     const d = new D()
 //        ^ definition local 5
 //        documentation ```ts\nD\n```
-//        documentation 
 //                ^ reference syntax 1.0.0 src/`accessors.ts`/D#
     d.length = 0
 //  ^ reference local 5

--- a/snapshots/output/syntax/src/accessors.ts
+++ b/snapshots/output/syntax/src/accessors.ts
@@ -1,15 +1,25 @@
   class C {
 //      ^ definition syntax 1.0.0 src/`accessors.ts`/C#
+//      documentation ```ts\nC\n```
+//      documentation 
     _length: number = 0
 //  ^^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/C#_length.
+//  documentation ```ts\nnumber\n```
+//  documentation 
     get length(): number {
 //      ^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/C#`<get>length`().
+//      documentation ```ts\nnumber\n```
+//      documentation 
       return this._length
 //                ^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/C#_length.
     }
     set length(value: number) {
 //      ^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/C#`<get>length`().
+//      documentation ```ts\nnumber\n```
+//      documentation 
 //             ^^^^^ definition syntax 1.0.0 src/`accessors.ts`/C#`<set>length`().(value)
+//             documentation ```ts\nnumber\n```
+//             documentation 
       this._length = value
 //         ^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/C#_length.
 //                   ^^^^^ reference syntax 1.0.0 src/`accessors.ts`/C#`<set>length`().(value)
@@ -17,8 +27,12 @@
   
     _capacity: number = 0
 //  ^^^^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/C#_capacity.
+//  documentation ```ts\nnumber\n```
+//  documentation 
     get capacity(): number {
 //      ^^^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/C#`<get>capacity`().
+//      documentation ```ts\nnumber\n```
+//      documentation 
       return this._capacity
 //                ^^^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/C#_capacity.
     }
@@ -26,16 +40,26 @@
   
   export class D {
 //             ^ definition syntax 1.0.0 src/`accessors.ts`/D#
+//             documentation ```ts\nD\n```
+//             documentation 
     _length: number = 0
 //  ^^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#_length.
+//  documentation ```ts\nnumber\n```
+//  documentation 
     public get length(): number {
 //             ^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#`<get>length`().
+//             documentation ```ts\nnumber\n```
+//             documentation 
       return this._length
 //                ^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/D#_length.
     }
     public set length(value: number) {
 //             ^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#`<get>length`().
+//             documentation ```ts\nnumber\n```
+//             documentation 
 //                    ^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#`<set>length`().(value)
+//                    documentation ```ts\nnumber\n```
+//                    documentation 
       this._length = value
 //         ^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/D#_length.
 //                   ^^^^^ reference syntax 1.0.0 src/`accessors.ts`/D#`<set>length`().(value)
@@ -43,21 +67,33 @@
   
     _capacity: number = 0
 //  ^^^^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#_capacity.
+//  documentation ```ts\nnumber\n```
+//  documentation 
     public get capacity(): number {
 //             ^^^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#`<get>capacity`().
+//             documentation ```ts\nnumber\n```
+//             documentation 
       return this._capacity
 //                ^^^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/D#_capacity.
     }
     private set capacity(value: number) {
 //              ^^^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#`<get>capacity`().
+//              documentation ```ts\nnumber\n```
+//              documentation 
 //                       ^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#`<set>capacity`().(value)
+//                       documentation ```ts\nnumber\n```
+//                       documentation 
       this._capacity = value
 //         ^^^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/D#_capacity.
 //                     ^^^^^ reference syntax 1.0.0 src/`accessors.ts`/D#`<set>capacity`().(value)
     }
     public unsafeSetCapacity(value: number): void {
 //         ^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#unsafeSetCapacity().
+//         documentation ```ts\n(value: number) => void\n```
+//         documentation 
 //                           ^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#unsafeSetCapacity().(value)
+//                           documentation ```ts\nnumber\n```
+//                           documentation 
       this.capacity = value
 //         ^^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/D#`<get>capacity`().
 //         ^^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/D#`<set>capacity`().
@@ -67,12 +103,20 @@
   
   function g(_: number): void {}
 //         ^ definition syntax 1.0.0 src/`accessors.ts`/g().
+//         documentation ```ts\n(_: number) => void\n```
+//         documentation 
 //           ^ definition syntax 1.0.0 src/`accessors.ts`/g().(_)
+//           documentation ```ts\nnumber\n```
+//           documentation 
   
   function f() {
 //         ^ definition syntax 1.0.0 src/`accessors.ts`/f().
+//         documentation ```ts\n() => void\n```
+//         documentation 
     const c = new C()
 //        ^ definition local 2
+//        documentation ```ts\nC\n```
+//        documentation 
 //                ^ reference syntax 1.0.0 src/`accessors.ts`/C#
     c.length = 10
 //  ^ reference local 2
@@ -95,6 +139,8 @@
   
     const d = new D()
 //        ^ definition local 5
+//        documentation ```ts\nD\n```
+//        documentation 
 //                ^ reference syntax 1.0.0 src/`accessors.ts`/D#
     d.length = 0
 //  ^ reference local 5

--- a/snapshots/output/syntax/src/class.ts
+++ b/snapshots/output/syntax/src/class.ts
@@ -1,29 +1,47 @@
   export class Class {
 //             ^^^^^ definition syntax 1.0.0 src/`class.ts`/Class#
+//             documentation ```ts\nClass\n```
+//             documentation 
     public classProperty: string
 //         ^^^^^^^^^^^^^ definition syntax 1.0.0 src/`class.ts`/Class#classProperty.
+//         documentation ```ts\nstring\n```
+//         documentation 
     constructor(constructorParam: string) {
 //              ^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`class.ts`/Class#`<constructor>`().(constructorParam)
+//              documentation ```ts\nstring\n```
+//              documentation 
       this.classProperty = constructorParam
 //         ^^^^^^^^^^^^^ reference syntax 1.0.0 src/`class.ts`/Class#classProperty.
 //                         ^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`class.ts`/Class#`<constructor>`().(constructorParam)
     }
     public method(methodParam: string): string {
 //         ^^^^^^ definition syntax 1.0.0 src/`class.ts`/Class#method().
+//         documentation ```ts\n(methodParam: string) => string\n```
+//         documentation 
 //                ^^^^^^^^^^^ definition syntax 1.0.0 src/`class.ts`/Class#method().(methodParam)
+//                documentation ```ts\nstring\n```
+//                documentation 
       return this.privateMethod(methodParam)
 //                ^^^^^^^^^^^^^ reference syntax 1.0.0 src/`class.ts`/Class#privateMethod().
 //                              ^^^^^^^^^^^ reference syntax 1.0.0 src/`class.ts`/Class#method().(methodParam)
     }
     public static staticMethod(methodParam: string): string {
 //                ^^^^^^^^^^^^ definition syntax 1.0.0 src/`class.ts`/Class#staticMethod().
+//                documentation ```ts\n(methodParam: string) => string\n```
+//                documentation 
 //                             ^^^^^^^^^^^ definition syntax 1.0.0 src/`class.ts`/Class#staticMethod().(methodParam)
+//                             documentation ```ts\nstring\n```
+//                             documentation 
       return methodParam
 //           ^^^^^^^^^^^ reference syntax 1.0.0 src/`class.ts`/Class#staticMethod().(methodParam)
     }
     private privateMethod(methodParam: string): string {
 //          ^^^^^^^^^^^^^ definition syntax 1.0.0 src/`class.ts`/Class#privateMethod().
+//          documentation ```ts\n(methodParam: string) => string\n```
+//          documentation 
 //                        ^^^^^^^^^^^ definition syntax 1.0.0 src/`class.ts`/Class#privateMethod().(methodParam)
+//                        documentation ```ts\nstring\n```
+//                        documentation 
       return methodParam
 //           ^^^^^^^^^^^ reference syntax 1.0.0 src/`class.ts`/Class#privateMethod().(methodParam)
     }
@@ -31,14 +49,22 @@
   
   export function newClass(param: string): string {
 //                ^^^^^^^^ definition syntax 1.0.0 src/`class.ts`/newClass().
+//                documentation ```ts\n(param: string) => string\n```
+//                documentation 
 //                         ^^^^^ definition syntax 1.0.0 src/`class.ts`/newClass().(param)
+//                         documentation ```ts\nstring\n```
+//                         documentation 
     const instance = new Class(param).classProperty
 //        ^^^^^^^^ definition local 2
+//        documentation ```ts\nstring\n```
+//        documentation 
 //                       ^^^^^ reference syntax 1.0.0 src/`class.ts`/Class#
 //                             ^^^^^ reference syntax 1.0.0 src/`class.ts`/newClass().(param)
 //                                    ^^^^^^^^^^^^^ reference syntax 1.0.0 src/`class.ts`/Class#classProperty.
     const instance2 = Class.staticMethod(param)
 //        ^^^^^^^^^ definition local 5
+//        documentation ```ts\nstring\n```
+//        documentation 
 //                    ^^^^^ reference syntax 1.0.0 src/`class.ts`/Class#
 //                          ^^^^^^^^^^^^ reference syntax 1.0.0 src/`class.ts`/Class#staticMethod().
 //                                       ^^^^^ reference syntax 1.0.0 src/`class.ts`/newClass().(param)

--- a/snapshots/output/syntax/src/class.ts
+++ b/snapshots/output/syntax/src/class.ts
@@ -1,15 +1,12 @@
   export class Class {
 //             ^^^^^ definition syntax 1.0.0 src/`class.ts`/Class#
 //             documentation ```ts\nClass\n```
-//             documentation 
     public classProperty: string
 //         ^^^^^^^^^^^^^ definition syntax 1.0.0 src/`class.ts`/Class#classProperty.
 //         documentation ```ts\nstring\n```
-//         documentation 
     constructor(constructorParam: string) {
 //              ^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`class.ts`/Class#`<constructor>`().(constructorParam)
 //              documentation ```ts\nstring\n```
-//              documentation 
       this.classProperty = constructorParam
 //         ^^^^^^^^^^^^^ reference syntax 1.0.0 src/`class.ts`/Class#classProperty.
 //                         ^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`class.ts`/Class#`<constructor>`().(constructorParam)
@@ -17,10 +14,8 @@
     public method(methodParam: string): string {
 //         ^^^^^^ definition syntax 1.0.0 src/`class.ts`/Class#method().
 //         documentation ```ts\n(methodParam: string) => string\n```
-//         documentation 
 //                ^^^^^^^^^^^ definition syntax 1.0.0 src/`class.ts`/Class#method().(methodParam)
 //                documentation ```ts\nstring\n```
-//                documentation 
       return this.privateMethod(methodParam)
 //                ^^^^^^^^^^^^^ reference syntax 1.0.0 src/`class.ts`/Class#privateMethod().
 //                              ^^^^^^^^^^^ reference syntax 1.0.0 src/`class.ts`/Class#method().(methodParam)
@@ -28,20 +23,16 @@
     public static staticMethod(methodParam: string): string {
 //                ^^^^^^^^^^^^ definition syntax 1.0.0 src/`class.ts`/Class#staticMethod().
 //                documentation ```ts\n(methodParam: string) => string\n```
-//                documentation 
 //                             ^^^^^^^^^^^ definition syntax 1.0.0 src/`class.ts`/Class#staticMethod().(methodParam)
 //                             documentation ```ts\nstring\n```
-//                             documentation 
       return methodParam
 //           ^^^^^^^^^^^ reference syntax 1.0.0 src/`class.ts`/Class#staticMethod().(methodParam)
     }
     private privateMethod(methodParam: string): string {
 //          ^^^^^^^^^^^^^ definition syntax 1.0.0 src/`class.ts`/Class#privateMethod().
 //          documentation ```ts\n(methodParam: string) => string\n```
-//          documentation 
 //                        ^^^^^^^^^^^ definition syntax 1.0.0 src/`class.ts`/Class#privateMethod().(methodParam)
 //                        documentation ```ts\nstring\n```
-//                        documentation 
       return methodParam
 //           ^^^^^^^^^^^ reference syntax 1.0.0 src/`class.ts`/Class#privateMethod().(methodParam)
     }
@@ -50,21 +41,17 @@
   export function newClass(param: string): string {
 //                ^^^^^^^^ definition syntax 1.0.0 src/`class.ts`/newClass().
 //                documentation ```ts\n(param: string) => string\n```
-//                documentation 
 //                         ^^^^^ definition syntax 1.0.0 src/`class.ts`/newClass().(param)
 //                         documentation ```ts\nstring\n```
-//                         documentation 
     const instance = new Class(param).classProperty
 //        ^^^^^^^^ definition local 2
 //        documentation ```ts\nstring\n```
-//        documentation 
 //                       ^^^^^ reference syntax 1.0.0 src/`class.ts`/Class#
 //                             ^^^^^ reference syntax 1.0.0 src/`class.ts`/newClass().(param)
 //                                    ^^^^^^^^^^^^^ reference syntax 1.0.0 src/`class.ts`/Class#classProperty.
     const instance2 = Class.staticMethod(param)
 //        ^^^^^^^^^ definition local 5
 //        documentation ```ts\nstring\n```
-//        documentation 
 //                    ^^^^^ reference syntax 1.0.0 src/`class.ts`/Class#
 //                          ^^^^^^^^^^^^ reference syntax 1.0.0 src/`class.ts`/Class#staticMethod().
 //                                       ^^^^^ reference syntax 1.0.0 src/`class.ts`/newClass().(param)

--- a/snapshots/output/syntax/src/enum.ts
+++ b/snapshots/output/syntax/src/enum.ts
@@ -1,13 +1,21 @@
   export enum Enum {
 //            ^^^^ definition syntax 1.0.0 src/`enum.ts`/Enum#
+//            documentation ```ts\nEnum\n```
+//            documentation 
     A,
 //  ^ definition syntax 1.0.0 src/`enum.ts`/Enum#A.
+//  documentation ```ts\nEnum.A\n```
+//  documentation 
     B,
 //  ^ definition syntax 1.0.0 src/`enum.ts`/Enum#B.
+//  documentation ```ts\nEnum.B\n```
+//  documentation 
   }
   
   export function newEnum(): Enum {
 //                ^^^^^^^ definition syntax 1.0.0 src/`enum.ts`/newEnum().
+//                documentation ```ts\n() => Enum\n```
+//                documentation 
 //                           ^^^^ reference syntax 1.0.0 src/`enum.ts`/Enum#
     return Enum.A
 //         ^^^^ reference syntax 1.0.0 src/`enum.ts`/Enum#

--- a/snapshots/output/syntax/src/enum.ts
+++ b/snapshots/output/syntax/src/enum.ts
@@ -1,21 +1,17 @@
   export enum Enum {
 //            ^^^^ definition syntax 1.0.0 src/`enum.ts`/Enum#
 //            documentation ```ts\nEnum\n```
-//            documentation 
     A,
 //  ^ definition syntax 1.0.0 src/`enum.ts`/Enum#A.
 //  documentation ```ts\nEnum.A\n```
-//  documentation 
     B,
 //  ^ definition syntax 1.0.0 src/`enum.ts`/Enum#B.
 //  documentation ```ts\nEnum.B\n```
-//  documentation 
   }
   
   export function newEnum(): Enum {
 //                ^^^^^^^ definition syntax 1.0.0 src/`enum.ts`/newEnum().
 //                documentation ```ts\n() => Enum\n```
-//                documentation 
 //                           ^^^^ reference syntax 1.0.0 src/`enum.ts`/Enum#
     return Enum.A
 //         ^^^^ reference syntax 1.0.0 src/`enum.ts`/Enum#

--- a/snapshots/output/syntax/src/function.ts
+++ b/snapshots/output/syntax/src/function.ts
@@ -1,3 +1,5 @@
   export function newFunction(): void {}
 //                ^^^^^^^^^^^ definition syntax 1.0.0 src/`function.ts`/newFunction().
+//                documentation ```ts\n() => void\n```
+//                documentation 
   

--- a/snapshots/output/syntax/src/function.ts
+++ b/snapshots/output/syntax/src/function.ts
@@ -1,5 +1,4 @@
   export function newFunction(): void {}
 //                ^^^^^^^^^^^ definition syntax 1.0.0 src/`function.ts`/newFunction().
 //                documentation ```ts\n() => void\n```
-//                documentation 
   

--- a/snapshots/output/syntax/src/import.ts
+++ b/snapshots/output/syntax/src/import.ts
@@ -11,7 +11,6 @@
   export function useEverything(): string {
 //                ^^^^^^^^^^^^^ definition syntax 1.0.0 src/`import.ts`/useEverything().
 //                documentation ```ts\n() => string\n```
-//                documentation 
     return (
       new Class('a').classProperty +
 //        ^^^^^ reference syntax 1.0.0 src/`class.ts`/Class#

--- a/snapshots/output/syntax/src/import.ts
+++ b/snapshots/output/syntax/src/import.ts
@@ -10,6 +10,8 @@
   
   export function useEverything(): string {
 //                ^^^^^^^^^^^^^ definition syntax 1.0.0 src/`import.ts`/useEverything().
+//                documentation ```ts\n() => string\n```
+//                documentation 
     return (
       new Class('a').classProperty +
 //        ^^^^^ reference syntax 1.0.0 src/`class.ts`/Class#

--- a/snapshots/output/syntax/src/interface.ts
+++ b/snapshots/output/syntax/src/interface.ts
@@ -1,54 +1,42 @@
   export interface Interface {
 //                 ^^^^^^^^^ definition syntax 1.0.0 src/`interface.ts`/Interface#
 //                 documentation ```ts\nInterface\n```
-//                 documentation 
     property: string
 //  ^^^^^^^^ definition syntax 1.0.0 src/`interface.ts`/Interface#property.
 //  documentation ```ts\nstring\n```
-//  documentation 
     methodSignature(param: string): string
 //  ^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`interface.ts`/Interface#methodSignature().
 //  documentation ```ts\n(param: string) => string\n```
-//  documentation 
 //                  ^^^^^ definition syntax 1.0.0 src/`interface.ts`/Interface#methodSignature().(param)
 //                  documentation ```ts\nstring\n```
-//                  documentation 
     methodSignature2: (param: string) => string
 //  ^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`interface.ts`/Interface#methodSignature2.
 //  documentation ```ts\n(param: string) => string\n```
-//  documentation 
 //                     ^^^^^ definition local 1
 //                     documentation ```ts\nstring\n```
-//                     documentation 
   }
   
   export function newInterface(): Interface {
 //                ^^^^^^^^^^^^ definition syntax 1.0.0 src/`interface.ts`/newInterface().
 //                documentation ```ts\n() => Interface\n```
-//                documentation 
 //                                ^^^^^^^^^ reference syntax 1.0.0 src/`interface.ts`/Interface#
     return {
       property: 'a',
 //    ^^^^^^^^ definition syntax 1.0.0 src/`interface.ts`/property0:
 //    documentation ```ts\nstring\n```
-//    documentation 
       methodSignature(param: string): string {
 //    ^^^^^^^^^^^^^^^ definition local 4
 //    documentation ```ts\n(param: string) => string\n```
-//    documentation 
 //                    ^^^^^ definition local 5
 //                    documentation ```ts\nstring\n```
-//                    documentation 
         return param
 //             ^^^^^ reference local 5
       },
       methodSignature2: (param: string): string => {
 //    ^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`interface.ts`/methodSignature20:
 //    documentation ```ts\n(param: string) => string\n```
-//    documentation 
 //                       ^^^^^ definition local 7
 //                       documentation ```ts\nstring\n```
-//                       documentation 
         return param
 //             ^^^^^ reference local 7
       },

--- a/snapshots/output/syntax/src/interface.ts
+++ b/snapshots/output/syntax/src/interface.ts
@@ -1,30 +1,54 @@
   export interface Interface {
 //                 ^^^^^^^^^ definition syntax 1.0.0 src/`interface.ts`/Interface#
+//                 documentation ```ts\nInterface\n```
+//                 documentation 
     property: string
 //  ^^^^^^^^ definition syntax 1.0.0 src/`interface.ts`/Interface#property.
+//  documentation ```ts\nstring\n```
+//  documentation 
     methodSignature(param: string): string
 //  ^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`interface.ts`/Interface#methodSignature().
+//  documentation ```ts\n(param: string) => string\n```
+//  documentation 
 //                  ^^^^^ definition syntax 1.0.0 src/`interface.ts`/Interface#methodSignature().(param)
+//                  documentation ```ts\nstring\n```
+//                  documentation 
     methodSignature2: (param: string) => string
 //  ^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`interface.ts`/Interface#methodSignature2.
+//  documentation ```ts\n(param: string) => string\n```
+//  documentation 
 //                     ^^^^^ definition local 1
+//                     documentation ```ts\nstring\n```
+//                     documentation 
   }
   
   export function newInterface(): Interface {
 //                ^^^^^^^^^^^^ definition syntax 1.0.0 src/`interface.ts`/newInterface().
+//                documentation ```ts\n() => Interface\n```
+//                documentation 
 //                                ^^^^^^^^^ reference syntax 1.0.0 src/`interface.ts`/Interface#
     return {
       property: 'a',
 //    ^^^^^^^^ definition syntax 1.0.0 src/`interface.ts`/property0:
+//    documentation ```ts\nstring\n```
+//    documentation 
       methodSignature(param: string): string {
 //    ^^^^^^^^^^^^^^^ definition local 4
+//    documentation ```ts\n(param: string) => string\n```
+//    documentation 
 //                    ^^^^^ definition local 5
+//                    documentation ```ts\nstring\n```
+//                    documentation 
         return param
 //             ^^^^^ reference local 5
       },
       methodSignature2: (param: string): string => {
 //    ^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`interface.ts`/methodSignature20:
+//    documentation ```ts\n(param: string) => string\n```
+//    documentation 
 //                       ^^^^^ definition local 7
+//                       documentation ```ts\nstring\n```
+//                       documentation 
         return param
 //             ^^^^^ reference local 7
       },

--- a/snapshots/output/syntax/src/issue-45.d.ts
+++ b/snapshots/output/syntax/src/issue-45.d.ts
@@ -1,14 +1,26 @@
   export namespace example {
 //                 ^^^^^^^ definition syntax 1.0.0 src/`issue-45.d.ts`/example/
+//                 documentation ```ts\ntypeof example\n```
+//                 documentation 
     class Server {
 //        ^^^^^^ definition syntax 1.0.0 src/`issue-45.d.ts`/example/Server#
+//        documentation ```ts\nServer\n```
+//        documentation 
       // This overloaded method reproduces the following issue https://github.com/sourcegraph/lsif-typescript/issues/45
       addListener(name: 'a'): void
 //    ^^^^^^^^^^^ definition syntax 1.0.0 src/`issue-45.d.ts`/example/Server#addListener().
+//    documentation ```ts\n{ (name: "a"): void; (name: "b"): void; }\n```
+//    documentation 
 //                ^^^^ definition syntax 1.0.0 src/`issue-45.d.ts`/example/Server#addListener().(name)
+//                documentation ```ts\n"b"\n```
+//                documentation 
       addListener(name: 'b'): void
 //    ^^^^^^^^^^^ definition syntax 1.0.0 src/`issue-45.d.ts`/example/Server#addListener().
+//    documentation ```ts\n{ (name: "a"): void; (name: "b"): void; }\n```
+//    documentation 
 //                ^^^^ definition syntax 1.0.0 src/`issue-45.d.ts`/example/Server#addListener().(name)
+//                documentation ```ts\n"b"\n```
+//                documentation 
     }
   }
   

--- a/snapshots/output/syntax/src/issue-45.d.ts
+++ b/snapshots/output/syntax/src/issue-45.d.ts
@@ -1,26 +1,20 @@
   export namespace example {
 //                 ^^^^^^^ definition syntax 1.0.0 src/`issue-45.d.ts`/example/
 //                 documentation ```ts\ntypeof example\n```
-//                 documentation 
     class Server {
 //        ^^^^^^ definition syntax 1.0.0 src/`issue-45.d.ts`/example/Server#
 //        documentation ```ts\nServer\n```
-//        documentation 
       // This overloaded method reproduces the following issue https://github.com/sourcegraph/lsif-typescript/issues/45
       addListener(name: 'a'): void
 //    ^^^^^^^^^^^ definition syntax 1.0.0 src/`issue-45.d.ts`/example/Server#addListener().
 //    documentation ```ts\n{ (name: "a"): void; (name: "b"): void; }\n```
-//    documentation 
 //                ^^^^ definition syntax 1.0.0 src/`issue-45.d.ts`/example/Server#addListener().(name)
 //                documentation ```ts\n"b"\n```
-//                documentation 
       addListener(name: 'b'): void
 //    ^^^^^^^^^^^ definition syntax 1.0.0 src/`issue-45.d.ts`/example/Server#addListener().
 //    documentation ```ts\n{ (name: "a"): void; (name: "b"): void; }\n```
-//    documentation 
 //                ^^^^ definition syntax 1.0.0 src/`issue-45.d.ts`/example/Server#addListener().(name)
 //                documentation ```ts\n"b"\n```
-//                documentation 
     }
   }
   

--- a/snapshots/output/syntax/src/local.ts
+++ b/snapshots/output/syntax/src/local.ts
@@ -1,18 +1,30 @@
   export function local(): string {
 //                ^^^^^ definition syntax 1.0.0 src/`local.ts`/local().
+//                documentation ```ts\n() => string\n```
+//                documentation 
     const a = 'a'
 //        ^ definition local 2
+//        documentation ```ts\n"a"\n```
+//        documentation 
     let b = a
 //      ^ definition local 5
+//      documentation ```ts\nstring\n```
+//      documentation 
 //          ^ reference local 2
     var c = b,
 //      ^ definition local 8
+//      documentation ```ts\nstring\n```
+//      documentation 
 //          ^ reference local 5
       c2 = b
 //    ^^ definition local 9
+//    documentation ```ts\nstring\n```
+//    documentation 
 //         ^ reference local 5
     for (let d = 0; d < c.length; d++) {
 //           ^ definition local 12
+//           documentation ```ts\nnumber\n```
+//           documentation 
 //                  ^ reference local 12
 //                      ^ reference local 8
 //                        ^^^^^^ reference typescript 4.6.2 lib/`lib.es5.d.ts`/String#length.
@@ -32,8 +44,14 @@
 //                 ^^^^^^ reference typescript 4.6.2 lib/`lib.es5.d.ts`/Array#reduce().
 //                 ^^^^^^ reference typescript 4.6.2 lib/`lib.es5.d.ts`/Array#reduce().
 //                         ^^^^^^^^^^^^^ definition local 16
+//                         documentation ```ts\nstring\n```
+//                         documentation 
 //                                        ^^^^^^^^^^^^ definition local 17
+//                                        documentation ```ts\nstring\n```
+//                                        documentation 
 //                                                      ^^^^^^^^^^^^ definition local 18
+//                                                      documentation ```ts\nnumber\n```
+//                                                      documentation 
       return previousValue + currentValue + currentIndex
 //           ^^^^^^^^^^^^^ reference local 16
 //                           ^^^^^^^^^^^^ reference local 17

--- a/snapshots/output/syntax/src/local.ts
+++ b/snapshots/output/syntax/src/local.ts
@@ -1,30 +1,24 @@
   export function local(): string {
 //                ^^^^^ definition syntax 1.0.0 src/`local.ts`/local().
 //                documentation ```ts\n() => string\n```
-//                documentation 
     const a = 'a'
 //        ^ definition local 2
 //        documentation ```ts\n"a"\n```
-//        documentation 
     let b = a
 //      ^ definition local 5
 //      documentation ```ts\nstring\n```
-//      documentation 
 //          ^ reference local 2
     var c = b,
 //      ^ definition local 8
 //      documentation ```ts\nstring\n```
-//      documentation 
 //          ^ reference local 5
       c2 = b
 //    ^^ definition local 9
 //    documentation ```ts\nstring\n```
-//    documentation 
 //         ^ reference local 5
     for (let d = 0; d < c.length; d++) {
 //           ^ definition local 12
 //           documentation ```ts\nnumber\n```
-//           documentation 
 //                  ^ reference local 12
 //                      ^ reference local 8
 //                        ^^^^^^ reference typescript 4.6.2 lib/`lib.es5.d.ts`/String#length.
@@ -45,13 +39,10 @@
 //                 ^^^^^^ reference typescript 4.6.2 lib/`lib.es5.d.ts`/Array#reduce().
 //                         ^^^^^^^^^^^^^ definition local 16
 //                         documentation ```ts\nstring\n```
-//                         documentation 
 //                                        ^^^^^^^^^^^^ definition local 17
 //                                        documentation ```ts\nstring\n```
-//                                        documentation 
 //                                                      ^^^^^^^^^^^^ definition local 18
 //                                                      documentation ```ts\nnumber\n```
-//                                                      documentation 
       return previousValue + currentValue + currentIndex
 //           ^^^^^^^^^^^^^ reference local 16
 //                           ^^^^^^^^^^^^ reference local 17

--- a/snapshots/output/syntax/src/module.d.ts
+++ b/snapshots/output/syntax/src/module.d.ts
@@ -2,6 +2,5 @@
     function hello(): string
 //           ^^^^^ definition syntax 1.0.0 src/`module.d.ts`/`'a:b'`/hello().
 //           documentation ```ts\n() => string\n```
-//           documentation 
   }
   

--- a/snapshots/output/syntax/src/module.d.ts
+++ b/snapshots/output/syntax/src/module.d.ts
@@ -1,5 +1,7 @@
   declare module 'a:b' {
     function hello(): string
 //           ^^^^^ definition syntax 1.0.0 src/`module.d.ts`/`'a:b'`/hello().
+//           documentation ```ts\n() => string\n```
+//           documentation 
   }
   

--- a/snapshots/output/syntax/src/namespace.d.ts
+++ b/snapshots/output/syntax/src/namespace.d.ts
@@ -1,24 +1,19 @@
   declare namespace a {
 //                  ^ definition syntax 1.0.0 src/`namespace.d.ts`/a/
 //                  documentation ```ts\ntypeof a\n```
-//                  documentation 
     function hello(): string
 //           ^^^^^ definition syntax 1.0.0 src/`namespace.d.ts`/a/hello().
 //           documentation ```ts\n() => string\n```
-//           documentation 
     interface Interface {
 //            ^^^^^^^^^ definition syntax 1.0.0 src/`namespace.d.ts`/a/Interface#
 //            documentation ```ts\nInterface\n```
-//            documentation 
       hello: string
 //    ^^^^^ definition syntax 1.0.0 src/`namespace.d.ts`/a/Interface#hello.
 //    documentation ```ts\nstring\n```
-//    documentation 
     }
     var i: Interface
 //      ^ definition syntax 1.0.0 src/`namespace.d.ts`/a/i.
 //      documentation ```ts\nInterface\n```
-//      documentation 
 //         ^^^^^^^^^ reference syntax 1.0.0 src/`namespace.d.ts`/a/Interface#
   }
   

--- a/snapshots/output/syntax/src/namespace.d.ts
+++ b/snapshots/output/syntax/src/namespace.d.ts
@@ -1,14 +1,24 @@
   declare namespace a {
 //                  ^ definition syntax 1.0.0 src/`namespace.d.ts`/a/
+//                  documentation ```ts\ntypeof a\n```
+//                  documentation 
     function hello(): string
 //           ^^^^^ definition syntax 1.0.0 src/`namespace.d.ts`/a/hello().
+//           documentation ```ts\n() => string\n```
+//           documentation 
     interface Interface {
 //            ^^^^^^^^^ definition syntax 1.0.0 src/`namespace.d.ts`/a/Interface#
+//            documentation ```ts\nInterface\n```
+//            documentation 
       hello: string
 //    ^^^^^ definition syntax 1.0.0 src/`namespace.d.ts`/a/Interface#hello.
+//    documentation ```ts\nstring\n```
+//    documentation 
     }
     var i: Interface
 //      ^ definition syntax 1.0.0 src/`namespace.d.ts`/a/i.
+//      documentation ```ts\nInterface\n```
+//      documentation 
 //         ^^^^^^^^^ reference syntax 1.0.0 src/`namespace.d.ts`/a/Interface#
   }
   

--- a/snapshots/output/syntax/src/property-assignment-reference.ts
+++ b/snapshots/output/syntax/src/property-assignment-reference.ts
@@ -7,6 +7,8 @@
   
   export function run(): string {
 //                ^^^ definition syntax 1.0.0 src/`property-assignment-reference.ts`/run().
+//                documentation ```ts\n() => string\n```
+//                documentation 
     return propertyAssignment().a + shorthandPropertyAssignment().a
 //         ^^^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`property-assignment.ts`/propertyAssignment().
 //                              ^ reference syntax 1.0.0 src/`property-assignment.ts`/a0:

--- a/snapshots/output/syntax/src/property-assignment-reference.ts
+++ b/snapshots/output/syntax/src/property-assignment-reference.ts
@@ -8,7 +8,6 @@
   export function run(): string {
 //                ^^^ definition syntax 1.0.0 src/`property-assignment-reference.ts`/run().
 //                documentation ```ts\n() => string\n```
-//                documentation 
     return propertyAssignment().a + shorthandPropertyAssignment().a
 //         ^^^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`property-assignment.ts`/propertyAssignment().
 //                              ^ reference syntax 1.0.0 src/`property-assignment.ts`/a0:

--- a/snapshots/output/syntax/src/property-assignment.ts
+++ b/snapshots/output/syntax/src/property-assignment.ts
@@ -1,14 +1,24 @@
   export function propertyAssignment() {
 //                ^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`property-assignment.ts`/propertyAssignment().
+//                documentation ```ts\n() => { a: string; }\n```
+//                documentation 
     return { a: 'a' }
 //           ^ definition syntax 1.0.0 src/`property-assignment.ts`/a0:
+//           documentation ```ts\nstring\n```
+//           documentation 
   }
   export function shorthandPropertyAssignment() {
 //                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`property-assignment.ts`/shorthandPropertyAssignment().
+//                documentation ```ts\n() => { a: string; }\n```
+//                documentation 
     const a = 'a'
 //        ^ definition local 2
+//        documentation ```ts\n"a"\n```
+//        documentation 
     return { a }
 //           ^ definition syntax 1.0.0 src/`property-assignment.ts`/a1:
+//           documentation ```ts\nstring\n```
+//           documentation 
 //           ^ reference local 2
   }
   

--- a/snapshots/output/syntax/src/property-assignment.ts
+++ b/snapshots/output/syntax/src/property-assignment.ts
@@ -1,24 +1,19 @@
   export function propertyAssignment() {
 //                ^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`property-assignment.ts`/propertyAssignment().
 //                documentation ```ts\n() => { a: string; }\n```
-//                documentation 
     return { a: 'a' }
 //           ^ definition syntax 1.0.0 src/`property-assignment.ts`/a0:
 //           documentation ```ts\nstring\n```
-//           documentation 
   }
   export function shorthandPropertyAssignment() {
 //                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`property-assignment.ts`/shorthandPropertyAssignment().
 //                documentation ```ts\n() => { a: string; }\n```
-//                documentation 
     const a = 'a'
 //        ^ definition local 2
 //        documentation ```ts\n"a"\n```
-//        documentation 
     return { a }
 //           ^ definition syntax 1.0.0 src/`property-assignment.ts`/a1:
 //           documentation ```ts\nstring\n```
-//           documentation 
 //           ^ reference local 2
   }
   

--- a/snapshots/output/syntax/src/type-alias.ts
+++ b/snapshots/output/syntax/src/type-alias.ts
@@ -1,55 +1,91 @@
   type S = string
 //     ^ definition syntax 1.0.0 src/`type-alias.ts`/S#
+//     documentation ```ts\nstring\n```
+//     documentation 
   
   const s: S = ''
 //      ^ definition syntax 1.0.0 src/`type-alias.ts`/s.
+//      documentation ```ts\nstring\n```
+//      documentation 
 //         ^ reference syntax 1.0.0 src/`type-alias.ts`/S#
   
   class C<T> {
 //      ^ definition syntax 1.0.0 src/`type-alias.ts`/C#
+//      documentation ```ts\nC<T>\n```
+//      documentation 
 //        ^ definition syntax 1.0.0 src/`type-alias.ts`/C#[T]
+//        documentation ```ts\nT\n```
+//        documentation 
     t: T
 //  ^ definition syntax 1.0.0 src/`type-alias.ts`/C#t.
+//  documentation ```ts\nT\n```
+//  documentation 
 //     ^ reference syntax 1.0.0 src/`type-alias.ts`/C#[T]
   }
   type Cstring = C<string>
 //     ^^^^^^^ definition syntax 1.0.0 src/`type-alias.ts`/Cstring#
+//     documentation ```ts\nCstring\n```
+//     documentation 
 //               ^ reference syntax 1.0.0 src/`type-alias.ts`/C#
   
   const cs: Cstring = new C<string>()
 //      ^^ definition syntax 1.0.0 src/`type-alias.ts`/cs.
+//      documentation ```ts\nCstring\n```
+//      documentation 
 //          ^^^^^^^ reference syntax 1.0.0 src/`type-alias.ts`/Cstring#
 //                        ^ reference syntax 1.0.0 src/`type-alias.ts`/C#
   
   class D<T, U> {
 //      ^ definition syntax 1.0.0 src/`type-alias.ts`/D#
+//      documentation ```ts\nD<T, U>\n```
+//      documentation 
 //        ^ definition syntax 1.0.0 src/`type-alias.ts`/D#[T]
+//        documentation ```ts\nT\n```
+//        documentation 
 //           ^ definition syntax 1.0.0 src/`type-alias.ts`/D#[U]
+//           documentation ```ts\nU\n```
+//           documentation 
     t: T
 //  ^ definition syntax 1.0.0 src/`type-alias.ts`/D#t.
+//  documentation ```ts\nT\n```
+//  documentation 
 //     ^ reference syntax 1.0.0 src/`type-alias.ts`/D#[T]
     u: U
 //  ^ definition syntax 1.0.0 src/`type-alias.ts`/D#u.
+//  documentation ```ts\nU\n```
+//  documentation 
 //     ^ reference syntax 1.0.0 src/`type-alias.ts`/D#[U]
   }
   type DT<T> = D<T, string> // partially specialized
 //     ^^ definition syntax 1.0.0 src/`type-alias.ts`/DT#
+//     documentation ```ts\nDT<T>\n```
+//     documentation 
 //        ^ definition syntax 1.0.0 src/`type-alias.ts`/DT#[T]
+//        documentation ```ts\nT\n```
+//        documentation 
 //             ^ reference syntax 1.0.0 src/`type-alias.ts`/D#
 //               ^ reference syntax 1.0.0 src/`type-alias.ts`/DT#[T]
   type DU<U> = D<string, DU<U>> // recursive!
 //     ^^ definition syntax 1.0.0 src/`type-alias.ts`/DU#
+//     documentation ```ts\nDU<U>\n```
+//     documentation 
 //        ^ definition syntax 1.0.0 src/`type-alias.ts`/DU#[U]
+//        documentation ```ts\nU\n```
+//        documentation 
 //             ^ reference syntax 1.0.0 src/`type-alias.ts`/D#
 //                       ^^ reference syntax 1.0.0 src/`type-alias.ts`/DU#
 //                          ^ reference syntax 1.0.0 src/`type-alias.ts`/DU#[U]
   
   const dt: DT<string> = new D()
 //      ^^ definition syntax 1.0.0 src/`type-alias.ts`/dt.
+//      documentation ```ts\nDT<string>\n```
+//      documentation 
 //          ^^ reference syntax 1.0.0 src/`type-alias.ts`/DT#
 //                           ^ reference syntax 1.0.0 src/`type-alias.ts`/D#
   const du: DU<string> = new D()
 //      ^^ definition syntax 1.0.0 src/`type-alias.ts`/du.
+//      documentation ```ts\nDU<string>\n```
+//      documentation 
 //          ^^ reference syntax 1.0.0 src/`type-alias.ts`/DU#
 //                           ^ reference syntax 1.0.0 src/`type-alias.ts`/D#
   

--- a/snapshots/output/syntax/src/type-alias.ts
+++ b/snapshots/output/syntax/src/type-alias.ts
@@ -1,77 +1,61 @@
   type S = string
 //     ^ definition syntax 1.0.0 src/`type-alias.ts`/S#
 //     documentation ```ts\nstring\n```
-//     documentation 
   
   const s: S = ''
 //      ^ definition syntax 1.0.0 src/`type-alias.ts`/s.
 //      documentation ```ts\nstring\n```
-//      documentation 
 //         ^ reference syntax 1.0.0 src/`type-alias.ts`/S#
   
   class C<T> {
 //      ^ definition syntax 1.0.0 src/`type-alias.ts`/C#
 //      documentation ```ts\nC<T>\n```
-//      documentation 
 //        ^ definition syntax 1.0.0 src/`type-alias.ts`/C#[T]
 //        documentation ```ts\nT\n```
-//        documentation 
     t: T
 //  ^ definition syntax 1.0.0 src/`type-alias.ts`/C#t.
 //  documentation ```ts\nT\n```
-//  documentation 
 //     ^ reference syntax 1.0.0 src/`type-alias.ts`/C#[T]
   }
   type Cstring = C<string>
 //     ^^^^^^^ definition syntax 1.0.0 src/`type-alias.ts`/Cstring#
 //     documentation ```ts\nCstring\n```
-//     documentation 
 //               ^ reference syntax 1.0.0 src/`type-alias.ts`/C#
   
   const cs: Cstring = new C<string>()
 //      ^^ definition syntax 1.0.0 src/`type-alias.ts`/cs.
 //      documentation ```ts\nCstring\n```
-//      documentation 
 //          ^^^^^^^ reference syntax 1.0.0 src/`type-alias.ts`/Cstring#
 //                        ^ reference syntax 1.0.0 src/`type-alias.ts`/C#
   
   class D<T, U> {
 //      ^ definition syntax 1.0.0 src/`type-alias.ts`/D#
 //      documentation ```ts\nD<T, U>\n```
-//      documentation 
 //        ^ definition syntax 1.0.0 src/`type-alias.ts`/D#[T]
 //        documentation ```ts\nT\n```
-//        documentation 
 //           ^ definition syntax 1.0.0 src/`type-alias.ts`/D#[U]
 //           documentation ```ts\nU\n```
-//           documentation 
     t: T
 //  ^ definition syntax 1.0.0 src/`type-alias.ts`/D#t.
 //  documentation ```ts\nT\n```
-//  documentation 
 //     ^ reference syntax 1.0.0 src/`type-alias.ts`/D#[T]
     u: U
 //  ^ definition syntax 1.0.0 src/`type-alias.ts`/D#u.
 //  documentation ```ts\nU\n```
-//  documentation 
 //     ^ reference syntax 1.0.0 src/`type-alias.ts`/D#[U]
   }
   type DT<T> = D<T, string> // partially specialized
 //     ^^ definition syntax 1.0.0 src/`type-alias.ts`/DT#
 //     documentation ```ts\nDT<T>\n```
-//     documentation 
 //        ^ definition syntax 1.0.0 src/`type-alias.ts`/DT#[T]
 //        documentation ```ts\nT\n```
-//        documentation 
 //             ^ reference syntax 1.0.0 src/`type-alias.ts`/D#
 //               ^ reference syntax 1.0.0 src/`type-alias.ts`/DT#[T]
   type DU<U> = D<string, DU<U>> // recursive!
 //     ^^ definition syntax 1.0.0 src/`type-alias.ts`/DU#
 //     documentation ```ts\nDU<U>\n```
-//     documentation 
 //        ^ definition syntax 1.0.0 src/`type-alias.ts`/DU#[U]
 //        documentation ```ts\nU\n```
-//        documentation 
 //             ^ reference syntax 1.0.0 src/`type-alias.ts`/D#
 //                       ^^ reference syntax 1.0.0 src/`type-alias.ts`/DU#
 //                          ^ reference syntax 1.0.0 src/`type-alias.ts`/DU#[U]
@@ -79,13 +63,11 @@
   const dt: DT<string> = new D()
 //      ^^ definition syntax 1.0.0 src/`type-alias.ts`/dt.
 //      documentation ```ts\nDT<string>\n```
-//      documentation 
 //          ^^ reference syntax 1.0.0 src/`type-alias.ts`/DT#
 //                           ^ reference syntax 1.0.0 src/`type-alias.ts`/D#
   const du: DU<string> = new D()
 //      ^^ definition syntax 1.0.0 src/`type-alias.ts`/du.
 //      documentation ```ts\nDU<string>\n```
-//      documentation 
 //          ^^ reference syntax 1.0.0 src/`type-alias.ts`/DU#
 //                           ^ reference syntax 1.0.0 src/`type-alias.ts`/D#
   

--- a/snapshots/output/syntax/src/type-parameter.ts
+++ b/snapshots/output/syntax/src/type-parameter.ts
@@ -1,10 +1,20 @@
   export function typeParameter<A, B>(parameter: A, parameter2: B): [A, B] {
 //                ^^^^^^^^^^^^^ definition syntax 1.0.0 src/`type-parameter.ts`/typeParameter().
+//                documentation ```ts\n<A, B>(parameter: A, parameter2: B) => [A, B]\n```
+//                documentation 
 //                              ^ definition syntax 1.0.0 src/`type-parameter.ts`/typeParameter().[A]
+//                              documentation ```ts\nA\n```
+//                              documentation 
 //                                 ^ definition syntax 1.0.0 src/`type-parameter.ts`/typeParameter().[B]
+//                                 documentation ```ts\nB\n```
+//                                 documentation 
 //                                    ^^^^^^^^^ definition syntax 1.0.0 src/`type-parameter.ts`/typeParameter().(parameter)
+//                                    documentation ```ts\nA\n```
+//                                    documentation 
 //                                               ^ reference syntax 1.0.0 src/`type-parameter.ts`/typeParameter().[A]
 //                                                  ^^^^^^^^^^ definition syntax 1.0.0 src/`type-parameter.ts`/typeParameter().(parameter2)
+//                                                  documentation ```ts\nB\n```
+//                                                  documentation 
 //                                                              ^ reference syntax 1.0.0 src/`type-parameter.ts`/typeParameter().[B]
 //                                                                   ^ reference syntax 1.0.0 src/`type-parameter.ts`/typeParameter().[A]
 //                                                                      ^ reference syntax 1.0.0 src/`type-parameter.ts`/typeParameter().[B]

--- a/snapshots/output/syntax/src/type-parameter.ts
+++ b/snapshots/output/syntax/src/type-parameter.ts
@@ -1,20 +1,15 @@
   export function typeParameter<A, B>(parameter: A, parameter2: B): [A, B] {
 //                ^^^^^^^^^^^^^ definition syntax 1.0.0 src/`type-parameter.ts`/typeParameter().
 //                documentation ```ts\n<A, B>(parameter: A, parameter2: B) => [A, B]\n```
-//                documentation 
 //                              ^ definition syntax 1.0.0 src/`type-parameter.ts`/typeParameter().[A]
 //                              documentation ```ts\nA\n```
-//                              documentation 
 //                                 ^ definition syntax 1.0.0 src/`type-parameter.ts`/typeParameter().[B]
 //                                 documentation ```ts\nB\n```
-//                                 documentation 
 //                                    ^^^^^^^^^ definition syntax 1.0.0 src/`type-parameter.ts`/typeParameter().(parameter)
 //                                    documentation ```ts\nA\n```
-//                                    documentation 
 //                                               ^ reference syntax 1.0.0 src/`type-parameter.ts`/typeParameter().[A]
 //                                                  ^^^^^^^^^^ definition syntax 1.0.0 src/`type-parameter.ts`/typeParameter().(parameter2)
 //                                                  documentation ```ts\nB\n```
-//                                                  documentation 
 //                                                              ^ reference syntax 1.0.0 src/`type-parameter.ts`/typeParameter().[B]
 //                                                                   ^ reference syntax 1.0.0 src/`type-parameter.ts`/typeParameter().[A]
 //                                                                      ^ reference syntax 1.0.0 src/`type-parameter.ts`/typeParameter().[B]

--- a/src/FileIndexer.ts
+++ b/src/FileIndexer.ts
@@ -141,16 +141,17 @@ export class FileIndexer {
     sym: ts.Symbol,
     symbol: LsifSymbol
   ): void {
+    const documentation = [
+      '```ts\n' +
+        this.checker.typeToString(this.checker.getTypeAtLocation(node)) +
+        '\n```',
+    ]
+    const docstring = sym.getDocumentationComment(this.checker)
+    if (docstring.length > 0) {
+      documentation.push(ts.displayPartsToString(docstring))
+    }
     this.document.symbols.push(
-      new lsiftyped.SymbolInformation({
-        symbol: symbol.value,
-        documentation: [
-          '```ts\n' +
-            this.checker.typeToString(this.checker.getTypeAtLocation(node)) +
-            '\n```',
-          ts.displayPartsToString(sym.getDocumentationComment(this.checker)),
-        ],
-      })
+      new lsiftyped.SymbolInformation({ symbol: symbol.value, documentation })
     )
   }
 

--- a/src/SnapshotTesting.ts
+++ b/src/SnapshotTesting.ts
@@ -1,0 +1,88 @@
+import { Input } from './Input'
+import * as lsif from './lsif'
+import { Range } from './Range'
+
+const lsiftyped = lsif.lib.codeintel.lsiftyped
+
+export function formatSnapshot(
+  input: Input,
+  document: lsif.lib.codeintel.lsiftyped.Document
+): string {
+  const out: string[] = []
+  document.occurrences.sort(occurrencesByLine)
+  const symbolTable = new Map<
+    string,
+    lsif.lib.codeintel.lsiftyped.SymbolInformation
+  >()
+  for (const symbolInfo of document.symbols) {
+    symbolTable.set(symbolInfo.symbol, symbolInfo)
+  }
+  let occurrenceIndex = 0
+  for (const [lineNumber, line] of input.lines.entries()) {
+    out.push('  ')
+    out.push(line)
+    out.push('\n')
+    while (
+      occurrenceIndex < document.occurrences.length &&
+      document.occurrences[occurrenceIndex].range[0] === lineNumber
+    ) {
+      const occurrence = document.occurrences[occurrenceIndex]
+      occurrenceIndex++
+      if (occurrence.range.length > 3) {
+        // Skip multiline occurrences for now.
+        continue
+      }
+      const range = Range.fromLsif(occurrence.range)
+      out.push('//')
+      out.push(' '.repeat(range.start.character))
+      const length = range.end.character - range.start.character
+      if (length < 0) {
+        throw new Error(input.format(range, 'negative length occurrence!'))
+      }
+      out.push('^'.repeat(length))
+      out.push(' ')
+      const isDefinition =
+        (occurrence.symbol_roles & lsiftyped.SymbolRole.Definition) > 0
+      out.push(isDefinition ? 'definition' : 'reference')
+      out.push(' ')
+      const symbol = occurrence.symbol.startsWith('lsif-typescript npm ')
+        ? occurrence.symbol.slice('lsif-typescript npm '.length)
+        : occurrence.symbol
+      out.push(symbol)
+      const info = symbolTable.get(occurrence.symbol)
+      if (!isDefinition || !info) {
+        out.push('\n')
+        continue
+      }
+      const prefix = '\n//' + ' '.repeat(range.start.character)
+      for (const documentation of info.documentation) {
+        out.push(prefix)
+        out.push('documentation ')
+        out.push(documentation.replace(/\n/g, '\\n'))
+      }
+      info.relationships.sort((a, b) => a.symbol.localeCompare(b.symbol))
+      for (const relationship of info.relationships) {
+        out.push(prefix)
+        out.push('relationship ')
+        if (relationship.is_implementation) {
+          out.push(' implementation')
+        }
+        if (relationship.is_reference) {
+          out.push(' reference')
+        }
+        if (relationship.is_type_definition) {
+          out.push(' type_definition')
+        }
+      }
+      out.push('\n')
+    }
+  }
+  return out.join('')
+}
+
+function occurrencesByLine(
+  a: lsif.lib.codeintel.lsiftyped.Occurrence,
+  b: lsif.lib.codeintel.lsiftyped.Occurrence
+): number {
+  return Range.fromLsif(a.range).compare(Range.fromLsif(b.range))
+}

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -9,9 +9,7 @@ import { test } from 'uvu'
 import { Input } from './Input'
 import * as lsif from './lsif'
 import { indexCommand } from './main'
-import { Range } from './Range'
-
-const lsiftyped = lsif.lib.codeintel.lsiftyped
+import { formatSnapshot } from './SnapshotTesting'
 
 function isUpdateSnapshot(): boolean {
   return process.argv.includes('--update-snapshots')
@@ -101,57 +99,6 @@ for (const snapshotDirectory of snapshotDirectories) {
       }
     }
   })
-}
-
-function formatSnapshot(
-  input: Input,
-  document: lsif.lib.codeintel.lsiftyped.Document
-): string {
-  const out: string[] = []
-  document.occurrences.sort(occurrencesByLine)
-  let occurrenceIndex = 0
-  for (const [lineNumber, line] of input.lines.entries()) {
-    out.push('  ')
-    out.push(line)
-    out.push('\n')
-    while (
-      occurrenceIndex < document.occurrences.length &&
-      document.occurrences[occurrenceIndex].range[0] === lineNumber
-    ) {
-      const occurrence = document.occurrences[occurrenceIndex]
-      occurrenceIndex++
-      if (occurrence.range.length > 3) {
-        // Skip multiline occurrences for now.
-        continue
-      }
-      const range = Range.fromLsif(occurrence.range)
-      out.push('//')
-      out.push(' '.repeat(range.start.character))
-      const length = range.end.character - range.start.character
-      if (length < 0) {
-        throw new Error(input.format(range, 'negative length occurrence!'))
-      }
-      out.push('^'.repeat(length))
-      out.push(' ')
-      const isDefinition =
-        (occurrence.symbol_roles & lsiftyped.SymbolRole.Definition) > 0
-      out.push(isDefinition ? 'definition' : 'reference')
-      out.push(' ')
-      const symbol = occurrence.symbol.startsWith('lsif-typescript npm ')
-        ? occurrence.symbol.slice('lsif-typescript npm '.length)
-        : occurrence.symbol
-      out.push(symbol)
-      out.push('\n')
-    }
-  }
-  return out.join('')
-}
-
-function occurrencesByLine(
-  a: lsif.lib.codeintel.lsiftyped.Occurrence,
-  b: lsif.lib.codeintel.lsiftyped.Occurrence
-): number {
-  return Range.fromLsif(a.range).compare(Range.fromLsif(b.range))
 }
 
 test.run()


### PR DESCRIPTION
Previously, the snapshot tests only displayed occurrence roles and symbols. Now, the additionally display the `SymbolInformation.{documentation,relationships}` fields for definition occurrences.

### Test plan
See updated snapshot tests.
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
