### PR TITLE
Emit occurrences for string literals

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.formatOnSave": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "editor.formatOnSave": true
+  "editor.formatOnSave": true
 }

--- a/snapshots/input/syntax/src/import.ts
+++ b/snapshots/input/syntax/src/import.ts
@@ -11,3 +11,7 @@ export function useEverything(): string {
     newFunction()
   )
 }
+
+export function dynamicImport(): Promise<void> {
+  return import('./function').then(c => c.newFunction())
+}

--- a/snapshots/input/syntax/src/string-literals.ts
+++ b/snapshots/input/syntax/src/string-literals.ts
@@ -1,0 +1,10 @@
+interface SomeInterface {
+  a: number
+  b: number
+  c: number
+}
+// "Go to definition" does not work for the 'a', 'b' and 'c' string literals
+// below when using tsserver so it's fine that scip-typescript does not emit
+// occurrences here either.
+export type OmitInterface = Omit<SomeInterface, 'a' | 'b'>
+export type PickInterface = Pick<SomeInterface, 'b' | 'c'>

--- a/snapshots/output/multi-project/packages/a/src/index.ts
+++ b/snapshots/output/multi-project/packages/a/src/index.ts
@@ -1,6 +1,6 @@
   export function a(): string {
 // definition @example/a 1.0.0 src/`index.ts`/
-//documentation ```ts\nmodule "index"\n```
+//documentation ```ts\nmodule "index.ts"\n```
 //                ^ definition @example/a 1.0.0 src/`index.ts`/a().
 //                documentation ```ts\nfunction a(): string\n```
     return ''

--- a/snapshots/output/multi-project/packages/a/src/index.ts
+++ b/snapshots/output/multi-project/packages/a/src/index.ts
@@ -1,4 +1,6 @@
   export function a(): string {
+// definition @example/a 1.0.0 src/`index.ts`/
+//documentation ```ts\nmodule "index"\n```
 //                ^ definition @example/a 1.0.0 src/`index.ts`/a().
 //                documentation ```ts\nfunction a(): string\n```
     return ''

--- a/snapshots/output/multi-project/packages/b/src/b.ts
+++ b/snapshots/output/multi-project/packages/b/src/b.ts
@@ -1,6 +1,6 @@
   import { a } from '@example/a/src'
 // definition @example/b 1.0.0 src/`b.ts`/
-//documentation ```ts\nmodule "b"\n```
+//documentation ```ts\nmodule "b.ts"\n```
 //         ^ reference @example/a 1.0.0 src/`index.ts`/a().
 //                  ^^^^^^^^^^^^^^^^ reference @example/a 1.0.0 src/`index.ts`/
   

--- a/snapshots/output/multi-project/packages/b/src/b.ts
+++ b/snapshots/output/multi-project/packages/b/src/b.ts
@@ -1,5 +1,8 @@
   import { a } from '@example/a/src'
+// definition @example/b 1.0.0 src/`b.ts`/
+//documentation ```ts\nmodule "b"\n```
 //         ^ reference @example/a 1.0.0 src/`index.ts`/a().
+//                  ^^^^^^^^^^^^^^^^ reference @example/a 1.0.0 src/`index.ts`/
   
   export function b() {
 //                ^ definition @example/b 1.0.0 src/`b.ts`/b().

--- a/snapshots/output/pure-js/src/main.js
+++ b/snapshots/output/pure-js/src/main.js
@@ -1,4 +1,6 @@
   function fib(n) {
+// definition pure-js 1.0.0 src/`main.js`/
+//documentation ```ts\nmodule "main"\n```
 //         ^^^ definition pure-js 1.0.0 src/`main.js`/fib().
 //         documentation ```ts\nfunction fib(n: any): any\n```
 //             ^ definition pure-js 1.0.0 src/`main.js`/fib().(n)

--- a/snapshots/output/pure-js/src/main.js
+++ b/snapshots/output/pure-js/src/main.js
@@ -1,6 +1,6 @@
   function fib(n) {
 // definition pure-js 1.0.0 src/`main.js`/
-//documentation ```ts\nmodule "main"\n```
+//documentation ```ts\nmodule "main.js"\n```
 //         ^^^ definition pure-js 1.0.0 src/`main.js`/fib().
 //         documentation ```ts\nfunction fib(n: any): any\n```
 //             ^ definition pure-js 1.0.0 src/`main.js`/fib().(n)

--- a/snapshots/output/react/src/LoaderInput.tsx
+++ b/snapshots/output/react/src/LoaderInput.tsx
@@ -1,6 +1,6 @@
   import React from 'react'
 // definition react-example 1.0.0 src/`LoaderInput.tsx`/
-//documentation ```ts\nmodule "LoaderInput"\n```
+//documentation ```ts\nmodule "LoaderInput.tsx"\n```
 //       ^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/
 //                  ^^^^^^^ reference @types/react 17.0.0 `index.d.ts`/
   

--- a/snapshots/output/react/src/LoaderInput.tsx
+++ b/snapshots/output/react/src/LoaderInput.tsx
@@ -1,5 +1,8 @@
   import React from 'react'
+// definition react-example 1.0.0 src/`LoaderInput.tsx`/
+//documentation ```ts\nmodule "LoaderInput"\n```
 //       ^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/
+//                  ^^^^^^^ reference @types/react 17.0.0 `index.d.ts`/
   
   /** Takes loading prop, input component as child */
   interface Props {

--- a/snapshots/output/react/src/MyTSXElement.tsx
+++ b/snapshots/output/react/src/MyTSXElement.tsx
@@ -1,5 +1,8 @@
   import React from 'react'
+// definition react-example 1.0.0 src/`MyTSXElement.tsx`/
+//documentation ```ts\nmodule "MyTSXElement"\n```
 //       ^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/
+//                  ^^^^^^^ reference @types/react 17.0.0 `index.d.ts`/
   
   export interface MyProps {}
 //                 ^^^^^^^ definition react-example 1.0.0 src/`MyTSXElement.tsx`/MyProps#

--- a/snapshots/output/react/src/MyTSXElement.tsx
+++ b/snapshots/output/react/src/MyTSXElement.tsx
@@ -1,6 +1,6 @@
   import React from 'react'
 // definition react-example 1.0.0 src/`MyTSXElement.tsx`/
-//documentation ```ts\nmodule "MyTSXElement"\n```
+//documentation ```ts\nmodule "MyTSXElement.tsx"\n```
 //       ^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/
 //                  ^^^^^^^ reference @types/react 17.0.0 `index.d.ts`/
   

--- a/snapshots/output/react/src/UseMyTSXElement.tsx
+++ b/snapshots/output/react/src/UseMyTSXElement.tsx
@@ -1,6 +1,6 @@
   import React from "react";
 // definition react-example 1.0.0 src/`UseMyTSXElement.tsx`/
-//documentation ```ts\nmodule "UseMyTSXElement"\n```
+//documentation ```ts\nmodule "UseMyTSXElement.tsx"\n```
 //       ^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/
 //                  ^^^^^^^ reference @types/react 17.0.0 `index.d.ts`/
   

--- a/snapshots/output/react/src/UseMyTSXElement.tsx
+++ b/snapshots/output/react/src/UseMyTSXElement.tsx
@@ -1,9 +1,13 @@
   import React from "react";
+// definition react-example 1.0.0 src/`UseMyTSXElement.tsx`/
+//documentation ```ts\nmodule "UseMyTSXElement"\n```
 //       ^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/
+//                  ^^^^^^^ reference @types/react 17.0.0 `index.d.ts`/
   
   import { MyProps, MyTSXElement } from "./MyTSXElement";
 //         ^^^^^^^ reference react-example 1.0.0 src/`MyTSXElement.tsx`/MyProps#
 //                  ^^^^^^^^^^^^ reference react-example 1.0.0 src/`MyTSXElement.tsx`/MyTSXElement.
+//                                      ^^^^^^^^^^^^^^^^ reference react-example 1.0.0 src/`MyTSXElement.tsx`/
   
   export const _: React.FunctionComponent<MyProps> =
 //             ^ definition react-example 1.0.0 src/`UseMyTSXElement.tsx`/_.

--- a/snapshots/output/syntax/src/accessors.ts
+++ b/snapshots/output/syntax/src/accessors.ts
@@ -1,6 +1,6 @@
   class C {
 // definition syntax 1.0.0 src/`accessors.ts`/
-//documentation ```ts\nmodule "accessors"\n```
+//documentation ```ts\nmodule "accessors.ts"\n```
 //      ^ definition syntax 1.0.0 src/`accessors.ts`/C#
 //      documentation ```ts\nclass C\n```
     _length: number = 0

--- a/snapshots/output/syntax/src/accessors.ts
+++ b/snapshots/output/syntax/src/accessors.ts
@@ -1,4 +1,6 @@
   class C {
+// definition syntax 1.0.0 src/`accessors.ts`/
+//documentation ```ts\nmodule "accessors"\n```
 //      ^ definition syntax 1.0.0 src/`accessors.ts`/C#
 //      documentation ```ts\nclass C\n```
     _length: number = 0

--- a/snapshots/output/syntax/src/class.ts
+++ b/snapshots/output/syntax/src/class.ts
@@ -1,4 +1,6 @@
   export class Class {
+// definition syntax 1.0.0 src/`class.ts`/
+//documentation ```ts\nmodule "class"\n```
 //             ^^^^^ definition syntax 1.0.0 src/`class.ts`/Class#
 //             documentation ```ts\nclass Class\n```
     public classProperty: string

--- a/snapshots/output/syntax/src/class.ts
+++ b/snapshots/output/syntax/src/class.ts
@@ -1,6 +1,6 @@
   export class Class {
 // definition syntax 1.0.0 src/`class.ts`/
-//documentation ```ts\nmodule "class"\n```
+//documentation ```ts\nmodule "class.ts"\n```
 //             ^^^^^ definition syntax 1.0.0 src/`class.ts`/Class#
 //             documentation ```ts\nclass Class\n```
     public classProperty: string

--- a/snapshots/output/syntax/src/enum.ts
+++ b/snapshots/output/syntax/src/enum.ts
@@ -1,6 +1,6 @@
   export enum Enum {
 // definition syntax 1.0.0 src/`enum.ts`/
-//documentation ```ts\nmodule "enum"\n```
+//documentation ```ts\nmodule "enum.ts"\n```
 //            ^^^^ definition syntax 1.0.0 src/`enum.ts`/Enum#
 //            documentation ```ts\nenum Enum\n```
     A,

--- a/snapshots/output/syntax/src/enum.ts
+++ b/snapshots/output/syntax/src/enum.ts
@@ -1,4 +1,6 @@
   export enum Enum {
+// definition syntax 1.0.0 src/`enum.ts`/
+//documentation ```ts\nmodule "enum"\n```
 //            ^^^^ definition syntax 1.0.0 src/`enum.ts`/Enum#
 //            documentation ```ts\nenum Enum\n```
     A,

--- a/snapshots/output/syntax/src/function.ts
+++ b/snapshots/output/syntax/src/function.ts
@@ -1,4 +1,6 @@
   export function newFunction(): void {}
+// definition syntax 1.0.0 src/`function.ts`/
+//documentation ```ts\nmodule "function"\n```
 //                ^^^^^^^^^^^ definition syntax 1.0.0 src/`function.ts`/newFunction().
 //                documentation ```ts\nfunction newFunction(): void\n```
   

--- a/snapshots/output/syntax/src/function.ts
+++ b/snapshots/output/syntax/src/function.ts
@@ -1,6 +1,6 @@
   export function newFunction(): void {}
 // definition syntax 1.0.0 src/`function.ts`/
-//documentation ```ts\nmodule "function"\n```
+//documentation ```ts\nmodule "function.ts"\n```
 //                ^^^^^^^^^^^ definition syntax 1.0.0 src/`function.ts`/newFunction().
 //                documentation ```ts\nfunction newFunction(): void\n```
   

--- a/snapshots/output/syntax/src/import.ts
+++ b/snapshots/output/syntax/src/import.ts
@@ -1,6 +1,6 @@
   import { Class } from './class'
 // definition syntax 1.0.0 src/`import.ts`/
-//documentation ```ts\nmodule "import"\n```
+//documentation ```ts\nmodule "import.ts"\n```
 //         ^^^^^ reference syntax 1.0.0 src/`class.ts`/Class#
 //                      ^^^^^^^^^ reference syntax 1.0.0 src/`class.ts`/
   import { Enum } from './enum'

--- a/snapshots/output/syntax/src/import.ts
+++ b/snapshots/output/syntax/src/import.ts
@@ -45,7 +45,7 @@
 //                ^^^^^^^^^^^^ reference syntax 1.0.0 src/`function.ts`/
 //                              ^^^^ reference typescript 4.8.4 lib/`lib.es5.d.ts`/Promise#then().
 //                                   ^ definition local 3
-//                                   documentation ```ts\n(parameter) c: typeof import("/Users/olafurpg/dev/sourcegraph/scip-typescript/snapshots/input/syntax/src/function")\n```
+//                                   documentation ```ts\n(parameter) c: typeof import("/src/function")\n```
 //                                        ^ reference local 3
 //                                          ^^^^^^^^^^^ reference syntax 1.0.0 src/`function.ts`/newFunction().
   }

--- a/snapshots/output/syntax/src/import.ts
+++ b/snapshots/output/syntax/src/import.ts
@@ -1,12 +1,18 @@
   import { Class } from './class'
+// definition syntax 1.0.0 src/`import.ts`/
+//documentation ```ts\nmodule "import"\n```
 //         ^^^^^ reference syntax 1.0.0 src/`class.ts`/Class#
+//                      ^^^^^^^^^ reference syntax 1.0.0 src/`class.ts`/
   import { Enum } from './enum'
 //         ^^^^ reference syntax 1.0.0 src/`enum.ts`/Enum#
+//                     ^^^^^^^^ reference syntax 1.0.0 src/`enum.ts`/
   import { newFunction } from './function'
 //         ^^^^^^^^^^^ reference syntax 1.0.0 src/`function.ts`/newFunction().
+//                            ^^^^^^^^^^^^ reference syntax 1.0.0 src/`function.ts`/
   import { newInterface as renamedInterface } from './interface'
 //         ^^^^^^^^^^^^ reference syntax 1.0.0 src/`interface.ts`/newInterface().
 //                         ^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`interface.ts`/newInterface().
+//                                                 ^^^^^^^^^^^^^ reference syntax 1.0.0 src/`interface.ts`/
   
   export function useEverything(): string {
 //                ^^^^^^^^^^^^^ definition syntax 1.0.0 src/`import.ts`/useEverything().
@@ -25,5 +31,22 @@
       newFunction()
 //    ^^^^^^^^^^^ reference syntax 1.0.0 src/`function.ts`/newFunction().
     )
+  }
+  
+  export function dynamicImport(): Promise<void> {
+//                ^^^^^^^^^^^^^ definition syntax 1.0.0 src/`import.ts`/dynamicImport().
+//                documentation ```ts\nfunction dynamicImport(): Promise<void>\n```
+//                                 ^^^^^^^ reference typescript 4.8.4 lib/`lib.es5.d.ts`/Promise#
+//                                 ^^^^^^^ reference typescript 4.8.4 lib/`lib.es2015.iterable.d.ts`/Promise#
+//                                 ^^^^^^^ reference typescript 4.8.4 lib/`lib.es2015.promise.d.ts`/Promise.
+//                                 ^^^^^^^ reference typescript 4.8.4 lib/`lib.es2015.symbol.wellknown.d.ts`/Promise#
+//                                 ^^^^^^^ reference typescript 4.8.4 lib/`lib.es2018.promise.d.ts`/Promise#
+    return import('./function').then(c => c.newFunction())
+//                ^^^^^^^^^^^^ reference syntax 1.0.0 src/`function.ts`/
+//                              ^^^^ reference typescript 4.8.4 lib/`lib.es5.d.ts`/Promise#then().
+//                                   ^ definition local 3
+//                                   documentation ```ts\n(parameter) c: typeof import("/Users/olafurpg/dev/sourcegraph/scip-typescript/snapshots/input/syntax/src/function")\n```
+//                                        ^ reference local 3
+//                                          ^^^^^^^^^^^ reference syntax 1.0.0 src/`function.ts`/newFunction().
   }
   

--- a/snapshots/output/syntax/src/inheritance.ts
+++ b/snapshots/output/syntax/src/inheritance.ts
@@ -1,5 +1,8 @@
   import { Overloader } from './overload'
+// definition syntax 1.0.0 src/`inheritance.ts`/
+//documentation ```ts\nmodule "inheritance"\n```
 //         ^^^^^^^^^^ reference syntax 1.0.0 src/`overload.d.ts`/Overloader#
+//                           ^^^^^^^^^^^^ reference syntax 1.0.0 src/`overload.d.ts`/
   
   export interface Superinterface {
 //                 ^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/Superinterface#

--- a/snapshots/output/syntax/src/inheritance.ts
+++ b/snapshots/output/syntax/src/inheritance.ts
@@ -1,6 +1,6 @@
   import { Overloader } from './overload'
 // definition syntax 1.0.0 src/`inheritance.ts`/
-//documentation ```ts\nmodule "inheritance"\n```
+//documentation ```ts\nmodule "inheritance.ts"\n```
 //         ^^^^^^^^^^ reference syntax 1.0.0 src/`overload.d.ts`/Overloader#
 //                           ^^^^^^^^^^^^ reference syntax 1.0.0 src/`overload.d.ts`/
   

--- a/snapshots/output/syntax/src/interface.ts
+++ b/snapshots/output/syntax/src/interface.ts
@@ -1,6 +1,6 @@
   export interface Interface {
 // definition syntax 1.0.0 src/`interface.ts`/
-//documentation ```ts\nmodule "interface"\n```
+//documentation ```ts\nmodule "interface.ts"\n```
 //                 ^^^^^^^^^ definition syntax 1.0.0 src/`interface.ts`/Interface#
 //                 documentation ```ts\ninterface Interface\n```
     property: string

--- a/snapshots/output/syntax/src/interface.ts
+++ b/snapshots/output/syntax/src/interface.ts
@@ -1,4 +1,6 @@
   export interface Interface {
+// definition syntax 1.0.0 src/`interface.ts`/
+//documentation ```ts\nmodule "interface"\n```
 //                 ^^^^^^^^^ definition syntax 1.0.0 src/`interface.ts`/Interface#
 //                 documentation ```ts\ninterface Interface\n```
     property: string

--- a/snapshots/output/syntax/src/issue-45.d.ts
+++ b/snapshots/output/syntax/src/issue-45.d.ts
@@ -1,6 +1,6 @@
   export namespace example {
 // definition syntax 1.0.0 src/`issue-45.d.ts`/
-//documentation ```ts\nmodule "issue-45.d"\n```
+//documentation ```ts\nmodule "issue-45.d.ts"\n```
 //                 ^^^^^^^ definition syntax 1.0.0 src/`issue-45.d.ts`/example/
 //                 documentation ```ts\nexample: typeof example\n```
     class Server {

--- a/snapshots/output/syntax/src/issue-45.d.ts
+++ b/snapshots/output/syntax/src/issue-45.d.ts
@@ -1,4 +1,6 @@
   export namespace example {
+// definition syntax 1.0.0 src/`issue-45.d.ts`/
+//documentation ```ts\nmodule "issue-45.d"\n```
 //                 ^^^^^^^ definition syntax 1.0.0 src/`issue-45.d.ts`/example/
 //                 documentation ```ts\nexample: typeof example\n```
     class Server {

--- a/snapshots/output/syntax/src/local.ts
+++ b/snapshots/output/syntax/src/local.ts
@@ -1,4 +1,6 @@
   export function local(): string {
+// definition syntax 1.0.0 src/`local.ts`/
+//documentation ```ts\nmodule "local"\n```
 //                ^^^^^ definition syntax 1.0.0 src/`local.ts`/local().
 //                documentation ```ts\nfunction local(): string\n```
     const a = 'a'

--- a/snapshots/output/syntax/src/local.ts
+++ b/snapshots/output/syntax/src/local.ts
@@ -1,6 +1,6 @@
   export function local(): string {
 // definition syntax 1.0.0 src/`local.ts`/
-//documentation ```ts\nmodule "local"\n```
+//documentation ```ts\nmodule "local.ts"\n```
 //                ^^^^^ definition syntax 1.0.0 src/`local.ts`/local().
 //                documentation ```ts\nfunction local(): string\n```
     const a = 'a'

--- a/snapshots/output/syntax/src/module.d.ts
+++ b/snapshots/output/syntax/src/module.d.ts
@@ -1,4 +1,8 @@
   declare module 'a:b' {
+// definition syntax 1.0.0 src/`module.d.ts`/
+//documentation ```ts\nmodule "module.d"\n```
+//               ^^^^^ definition syntax 1.0.0 src/`module.d.ts`/`'a:b'`/
+//               documentation ```ts\n'a:b': typeof import("a:b")\n```
     function hello(): string
 //           ^^^^^ definition syntax 1.0.0 src/`module.d.ts`/`'a:b'`/hello().
 //           documentation ```ts\nfunction hello(): string\n```

--- a/snapshots/output/syntax/src/module.d.ts
+++ b/snapshots/output/syntax/src/module.d.ts
@@ -1,6 +1,6 @@
   declare module 'a:b' {
 // definition syntax 1.0.0 src/`module.d.ts`/
-//documentation ```ts\nmodule "module.d"\n```
+//documentation ```ts\nmodule "module.d.ts"\n```
 //               ^^^^^ definition syntax 1.0.0 src/`module.d.ts`/`'a:b'`/
 //               documentation ```ts\n'a:b': typeof import("a:b")\n```
     function hello(): string

--- a/snapshots/output/syntax/src/namespace.d.ts
+++ b/snapshots/output/syntax/src/namespace.d.ts
@@ -1,4 +1,6 @@
   declare namespace a {
+// definition syntax 1.0.0 src/`namespace.d.ts`/
+//documentation ```ts\nmodule "namespace.d"\n```
 //                  ^ definition syntax 1.0.0 src/`namespace.d.ts`/a/
 //                  documentation ```ts\na: typeof a\n```
     function hello(): string

--- a/snapshots/output/syntax/src/namespace.d.ts
+++ b/snapshots/output/syntax/src/namespace.d.ts
@@ -1,6 +1,6 @@
   declare namespace a {
 // definition syntax 1.0.0 src/`namespace.d.ts`/
-//documentation ```ts\nmodule "namespace.d"\n```
+//documentation ```ts\nmodule "namespace.d.ts"\n```
 //                  ^ definition syntax 1.0.0 src/`namespace.d.ts`/a/
 //                  documentation ```ts\na: typeof a\n```
     function hello(): string

--- a/snapshots/output/syntax/src/overload.d.ts
+++ b/snapshots/output/syntax/src/overload.d.ts
@@ -1,6 +1,6 @@
   export interface Overloader {
 // definition syntax 1.0.0 src/`overload.d.ts`/
-//documentation ```ts\nmodule "overload.d"\n```
+//documentation ```ts\nmodule "overload.d.ts"\n```
 //                 ^^^^^^^^^^ definition syntax 1.0.0 src/`overload.d.ts`/Overloader#
 //                 documentation ```ts\ninterface Overloader\n```
     onLiteral(param: 'a'): void

--- a/snapshots/output/syntax/src/overload.d.ts
+++ b/snapshots/output/syntax/src/overload.d.ts
@@ -1,4 +1,6 @@
   export interface Overloader {
+// definition syntax 1.0.0 src/`overload.d.ts`/
+//documentation ```ts\nmodule "overload.d"\n```
 //                 ^^^^^^^^^^ definition syntax 1.0.0 src/`overload.d.ts`/Overloader#
 //                 documentation ```ts\ninterface Overloader\n```
     onLiteral(param: 'a'): void

--- a/snapshots/output/syntax/src/property-assignment-reference.ts
+++ b/snapshots/output/syntax/src/property-assignment-reference.ts
@@ -1,9 +1,12 @@
   import {
+// definition syntax 1.0.0 src/`property-assignment-reference.ts`/
+//documentation ```ts\nmodule "property-assignment-reference"\n```
     propertyAssignment,
 //  ^^^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`property-assignment.ts`/propertyAssignment().
     shorthandPropertyAssignment,
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`property-assignment.ts`/shorthandPropertyAssignment().
   } from './property-assignment'
+//       ^^^^^^^^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`property-assignment.ts`/
   
   export function run(): string {
 //                ^^^ definition syntax 1.0.0 src/`property-assignment-reference.ts`/run().

--- a/snapshots/output/syntax/src/property-assignment-reference.ts
+++ b/snapshots/output/syntax/src/property-assignment-reference.ts
@@ -1,6 +1,6 @@
   import {
 // definition syntax 1.0.0 src/`property-assignment-reference.ts`/
-//documentation ```ts\nmodule "property-assignment-reference"\n```
+//documentation ```ts\nmodule "property-assignment-reference.ts"\n```
     propertyAssignment,
 //  ^^^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`property-assignment.ts`/propertyAssignment().
     shorthandPropertyAssignment,

--- a/snapshots/output/syntax/src/property-assignment.ts
+++ b/snapshots/output/syntax/src/property-assignment.ts
@@ -1,6 +1,6 @@
   export function propertyAssignment() {
 // definition syntax 1.0.0 src/`property-assignment.ts`/
-//documentation ```ts\nmodule "property-assignment"\n```
+//documentation ```ts\nmodule "property-assignment.ts"\n```
 //                ^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`property-assignment.ts`/propertyAssignment().
 //                documentation ```ts\nfunction propertyAssignment(): { a: string; }\n```
     return { a: 'a' }

--- a/snapshots/output/syntax/src/property-assignment.ts
+++ b/snapshots/output/syntax/src/property-assignment.ts
@@ -1,4 +1,6 @@
   export function propertyAssignment() {
+// definition syntax 1.0.0 src/`property-assignment.ts`/
+//documentation ```ts\nmodule "property-assignment"\n```
 //                ^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`property-assignment.ts`/propertyAssignment().
 //                documentation ```ts\nfunction propertyAssignment(): { a: string; }\n```
     return { a: 'a' }

--- a/snapshots/output/syntax/src/string-literals.ts
+++ b/snapshots/output/syntax/src/string-literals.ts
@@ -1,0 +1,29 @@
+  interface SomeInterface {
+// definition syntax 1.0.0 src/`string-literals.ts`/
+//documentation ```ts\nmodule "string-literals"\n```
+//          ^^^^^^^^^^^^^ definition syntax 1.0.0 src/`string-literals.ts`/SomeInterface#
+//          documentation ```ts\ninterface SomeInterface\n```
+    a: number
+//  ^ definition syntax 1.0.0 src/`string-literals.ts`/SomeInterface#a.
+//  documentation ```ts\n(property) a: number\n```
+    b: number
+//  ^ definition syntax 1.0.0 src/`string-literals.ts`/SomeInterface#b.
+//  documentation ```ts\n(property) b: number\n```
+    c: number
+//  ^ definition syntax 1.0.0 src/`string-literals.ts`/SomeInterface#c.
+//  documentation ```ts\n(property) c: number\n```
+  }
+  // "Go to definition" does not work for the 'a', 'b' and 'c' string literals
+  // below when using tsserver so it's fine that scip-typescript does not emit
+  // occurrences here either.
+  export type OmitInterface = Omit<SomeInterface, 'a' | 'b'>
+//            ^^^^^^^^^^^^^ definition syntax 1.0.0 src/`string-literals.ts`/OmitInterface#
+//            documentation ```ts\ntype OmitInterface\n```
+//                            ^^^^ reference typescript 4.8.4 lib/`lib.es5.d.ts`/Omit#
+//                                 ^^^^^^^^^^^^^ reference syntax 1.0.0 src/`string-literals.ts`/SomeInterface#
+  export type PickInterface = Pick<SomeInterface, 'b' | 'c'>
+//            ^^^^^^^^^^^^^ definition syntax 1.0.0 src/`string-literals.ts`/PickInterface#
+//            documentation ```ts\ntype PickInterface\n```
+//                            ^^^^ reference typescript 4.8.4 lib/`lib.es5.d.ts`/Pick#
+//                                 ^^^^^^^^^^^^^ reference syntax 1.0.0 src/`string-literals.ts`/SomeInterface#
+  

--- a/snapshots/output/syntax/src/string-literals.ts
+++ b/snapshots/output/syntax/src/string-literals.ts
@@ -1,6 +1,6 @@
   interface SomeInterface {
 // definition syntax 1.0.0 src/`string-literals.ts`/
-//documentation ```ts\nmodule "string-literals"\n```
+//documentation ```ts\nmodule "string-literals.ts"\n```
 //          ^^^^^^^^^^^^^ definition syntax 1.0.0 src/`string-literals.ts`/SomeInterface#
 //          documentation ```ts\ninterface SomeInterface\n```
     a: number

--- a/snapshots/output/syntax/src/type-alias.ts
+++ b/snapshots/output/syntax/src/type-alias.ts
@@ -1,6 +1,6 @@
   type S = string
 // definition syntax 1.0.0 src/`type-alias.ts`/
-//documentation ```ts\nmodule "type-alias"\n```
+//documentation ```ts\nmodule "type-alias.ts"\n```
 //     ^ definition syntax 1.0.0 src/`type-alias.ts`/S#
 //     documentation ```ts\ntype S\n```
   

--- a/snapshots/output/syntax/src/type-alias.ts
+++ b/snapshots/output/syntax/src/type-alias.ts
@@ -1,4 +1,6 @@
   type S = string
+// definition syntax 1.0.0 src/`type-alias.ts`/
+//documentation ```ts\nmodule "type-alias"\n```
 //     ^ definition syntax 1.0.0 src/`type-alias.ts`/S#
 //     documentation ```ts\ntype S\n```
   

--- a/snapshots/output/syntax/src/type-parameter.ts
+++ b/snapshots/output/syntax/src/type-parameter.ts
@@ -1,4 +1,6 @@
   export function typeParameter<A, B>(parameter: A, parameter2: B): [A, B] {
+// definition syntax 1.0.0 src/`type-parameter.ts`/
+//documentation ```ts\nmodule "type-parameter"\n```
 //                ^^^^^^^^^^^^^ definition syntax 1.0.0 src/`type-parameter.ts`/typeParameter().
 //                documentation ```ts\nfunction typeParameter<A, B>(parameter: A, parameter2: B): [A, B]\n```
 //                              ^ definition syntax 1.0.0 src/`type-parameter.ts`/typeParameter().[A]

--- a/snapshots/output/syntax/src/type-parameter.ts
+++ b/snapshots/output/syntax/src/type-parameter.ts
@@ -1,6 +1,6 @@
   export function typeParameter<A, B>(parameter: A, parameter2: B): [A, B] {
 // definition syntax 1.0.0 src/`type-parameter.ts`/
-//documentation ```ts\nmodule "type-parameter"\n```
+//documentation ```ts\nmodule "type-parameter.ts"\n```
 //                ^^^^^^^^^^^^^ definition syntax 1.0.0 src/`type-parameter.ts`/typeParameter().
 //                documentation ```ts\nfunction typeParameter<A, B>(parameter: A, parameter2: B): [A, B]\n```
 //                              ^ definition syntax 1.0.0 src/`type-parameter.ts`/typeParameter().[A]

--- a/src/FileIndexer.ts
+++ b/src/FileIndexer.ts
@@ -2,6 +2,7 @@ import path from 'path'
 
 import * as ts from 'typescript'
 
+import { ProjectOptions } from './CommandLineOptions'
 import { Counter } from './Counter'
 import {
   metaDescriptor,
@@ -29,6 +30,7 @@ export class FileIndexer {
   private localSymbolTable: Map<ts.Node, LsifSymbol> = new Map()
   constructor(
     public readonly checker: ts.TypeChecker,
+    public readonly options: ProjectOptions,
     public readonly input: Input,
     public readonly document: lsif.lib.codeintel.lsiftyped.Document,
     public readonly globalSymbolTable: Map<ts.Node, LsifSymbol>,
@@ -166,6 +168,9 @@ export class FileIndexer {
     }
   }
 
+  private hideWorkingDirectory(value: string): string {
+    return value.replaceAll(this.options.cwd, '')
+  }
   private addSymbolInformation(
     node: ts.Node,
     sym: ts.Symbol,
@@ -173,7 +178,9 @@ export class FileIndexer {
     symbol: LsifSymbol
   ): void {
     const documentation = [
-      '```ts\n' + this.signatureForDocumentation(node, sym) + '\n```',
+      '```ts\n' +
+        this.hideWorkingDirectory(this.signatureForDocumentation(node, sym)) +
+        '\n```',
     ]
     const docstring = sym.getDocumentationComment(this.checker)
     if (docstring.length > 0) {

--- a/src/FileIndexer.ts
+++ b/src/FileIndexer.ts
@@ -57,11 +57,7 @@ export class FileIndexer {
       })
     )
     const moduleName =
-      this.sourceFile.moduleName ||
-      path
-        .basename(this.sourceFile.fileName)
-        .replace(/.tsx?$/, '')
-        .replace(/.jsx?/, '')
+      this.sourceFile.moduleName || path.basename(this.sourceFile.fileName)
     this.document.symbols.push(
       new lsiftyped.SymbolInformation({
         symbol: symbol.value,

--- a/src/FileIndexer.ts
+++ b/src/FileIndexer.ts
@@ -28,6 +28,7 @@ export class FileIndexer {
   private localCounter = new Counter()
   private propertyCounters: Map<string, Counter> = new Map()
   private localSymbolTable: Map<ts.Node, LsifSymbol> = new Map()
+  private workingDirectoryRegExp: RegExp
   constructor(
     public readonly checker: ts.TypeChecker,
     public readonly options: ProjectOptions,
@@ -36,7 +37,9 @@ export class FileIndexer {
     public readonly globalSymbolTable: Map<ts.Node, LsifSymbol>,
     public readonly packages: Packages,
     public readonly sourceFile: ts.SourceFile
-  ) {}
+  ) {
+    this.workingDirectoryRegExp = new RegExp(options.cwd, 'g')
+  }
   public index(): void {
     this.emitSourceFileOccurrence()
     this.visit(this.sourceFile)
@@ -169,7 +172,7 @@ export class FileIndexer {
   }
 
   private hideWorkingDirectory(value: string): string {
-    return value.replaceAll(this.options.cwd, '')
+    return value.replace(this.workingDirectoryRegExp, '')
   }
   private addSymbolInformation(
     node: ts.Node,

--- a/src/ProjectIndexer.ts
+++ b/src/ProjectIndexer.ts
@@ -69,17 +69,15 @@ function createCompilerHost(
 }
 
 export class ProjectIndexer {
-  private options: ProjectOptions
   private program: ts.Program
   private checker: ts.TypeChecker
   private symbolCache: Map<ts.Node, LsifSymbol> = new Map()
   private packages: Packages
   constructor(
     public readonly config: ts.ParsedCommandLine,
-    options: ProjectOptions,
+    public readonly options: ProjectOptions,
     cache: GlobalCache
   ) {
-    this.options = options
     const host = createCompilerHost(cache, config.options, options)
     this.program = ts.createProgram(config.fileNames, config.options, host)
     this.checker = this.program.getTypeChecker()
@@ -138,6 +136,7 @@ export class ProjectIndexer {
       const input = new Input(sourceFile.fileName, sourceFile.getText())
       const visitor = new FileIndexer(
         this.checker,
+        this.options,
         input,
         document,
         this.symbolCache,


### PR DESCRIPTION
Previously, scip-typescript only emitted occurrences for identifiers. Now, we additionally emit occurrences for string literals so that features like "Go to definition" work with `import` statements and other locations where string literals reference actual symbols.

### Test plan

See the updated snapshot tests. I additionally manually verified that it works as expected on Sourcegraph https://sourcegraph.com/github.com/sourcegraph/scip-typescript@324cb332db75b3082fdbccc45a1a8e166d546b28/-/blob/src/FileIndexer.ts?L21:28&popover=pinned

<img width="792" alt="CleanShot 2022-10-18 at 11 39 31@2x" src="https://user-images.githubusercontent.com/1408093/196395478-6f2d9af0-ae57-41cb-a039-84a32074d868.png">

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
