### PR TITLE
Emit index.scip instead of dump.lsif-typed

### DIFF
--- a/.github/workflows/sourcegraph.yml
+++ b/.github/workflows/sourcegraph.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Convert LSIF Typed into LSIF Graph
         run: |
           curl -Lo lsif-typed https://github.com/sourcegraph/lsif-typescript/releases/download/v0.1.8/lsif-typed && chmod +x lsif-typed
-          ./lsif-typed dump.lsif-typed > dump.lsif
+          ./lsif-typed index.scip > dump.lsif
       - name: Upload LSIF data
         uses: sourcegraph/lsif-upload-action@master
         with:

--- a/.github/workflows/sourcegraph.yml
+++ b/.github/workflows/sourcegraph.yml
@@ -12,11 +12,11 @@ jobs:
       - run: yarn install
       - run: yarn global add ts-node
       - run: ts-node src/main.ts index
-      - name: Convert LSIF Typed into LSIF Graph
+      - run: cp index.scip dump.lsif-typed
+      - name: Install src-cli
         run: |
-          curl -Lo lsif-typed https://github.com/sourcegraph/lsif-typescript/releases/download/v0.1.8/lsif-typed && chmod +x lsif-typed
-          ./lsif-typed index.scip > dump.lsif
-      - name: Upload LSIF data
-        uses: sourcegraph/lsif-upload-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          curl -L https://sourcegraph.com/.api/src-cli/src_linux_amd64 -o src-cli
+          chmod +x ./src-cli
+      - run: ./src-cli lsif upload -file=dump.lsif-typed "-commit=${GITHUB_SHA}" "-github-token=${GITHUB_TOKEN}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Development.md
+++ b/Development.md
@@ -25,7 +25,7 @@ Generate snapshots and update.
 ```sh
 cd /path/to/dir
 DIR=/path/to/scip-typescript "$DIR/node_modules/.bin/ts-node" "$DIR/src/main.ts" index # add --yarn-workspaces if applicable
-lsif-typed dump.lsif-typed > dump.lsif # from github.com/sourcegraph/sourcegraph/lib/codeintel/tools/lsif-typed
+lsif-typed index.scip > dump.lsif # from github.com/sourcegraph/sourcegraph/lib/codeintel/tools/lsif-typed
 lsif-java snapshot-lsif # from github.com/sourcegraph/lsif-java
 ```
 

--- a/Dockerfile.autoindex
+++ b/Dockerfile.autoindex
@@ -1,4 +1,4 @@
-FROM sourcegraph/src-cli:3.39.1@sha256:418225d34348a80613a6a20c6c0203d95a74a33adc6fb6e6f45af84ff60beff0 AS src-cli
+FROM sourcegraph/src-cli:3.40.0
 
 # Keep in sync with default Dockerfile
 FROM node:17.7.1-alpine3.14@sha256:cbb62fa2f740959b173b180e4806a5e479fbbd7a20072c3d6b4283bf2b9951d1
@@ -9,9 +9,7 @@ RUN apk add --no-cache git bash curl ca-certificates python3 make libstdc++ libg
 
 COPY --from=src-cli /usr/bin/src /usr/bin
 
-RUN curl -Lo /usr/bin/lsif-typed https://github.com/sourcegraph/lsif-typescript/releases/download/v0.1.13/lsif-typed && chmod +x /usr/bin/lsif-typed
-
-RUN echo 'scip-typescript "$@" --no-progress-bar && lsif-typed dump.lsif-typed > dump.lsif' > /usr/bin/scip-typescript-autoindex && chmod +x /usr/bin/scip-typescript-autoindex
+RUN echo 'scip-typescript "$@" --no-progress-bar' > /usr/bin/scip-typescript-autoindex && chmod +x /usr/bin/scip-typescript-autoindex
 
 RUN npm install --global n@latest @sourcegraph/scip-typescript@latest
 

--- a/src/CommandLineOptions.test.ts
+++ b/src/CommandLineOptions.test.ts
@@ -27,7 +27,7 @@ checkIndexParser([], {
   progressBar: true,
   cwd: process.cwd(),
   inferTsconfig: false,
-  output: 'dump.lsif-typed',
+  output: 'index.scip',
   yarnWorkspaces: false,
 })
 

--- a/src/CommandLineOptions.ts
+++ b/src/CommandLineOptions.ts
@@ -40,7 +40,7 @@ export function mainCommand(
       "whether to infer the tsconfig.json file, if it's missing",
       false
     )
-    .option('--output <path>', 'path to the output file', 'dump.lsif-typed')
+    .option('--output <path>', 'path to the output file', 'index.scip')
     .option('--no-progress-bar', 'whether to disable the progress bar')
     .argument('[projects...]')
     .action((parsedProjects, parsedOptions) => {

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -45,7 +45,7 @@ for (const snapshotDirectory of snapshotDirectories) {
     ) as PackageJson
     const tsconfigJsonPath = path.join(inputRoot, 'tsconfig.json')
     const inferTsconfig = !fs.existsSync(tsconfigJsonPath)
-    const output = path.join(inputRoot, 'dump.lsif-typed')
+    const output = path.join(inputRoot, 'index.scip')
     indexCommand([], {
       cwd: inputRoot,
       inferTsconfig,
@@ -58,10 +58,10 @@ for (const snapshotDirectory of snapshotDirectories) {
       fs.rmSync(tsconfigJsonPath)
     }
     const index = lsif.lib.codeintel.lsiftyped.Index.deserializeBinary(
-      fs.readFileSync(path.join(inputRoot, 'dump.lsif-typed'))
+      fs.readFileSync(path.join(inputRoot, 'index.scip'))
     )
     fs.mkdirSync(outputRoot, { recursive: true })
-    fs.renameSync(output, path.join(outputRoot, 'dump.lsif-typed'))
+    fs.renameSync(output, path.join(outputRoot, 'index.scip'))
     if (index.documents.length === 0) {
       throw new Error('empty LSIF index')
     }


### PR DESCRIPTION
### Test plan

Manually run `scip-typescript index` and see it produce an `index.scip` file instead of `dump.lsif-typed`
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
