### PR TITLE
Implement "Find implementations" for classes, properties, and methods

### DIFF
--- a/snapshots/input/syntax/src/inheritance.ts
+++ b/snapshots/input/syntax/src/inheritance.ts
@@ -1,3 +1,5 @@
+import { Overloader } from './overload'
+
 export interface Superinterface {
   property: string
   interfaceMethod(): string
@@ -9,12 +11,18 @@ export abstract class Superclass {
   public abstract overrideMethod(): string
 }
 export abstract class IntermediateSuperclass extends Superclass {
+  public override overrideMethod(): string {
+    return 'this will get overridden'
+  }
   public abstract intermediateOverrideMethod(): string
 }
 export class Subclass
   extends IntermediateSuperclass
-  implements IntermediateSuperinterface
+  implements IntermediateSuperinterface, Overloader
 {
+  public onLiteral(param: any): void {
+    throw new Error('Method not implemented.' + param)
+  }
   property = 'property'
   public overrideMethod(): string {
     throw new Error('Method not implemented.')

--- a/snapshots/input/syntax/src/inheritance.ts
+++ b/snapshots/input/syntax/src/inheritance.ts
@@ -2,16 +2,30 @@ export interface Superinterface {
   property: string
   interfaceMethod(): string
 }
+export interface IntermediateSuperinterface extends Superinterface {
+  intermediateInterfaceMethod(): string
+}
 export abstract class Superclass {
   public abstract overrideMethod(): string
 }
-export abstract class IntermediateSuperclass extends Superclass {}
-export class Subclass extends IntermediateSuperclass implements Superinterface {
+export abstract class IntermediateSuperclass extends Superclass {
+  public abstract intermediateOverrideMethod(): string
+}
+export class Subclass
+  extends IntermediateSuperclass
+  implements IntermediateSuperinterface
+{
   property = 'property'
   public overrideMethod(): string {
     throw new Error('Method not implemented.')
   }
+  public intermediateOverrideMethod(): string {
+    throw new Error('Method not implemented.')
+  }
   public interfaceMethod(): string {
+    throw new Error('Method not implemented.')
+  }
+  public intermediateInterfaceMethod(): string {
     throw new Error('Method not implemented.')
   }
 }

--- a/snapshots/input/syntax/src/overload.d.ts
+++ b/snapshots/input/syntax/src/overload.d.ts
@@ -1,0 +1,4 @@
+export interface Overloader {
+  onLiteral(param: 'a'): void
+  onLiteral(param: 'b'): void
+}

--- a/snapshots/input/syntax/tsconfig.json
+++ b/snapshots/input/syntax/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "outDir": "dist",
     "target": "ES5"
   }
 }

--- a/snapshots/output/syntax/src/inheritance.ts
+++ b/snapshots/output/syntax/src/inheritance.ts
@@ -1,3 +1,6 @@
+  import { Overloader } from './overload'
+//         ^^^^^^^^^^ reference syntax 1.0.0 src/`overload.d.ts`/Overloader#
+  
   export interface Superinterface {
 //                 ^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/Superinterface#
 //                 documentation ```ts\ninterface Superinterface\n```
@@ -28,6 +31,12 @@
 //                      documentation ```ts\nclass IntermediateSuperclass\n```
 //                      relationship implementation scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superclass#
 //                                                     ^^^^^^^^^^ reference syntax 1.0.0 src/`inheritance.ts`/Superclass#
+    public override overrideMethod(): string {
+//                  ^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperclass#overrideMethod().
+//                  documentation ```ts\n(method) overrideMethod(): string\n```
+//                  relationship implementation reference scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superclass#overrideMethod().
+      return 'this will get overridden'
+    }
     public abstract intermediateOverrideMethod(): string
 //                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperclass#intermediateOverrideMethod().
 //                  documentation ```ts\n(method) intermediateOverrideMethod(): string\n```
@@ -39,19 +48,33 @@
 //             relationship implementation scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperinterface#
 //             relationship implementation scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superclass#
 //             relationship implementation scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superinterface#
+//             relationship implementation scip-typescript npm syntax 1.0.0 src/`overload.d.ts`/Overloader#
     extends IntermediateSuperclass
 //          ^^^^^^^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperclass#
-    implements IntermediateSuperinterface
+    implements IntermediateSuperinterface, Overloader
 //             ^^^^^^^^^^^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperinterface#
+//                                         ^^^^^^^^^^ reference syntax 1.0.0 src/`overload.d.ts`/Overloader#
   {
+    public onLiteral(param: any): void {
+//         ^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/Subclass#onLiteral().
+//         documentation ```ts\n(method) onLiteral(param: any): void\n```
+//         relationship implementation reference scip-typescript npm syntax 1.0.0 src/`overload.d.ts`/Overloader#onLiteral().
+//                   ^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/Subclass#onLiteral().(param)
+//                   documentation ```ts\n(parameter) param: any\n```
+      throw new Error('Method not implemented.' + param)
+//              ^^^^^ reference typescript 4.6.2 lib/`lib.es5.d.ts`/Error#
+//              ^^^^^ reference typescript 4.6.2 lib/`lib.es5.d.ts`/Error.
+//                                                ^^^^^ reference syntax 1.0.0 src/`inheritance.ts`/Subclass#onLiteral().(param)
+    }
     property = 'property'
 //  ^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/Subclass#property.
 //  documentation ```ts\n(property) property: string\n```
-//  relationship implementation scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superinterface#property.
+//  relationship implementation reference scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superinterface#property.
     public overrideMethod(): string {
 //         ^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/Subclass#overrideMethod().
 //         documentation ```ts\n(method) overrideMethod(): string\n```
-//         relationship implementation scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superclass#overrideMethod().
+//         relationship implementation reference scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperclass#overrideMethod().
+//         relationship implementation reference scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superclass#overrideMethod().
       throw new Error('Method not implemented.')
 //              ^^^^^ reference typescript 4.6.2 lib/`lib.es5.d.ts`/Error#
 //              ^^^^^ reference typescript 4.6.2 lib/`lib.es5.d.ts`/Error.
@@ -59,7 +82,7 @@
     public intermediateOverrideMethod(): string {
 //         ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/Subclass#intermediateOverrideMethod().
 //         documentation ```ts\n(method) intermediateOverrideMethod(): string\n```
-//         relationship implementation scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperclass#intermediateOverrideMethod().
+//         relationship implementation reference scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperclass#intermediateOverrideMethod().
       throw new Error('Method not implemented.')
 //              ^^^^^ reference typescript 4.6.2 lib/`lib.es5.d.ts`/Error#
 //              ^^^^^ reference typescript 4.6.2 lib/`lib.es5.d.ts`/Error.
@@ -67,7 +90,7 @@
     public interfaceMethod(): string {
 //         ^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/Subclass#interfaceMethod().
 //         documentation ```ts\n(method) interfaceMethod(): string\n```
-//         relationship implementation scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superinterface#interfaceMethod().
+//         relationship implementation reference scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superinterface#interfaceMethod().
       throw new Error('Method not implemented.')
 //              ^^^^^ reference typescript 4.6.2 lib/`lib.es5.d.ts`/Error#
 //              ^^^^^ reference typescript 4.6.2 lib/`lib.es5.d.ts`/Error.
@@ -75,7 +98,7 @@
     public intermediateInterfaceMethod(): string {
 //         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/Subclass#intermediateInterfaceMethod().
 //         documentation ```ts\n(method) intermediateInterfaceMethod(): string\n```
-//         relationship implementation scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperinterface#intermediateInterfaceMethod().
+//         relationship implementation reference scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperinterface#intermediateInterfaceMethod().
       throw new Error('Method not implemented.')
 //              ^^^^^ reference typescript 4.6.2 lib/`lib.es5.d.ts`/Error#
 //              ^^^^^ reference typescript 4.6.2 lib/`lib.es5.d.ts`/Error.
@@ -88,11 +111,11 @@
     property: 'property',
 //  ^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/property0:
 //  documentation ```ts\n(property) property: string\n```
-//  relationship implementation scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superinterface#property.
+//  relationship implementation reference scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superinterface#property.
     interfaceMethod: (): string => {
 //  ^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/interfaceMethod0:
 //  documentation ```ts\n(property) interfaceMethod: () => string\n```
-//  relationship implementation scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superinterface#interfaceMethod().
+//  relationship implementation reference scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superinterface#interfaceMethod().
       throw new Error('Function not implemented.')
 //              ^^^^^ reference typescript 4.6.2 lib/`lib.es5.d.ts`/Error#
 //              ^^^^^ reference typescript 4.6.2 lib/`lib.es5.d.ts`/Error.
@@ -112,11 +135,11 @@
       interfaceMethod: (): string => 'inferred',
 //    ^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/interfaceMethod1:
 //    documentation ```ts\n(property) interfaceMethod: () => string\n```
-//    relationship implementation scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superinterface#interfaceMethod().
+//    relationship implementation reference scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superinterface#interfaceMethod().
       property: 'inferred',
 //    ^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/property1:
 //    documentation ```ts\n(property) property: string\n```
-//    relationship implementation scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superinterface#property.
+//    relationship implementation reference scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superinterface#property.
     })
   }
   

--- a/snapshots/output/syntax/src/inheritance.ts
+++ b/snapshots/output/syntax/src/inheritance.ts
@@ -8,6 +8,14 @@
 //  ^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/Superinterface#interfaceMethod().
 //  documentation ```ts\n(method) interfaceMethod() => string\n```
   }
+  export interface IntermediateSuperinterface extends Superinterface {
+//                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperinterface#
+//                 documentation ```ts\ninterface IntermediateSuperinterface\n```
+//                                                    ^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`inheritance.ts`/Superinterface#
+    intermediateInterfaceMethod(): string
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperinterface#intermediateInterfaceMethod().
+//  documentation ```ts\n(method) intermediateInterfaceMethod() => string\n```
+  }
   export abstract class Superclass {
 //                      ^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/Superclass#
 //                      documentation ```ts\nclass Superclass\n```
@@ -15,19 +23,27 @@
 //                  ^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/Superclass#overrideMethod().
 //                  documentation ```ts\n(method) overrideMethod(): string\n```
   }
-  export abstract class IntermediateSuperclass extends Superclass {}
+  export abstract class IntermediateSuperclass extends Superclass {
 //                      ^^^^^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperclass#
 //                      documentation ```ts\nclass IntermediateSuperclass\n```
 //                      relationship implementation scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superclass#
 //                                                     ^^^^^^^^^^ reference syntax 1.0.0 src/`inheritance.ts`/Superclass#
-  export class Subclass extends IntermediateSuperclass implements Superinterface {
+    public abstract intermediateOverrideMethod(): string
+//                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperclass#intermediateOverrideMethod().
+//                  documentation ```ts\n(method) intermediateOverrideMethod(): string\n```
+  }
+  export class Subclass
 //             ^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/Subclass#
 //             documentation ```ts\nclass Subclass\n```
 //             relationship implementation scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperclass#
+//             relationship implementation scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperinterface#
 //             relationship implementation scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superclass#
 //             relationship implementation scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superinterface#
-//                              ^^^^^^^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperclass#
-//                                                                ^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`inheritance.ts`/Superinterface#
+    extends IntermediateSuperclass
+//          ^^^^^^^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperclass#
+    implements IntermediateSuperinterface
+//             ^^^^^^^^^^^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperinterface#
+  {
     property = 'property'
 //  ^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/Subclass#property.
 //  documentation ```ts\n(property) property: string\n```
@@ -40,10 +56,26 @@
 //              ^^^^^ reference typescript 4.6.2 lib/`lib.es5.d.ts`/Error#
 //              ^^^^^ reference typescript 4.6.2 lib/`lib.es5.d.ts`/Error.
     }
+    public intermediateOverrideMethod(): string {
+//         ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/Subclass#intermediateOverrideMethod().
+//         documentation ```ts\n(method) intermediateOverrideMethod(): string\n```
+//         relationship implementation scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperclass#intermediateOverrideMethod().
+      throw new Error('Method not implemented.')
+//              ^^^^^ reference typescript 4.6.2 lib/`lib.es5.d.ts`/Error#
+//              ^^^^^ reference typescript 4.6.2 lib/`lib.es5.d.ts`/Error.
+    }
     public interfaceMethod(): string {
 //         ^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/Subclass#interfaceMethod().
 //         documentation ```ts\n(method) interfaceMethod(): string\n```
 //         relationship implementation scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superinterface#interfaceMethod().
+      throw new Error('Method not implemented.')
+//              ^^^^^ reference typescript 4.6.2 lib/`lib.es5.d.ts`/Error#
+//              ^^^^^ reference typescript 4.6.2 lib/`lib.es5.d.ts`/Error.
+    }
+    public intermediateInterfaceMethod(): string {
+//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/Subclass#intermediateInterfaceMethod().
+//         documentation ```ts\n(method) intermediateInterfaceMethod(): string\n```
+//         relationship implementation scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperinterface#intermediateInterfaceMethod().
       throw new Error('Method not implemented.')
 //              ^^^^^ reference typescript 4.6.2 lib/`lib.es5.d.ts`/Error#
 //              ^^^^^ reference typescript 4.6.2 lib/`lib.es5.d.ts`/Error.

--- a/snapshots/output/syntax/src/inheritance.ts
+++ b/snapshots/output/syntax/src/inheritance.ts
@@ -18,18 +18,24 @@
   export abstract class IntermediateSuperclass extends Superclass {}
 //                      ^^^^^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperclass#
 //                      documentation ```ts\nclass IntermediateSuperclass\n```
+//                      relationship implementation scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superclass#
 //                                                     ^^^^^^^^^^ reference syntax 1.0.0 src/`inheritance.ts`/Superclass#
   export class Subclass extends IntermediateSuperclass implements Superinterface {
 //             ^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/Subclass#
 //             documentation ```ts\nclass Subclass\n```
+//             relationship implementation scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperclass#
+//             relationship implementation scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superclass#
+//             relationship implementation scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superinterface#
 //                              ^^^^^^^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperclass#
 //                                                                ^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`inheritance.ts`/Superinterface#
     property = 'property'
 //  ^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/Subclass#property.
 //  documentation ```ts\n(property) property: string\n```
+//  relationship implementation scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superinterface#property.
     public overrideMethod(): string {
 //         ^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/Subclass#overrideMethod().
 //         documentation ```ts\n(method) overrideMethod(): string\n```
+//         relationship implementation scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superclass#overrideMethod().
       throw new Error('Method not implemented.')
 //              ^^^^^ reference typescript 4.6.2 lib/`lib.es5.d.ts`/Error#
 //              ^^^^^ reference typescript 4.6.2 lib/`lib.es5.d.ts`/Error.
@@ -37,6 +43,7 @@
     public interfaceMethod(): string {
 //         ^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/Subclass#interfaceMethod().
 //         documentation ```ts\n(method) interfaceMethod(): string\n```
+//         relationship implementation scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superinterface#interfaceMethod().
       throw new Error('Method not implemented.')
 //              ^^^^^ reference typescript 4.6.2 lib/`lib.es5.d.ts`/Error#
 //              ^^^^^ reference typescript 4.6.2 lib/`lib.es5.d.ts`/Error.
@@ -49,9 +56,11 @@
     property: 'property',
 //  ^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/property0:
 //  documentation ```ts\n(property) property: string\n```
+//  relationship implementation scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superinterface#property.
     interfaceMethod: (): string => {
 //  ^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/interfaceMethod0:
 //  documentation ```ts\n(property) interfaceMethod: () => string\n```
+//  relationship implementation scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superinterface#interfaceMethod().
       throw new Error('Function not implemented.')
 //              ^^^^^ reference typescript 4.6.2 lib/`lib.es5.d.ts`/Error#
 //              ^^^^^ reference typescript 4.6.2 lib/`lib.es5.d.ts`/Error.
@@ -71,9 +80,11 @@
       interfaceMethod: (): string => 'inferred',
 //    ^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/interfaceMethod1:
 //    documentation ```ts\n(property) interfaceMethod: () => string\n```
+//    relationship implementation scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superinterface#interfaceMethod().
       property: 'inferred',
 //    ^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/property1:
 //    documentation ```ts\n(property) property: string\n```
+//    relationship implementation scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superinterface#property.
     })
   }
   

--- a/snapshots/output/syntax/src/overload.d.ts
+++ b/snapshots/output/syntax/src/overload.d.ts
@@ -1,0 +1,15 @@
+  export interface Overloader {
+//                 ^^^^^^^^^^ definition syntax 1.0.0 src/`overload.d.ts`/Overloader#
+//                 documentation ```ts\ninterface Overloader\n```
+    onLiteral(param: 'a'): void
+//  ^^^^^^^^^ definition syntax 1.0.0 src/`overload.d.ts`/Overloader#onLiteral().
+//  documentation ```ts\n(method) onLiteral{ (param: "a"): void; (param: "b"): void; }\n```
+//            ^^^^^ definition syntax 1.0.0 src/`overload.d.ts`/Overloader#onLiteral().(param)
+//            documentation ```ts\n(parameter) param: "b"\n```
+    onLiteral(param: 'b'): void
+//  ^^^^^^^^^ definition syntax 1.0.0 src/`overload.d.ts`/Overloader#onLiteral().
+//  documentation ```ts\n(method) onLiteral{ (param: "a"): void; (param: "b"): void; }\n```
+//            ^^^^^ definition syntax 1.0.0 src/`overload.d.ts`/Overloader#onLiteral().(param)
+//            documentation ```ts\n(parameter) param: "b"\n```
+  }
+  

--- a/src/FileIndexer.ts
+++ b/src/FileIndexer.ts
@@ -165,6 +165,7 @@ export class FileIndexer {
     declarationSymbol: LsifSymbol
   ): Relationship[] {
     const relationships: Relationship[] = []
+    const isAddedSymbol = new Set<string>()
     const pushImplementation = (
       node: ts.NamedDeclaration,
       isReferences: boolean
@@ -176,6 +177,12 @@ export class FileIndexer {
       if (symbol.value === declarationSymbol.value) {
         return
       }
+      if (isAddedSymbol.has(symbol.value)) {
+        // Avoid duplicate relationships. This can happen for overloaded methods
+        // that have different ts.Symbol but the same SCIP symbol.
+        return
+      }
+      isAddedSymbol.add(symbol.value)
       relationships.push(
         new lsiftyped.Relationship({
           symbol: symbol.value,

--- a/src/FileIndexer.ts
+++ b/src/FileIndexer.ts
@@ -155,12 +155,12 @@ export class FileIndexer {
       new lsiftyped.SymbolInformation({
         symbol: symbol.value,
         documentation,
-        relationships: this.scipRelationships(declaration, symbol),
+        relationships: this.relationships(declaration, symbol),
       })
     )
   }
 
-  private scipRelationships(
+  private relationships(
     declaration: ts.Node,
     declarationSymbol: LsifSymbol
   ): Relationship[] {
@@ -189,9 +189,10 @@ export class FileIndexer {
       ts.isPropertyAssignment(declaration) ||
       ts.isPropertyDeclaration(declaration)
     ) {
+      const declarationName = declaration.name.getText()
       this.forEachParent(declaration.parent, parent => {
         for (const member of parent.members) {
-          if (declaration.name.getText() === member.name?.getText()) {
+          if (declarationName === member.name?.getText()) {
             pushImplementation(this.lsifSymbol(member))
           }
         }
@@ -471,7 +472,10 @@ export class FileIndexer {
         for (const symbolDeclaration of tpe.symbol?.declarations || []) {
           loop(symbolDeclaration)
         }
-      } else if (ts.isClassLike(declaration)) {
+      } else if (
+        ts.isClassLike(declaration) ||
+        ts.isInterfaceDeclaration(declaration)
+      ) {
         for (const heritageClause of declaration?.heritageClauses || []) {
           for (const tpe of heritageClause.types) {
             const parentSymbol = this.getTSSymbolAtLocation(tpe.expression)

--- a/src/SnapshotTesting.ts
+++ b/src/SnapshotTesting.ts
@@ -63,7 +63,7 @@ export function formatSnapshot(
       info.relationships.sort((a, b) => a.symbol.localeCompare(b.symbol))
       for (const relationship of info.relationships) {
         out.push(prefix)
-        out.push('relationship ')
+        out.push('relationship')
         if (relationship.is_implementation) {
           out.push(' implementation')
         }
@@ -73,6 +73,7 @@ export function formatSnapshot(
         if (relationship.is_type_definition) {
           out.push(' type_definition')
         }
+        out.push(' ' + relationship.symbol)
       }
       out.push('\n')
     }


### PR DESCRIPTION
Previously, scip-typescript did not support "Find implementations". Now,
it supports this functionality for a few commonly used patterns where
inheritance is used. This PR does not implement all locations where
inheritance is used, but we can add that functionality later.

### Test plan

See the newly added snapshot tests. I also manually ran the indexer against sourcegraph/sourcegraph to verify that these changes don't introduce new unexpected crashes when running against a larger codebase. This change adds maybe ~10% overhead based on very rough observations but I feel like we can optimize some parts if necessary (for example, cache the logic that walks through parents).
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
