### PR TITLE
Use test matrix for Node v14, v16 and v18.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x] # NOTE: Keep in sync with README.
         # See Node.js release schedule: https://nodejs.org/en/about/releases/
         # - v14 EOL: Apr 30 2023
         # - v16 EOL: Apr 30 2024

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,19 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [14.x, 16.x, 18.x]
+        # See Node.js release schedule: https://nodejs.org/en/about/releases/
+        # - v14 EOL: Apr 30 2023
+        # - v16 EOL: Apr 30 2024
+        # - v18 EOL: Apr 30 2025
     steps:
       - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
       - run: yarn install
       - run: npm run test
   lint:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ LSIF indexer for TypeScript and JavaScript.
 npm install -g @sourcegraph/lsif-typescript
 ```
 
+Currently, Node v14, Node v16 and Node v18 are supported. <!-- Source of truth: .github/workflows/ci.yml -->
+
 ### Indexing a TypeScript project
 
 Navigate to the project root, containing `tsconfig.json`.


### PR DESCRIPTION
Fixes issue #125.

### Test plan

This PR should run tests.