### PR TITLE
Update Node version used by Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM sourcegraph/src-cli:3.38.0@sha256:5d26b9225268c5e49f24ceedf7bae303c9e34640faae3f254f4c8f312d77d4cb AS src-cli
 
-FROM node:14.5-alpine3.10@sha256:7fb1e608dc4081c25930db83cb4a5df884b6a3f6e4e9f5fa2df08f22778fcfad
+# Keep in sync with Dockerfile.autoindex
+FROM node:17.7.1-alpine3.14@sha256:cbb62fa2f740959b173b180e4806a5e479fbbd7a20072c3d6b4283bf2b9951d1
 
 ARG TAG
 

--- a/Dockerfile.autoindex
+++ b/Dockerfile.autoindex
@@ -1,5 +1,6 @@
 FROM sourcegraph/src-cli:3.38.0@sha256:5d26b9225268c5e49f24ceedf7bae303c9e34640faae3f254f4c8f312d77d4cb AS src-cli
 
+# Keep in sync with default Dockerfile
 FROM node:17.7.1-alpine3.14@sha256:cbb62fa2f740959b173b180e4806a5e479fbbd7a20072c3d6b4283bf2b9951d1
 
 ENV NODE_OPTIONS=--max-old-space-size=4096


### PR DESCRIPTION
The existing image causes failures because the `fs.close()` method
is used with a single filedescriptor argument. However, the callback
argument is mandatory before v15.9.0 and v14.17.0.
See https://nodejs.org/api/fs.html#fsclosefd-callback

### Test plan

We're already using this node version for auto-indexing.