### PR TITLE
Add GitHub Action to index lsif-typescript's code.

### DIFF
--- a/.github/workflows/lsif-typescript.yml
+++ b/.github/workflows/lsif-typescript.yml
@@ -16,10 +16,8 @@ jobs:
         run: |
           curl -L https://sourcegraph.com/.api/src-cli/src_linux_amd64 -o /usr/local/bin/src
           chmod +x /usr/local/bin/src
-      - name: Install lsif-typescript
-        run: yarn run build
       - name: Run lsif-typescript
-        run: node ./dist/src/main.js index
+        run: ./node_modules/.bin/ts-node src/main.ts index --no-progress-bar
       - name: Upload index
         run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress
         env:

--- a/.github/workflows/lsif-typescript.yml
+++ b/.github/workflows/lsif-typescript.yml
@@ -1,0 +1,26 @@
+name: upload-index
+on:
+  push:
+    paths:
+      - '**.ts'
+
+jobs:
+  upload-index:
+    if: github.repository == 'sourcegraph/lsif-typescript'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install npm dependencies
+        run: yarn --ignore-engines --ignore-scripts
+      - name: Install src-cli
+        run: |
+          curl -L https://sourcegraph.com/.api/src-cli/src_linux_amd64 -o /usr/local/bin/src
+          chmod +x /usr/local/bin/src
+      - name: Install lsif-typescript
+        run: yarn run build
+      - name: Run lsif-typescript
+        run: node ./dist/src/main.js index
+      - name: Upload index
+        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress
+        env:
+          SRC_ENDPOINT: https://sourcegraph.com/

--- a/Development.md
+++ b/Development.md
@@ -23,9 +23,8 @@ Generate snapshots and update.
 ## Snapshotting arbitrary projects
 
 ```sh
-npm run build # build lsif-typescript
 cd /path/to/dir
-node /path/to/lsif-typescript/dist/src/main.js index # add --yarn-workspaces if applicable
+DIR=/path/to/lsif-typescript "$DIR/node_modules/.bin/ts-node" "$DIR/src/main.ts" index # add --yarn-workspaces if applicable
 lsif-typed dump.lsif-typed > dump.lsif # from github.com/sourcegraph/sourcegraph/lib/codeintel/tools/lsif-typed
 lsif-java snapshot-lsif # from github.com/sourcegraph/lsif-java
 ```


### PR DESCRIPTION
Based on the workflow in sourcegraph/sourcegraph repo.

### Test plan

n/a