### PR TITLE
fix: Fix --yarn-workspace with Yarn 3.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ Navigate to the project root, containing `package.json`.
 ```sh
 yarn install
 
-scip-typescript index --yarn-workspaces # For Yarn v2
-scip-typescript index --yarn-berry-workspaces # For Yarn v3 (Berry)
+scip-typescript index --yarn-workspaces
 ```
 
 ### Indexing in CI

--- a/src/CommandLineOptions.ts
+++ b/src/CommandLineOptions.ts
@@ -38,7 +38,7 @@ export function mainCommand(
     .option('--yarn-workspaces', 'whether to index all yarn workspaces', false)
     .option(
       '--yarn-berry-workspaces',
-      'whether to index all yarn v3 workspaces',
+      '(deprecated) use --yarn-workspaces instead',
       false
     )
     .option(

--- a/src/main.ts
+++ b/src/main.ts
@@ -245,9 +245,9 @@ function listYarnWorkspaces(
   }
   if (yarnVersion === 'tryYarn1') {
     try {
-      yarn1WorkspaceInfo()
-    } catch {
       yarn2PlusWorkspaceInfo()
+    } catch {
+      yarn1WorkspaceInfo()
     }
   } else {
     yarn2PlusWorkspaceInfo()


### PR DESCRIPTION
Fixes #180.

### Test plan

Manually tested against the Sourcegraph monorepo with Yarn 3 which seems to have been made the default around Sept 1 (http://github.com/sourcegraph/sourcegraph/pull/39728). The last scip-typescript upload for sg/sg was on Sept 2 (https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/code-graph/uploads?query=scip-typescript), so it seems like this job has been broken since then.