### PR TITLE
Add support for Yarn v3

### DIFF
--- a/src/CommandLineOptions.ts
+++ b/src/CommandLineOptions.ts
@@ -9,6 +9,7 @@ export interface MultiProjectOptions {
   inferTsconfig: boolean
   progressBar: boolean
   yarnWorkspaces: boolean
+  yarnBerryWorkspaces: boolean
   cwd: string
   output: string
   indexedProjects: Set<string>
@@ -35,6 +36,11 @@ export function mainCommand(
     .command('index')
     .option('--cwd <path>', 'the working directory', process.cwd())
     .option('--yarn-workspaces', 'whether to index all yarn workspaces', false)
+    .option(
+      '--yarn-berry-workspaces',
+      'whether to index all yarn v3 workspaces',
+      false
+    )
     .option(
       '--infer-tsconfig',
       "whether to infer the tsconfig.json file, if it's missing",

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -51,6 +51,7 @@ for (const snapshotDirectory of snapshotDirectories) {
       inferTsconfig,
       output,
       yarnWorkspaces: Boolean(packageJson.workspaces),
+      yarnBerryWorkspaces: false,
       progressBar: false,
       indexedProjects: new Set(),
     })

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,8 @@ export function indexCommand(
 ): void {
   if (options.yarnWorkspaces) {
     projects.push(...listYarnWorkspaces(options.cwd))
+  } else if (options.yarnBerryWorkspaces) {
+    projects.push(...listYarnBerryWorkspaces(options.cwd))
   } else if (projects.length === 0) {
     projects.push(options.cwd)
   }
@@ -196,6 +198,28 @@ function defaultCompilerOptions(configFileName?: string): ts.CompilerOptions {
         }
       : {}
   return options
+}
+
+function listYarnBerryWorkspaces(directory: string): string[] {
+  const result: string[] = []
+  const lines = child_process
+    .execSync('yarn workspaces list --json', {
+      cwd: directory,
+      encoding: 'utf-8',
+    })
+    .split('\n')
+  for (const line of lines) {
+    if (!line) {
+      continue
+    }
+    const location = 'location'
+    const json = JSON.parse(line)
+    if (json[location] !== undefined) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+      result.push(path.join(directory, json[location]))
+    }
+  }
+  return result
 }
 
 function listYarnWorkspaces(directory: string): string[] {


### PR DESCRIPTION
### Test plan

I ran `npx ts-node ~/dev/sourcegraph/scip-typescript/src/main.ts index --yarn-berry-workspaces` locally and it successfully indexed the Sourcegraph repo from this PR here https://github.com/sourcegraph/sourcegraph/pull/39728
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
