### PR TITLE
Print message when npm/yarn install fails during auto-indexing

### DIFF
--- a/dev/lenient-npm.sh
+++ b/dev/lenient-npm.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -eux
 
+
 if [ $# -gt 0 ] && [ "$1" == "install" ]; then
-	/usr/local/bin/actual-npm "$@" || true
+	/usr/local/bin/actual-npm "$@" || echo "scip-typescript: ignoring npm install failure, will try to auto-index the project with partial dependency information"
 else
 	/usr/local/bin/actual-npm "$@"
 fi

--- a/dev/lenient-yarn.sh
+++ b/dev/lenient-yarn.sh
@@ -2,7 +2,7 @@
 set -eux
 
 if [ $# -gt 1 ] && [ "$1" == "install" ]; then
-	/usr/local/bin/actual-yarn "$@" || true
+	/usr/local/bin/actual-yarn "$@" || echo "scip-typescript: ignoring yarn install failure, will try to auto-index the project with partial dependency information"
 else
 	/usr/local/bin/actual-yarn "$@"
 fi


### PR DESCRIPTION
Previously, auto-indexing jobs silently ignored npm/yarn install
failures making it difficult to understand why the failures were
ignored.

### Test plan

I ran `false  || echo "hello"` to verify that the exit code remains non-zero.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
