### PR TITLE
Emit correct occurrences for destructured objects

### DIFF
--- a/snapshots/input/syntax/src/destructuring.ts
+++ b/snapshots/input/syntax/src/destructuring.ts
@@ -31,3 +31,7 @@ export function forLoopArrayDestructuring(): number {
   }
   return 1
 }
+
+export function parameterDestructuring({ a }: Props): number {
+  return a
+}

--- a/snapshots/input/syntax/src/destructuring.ts
+++ b/snapshots/input/syntax/src/destructuring.ts
@@ -1,0 +1,33 @@
+interface Props {
+  a: number
+}
+const props: Props = { a: 42 }
+
+export function objectDestructuring(): number[] {
+  const { a: b } = props
+  return [props].map(({ a }) => a + b)
+}
+
+export function arrayDestructuring(): number[] {
+  const [b] = [props]
+  return [[b]].map(([a]) => a.a)
+}
+
+export function nestedDestructuring(): number[] {
+  const [[b]] = [[props]]
+  return [[props]].map(([{ a }]) => a + b.a)
+}
+
+export function forLoopObjectDestructuring(): number {
+  for (const { a } of [props]) {
+    return a
+  }
+  return 1
+}
+
+export function forLoopArrayDestructuring(): number {
+  for (const [{ a }] of [[props]]) {
+    return a
+  }
+  return 1
+}

--- a/snapshots/input/syntax/src/structural-type.ts
+++ b/snapshots/input/syntax/src/structural-type.ts
@@ -1,0 +1,9 @@
+export function foo(): Promise<{ member: number }> {
+  return Promise.resolve({ member: 42 })
+}
+export function bar(): Promise<number> {
+  return foo().then(x => x.member)
+}
+export function bar2(): Promise<number> {
+  return foo().then(({ member }) => member)
+}

--- a/snapshots/input/syntax/src/structural-type.ts
+++ b/snapshots/input/syntax/src/structural-type.ts
@@ -7,3 +7,8 @@ export function bar(): Promise<number> {
 export function bar2(): Promise<number> {
   return foo().then(({ member }) => member)
 }
+
+type OptionsFlags<Type> = { [Property in keyof Type]: boolean }
+type FeatureFlags = { darkMode: () => void }
+export type FeatureOptions = OptionsFlags<FeatureFlags> // implicitly // type FeatureOptions = { // darkMode: boolean; // } const fo: FeatureOptions = { darkMode: true }; // ^ go to def
+export const fo: FeatureOptions = { darkMode: true }

--- a/snapshots/input/syntax/src/typings.d.ts
+++ b/snapshots/input/syntax/src/typings.d.ts
@@ -1,0 +1,5 @@
+declare var window: Window & typeof globalThis
+interface Window {
+  process: any
+  require: any
+}

--- a/snapshots/input/syntax/src/typings.ts
+++ b/snapshots/input/syntax/src/typings.ts
@@ -1,0 +1,3 @@
+export function process() {
+  return window.process
+}

--- a/snapshots/output/react/src/LoaderInput.tsx
+++ b/snapshots/output/react/src/LoaderInput.tsx
@@ -26,9 +26,14 @@
 //                                ^^^^^^^^^^^^^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/FunctionComponent#
 //                                                  ^^^^^ reference react-example 1.0.0 src/`LoaderInput.tsx`/Props#
     loading,
-//  ^^^^^^^ reference local 3
+//  ^^^^^^^ definition local 3
+//  documentation ```ts\n(parameter) loading: boolean\n```
+//  ^^^^^^^ reference react-example 1.0.0 src/`LoaderInput.tsx`/Props#loading.
     children,
-//  ^^^^^^^^ reference local 4
+//  ^^^^^^^^ definition local 4
+//  documentation ```ts\n(parameter) children: ReactNode\n```
+//  ^^^^^^^^ reference react-example 1.0.0 src/`LoaderInput.tsx`/Props#children.
+//  ^^^^^^^^ reference local 7
   }) => (
     <div className="hello">
 //   ^^^ reference @types/react 17.0.0 `index.d.ts`/global/JSX/IntrinsicElements#div.
@@ -49,15 +54,15 @@
 //                           ^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/
 //                                 ^^^^^^^^^^^^^^^^^ reference @types/react 17.0.0 `index.d.ts`/React/FunctionComponent#
 //                                                   ^^^^^ reference react-example 1.0.0 src/`LoaderInput.tsx`/Props#
-//                                                            ^^^^^ definition local 6
+//                                                            ^^^^^ definition local 9
 //                                                            documentation ```ts\n(parameter) props: PropsWithChildren<Props>\n```
     return <LoaderInput loading={true} key="key" children={props.children} />
 //          ^^^^^^^^^^^ reference react-example 1.0.0 src/`LoaderInput.tsx`/LoaderInput.
 //                      ^^^^^^^ reference react-example 1.0.0 src/`LoaderInput.tsx`/Props#loading.
-//                                     ^^^ reference local 10
+//                                     ^^^ reference local 13
 //                                               ^^^^^^^^ reference react-example 1.0.0 src/`LoaderInput.tsx`/Props#children.
-//                                                         ^^^^^ reference local 6
+//                                                         ^^^^^ reference local 9
 //                                                               ^^^^^^^^ reference react-example 1.0.0 src/`LoaderInput.tsx`/Props#children.
-//                                                               ^^^^^^^^ reference local 13
+//                                                               ^^^^^^^^ reference local 7
   }
   

--- a/snapshots/output/syntax/src/destructuring.ts
+++ b/snapshots/output/syntax/src/destructuring.ts
@@ -95,3 +95,14 @@
     return 1
   }
   
+  export function parameterDestructuring({ a }: Props): number {
+//                ^^^^^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`destructuring.ts`/parameterDestructuring().
+//                documentation ```ts\nfunction parameterDestructuring({ a }: Props): number\n```
+//                                         ^ definition local 50
+//                                         documentation ```ts\n(parameter) a: number\n```
+//                                         ^ reference syntax 1.0.0 src/`destructuring.ts`/Props#a.
+//                                              ^^^^^ reference syntax 1.0.0 src/`destructuring.ts`/Props#
+    return a
+//         ^ reference local 50
+  }
+  

--- a/snapshots/output/syntax/src/destructuring.ts
+++ b/snapshots/output/syntax/src/destructuring.ts
@@ -1,0 +1,97 @@
+  interface Props {
+// definition syntax 1.0.0 src/`destructuring.ts`/
+//documentation ```ts\nmodule "destructuring.ts"\n```
+//          ^^^^^ definition syntax 1.0.0 src/`destructuring.ts`/Props#
+//          documentation ```ts\ninterface Props\n```
+    a: number
+//  ^ definition syntax 1.0.0 src/`destructuring.ts`/Props#a.
+//  documentation ```ts\n(property) a: number\n```
+  }
+  const props: Props = { a: 42 }
+//      ^^^^^ definition syntax 1.0.0 src/`destructuring.ts`/props.
+//      documentation ```ts\nvar props: Props\n```
+//             ^^^^^ reference syntax 1.0.0 src/`destructuring.ts`/Props#
+//                       ^ definition syntax 1.0.0 src/`destructuring.ts`/a0:
+//                       documentation ```ts\n(property) a: number\n```
+//                       relationship implementation reference scip-typescript npm syntax 1.0.0 src/`destructuring.ts`/Props#a.
+  
+  export function objectDestructuring(): number[] {
+//                ^^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`destructuring.ts`/objectDestructuring().
+//                documentation ```ts\nfunction objectDestructuring(): number[]\n```
+    const { a: b } = props
+//          ^ reference syntax 1.0.0 src/`destructuring.ts`/Props#a.
+//             ^ definition local 4
+//             documentation ```ts\nvar b: number\n```
+//                   ^^^^^ reference syntax 1.0.0 src/`destructuring.ts`/props.
+    return [props].map(({ a }) => a + b)
+//          ^^^^^ reference syntax 1.0.0 src/`destructuring.ts`/props.
+//                 ^^^ reference typescript 4.8.4 lib/`lib.es5.d.ts`/Array#map().
+//                        ^ definition local 10
+//                        documentation ```ts\n(parameter) a: number\n```
+//                        ^ reference syntax 1.0.0 src/`destructuring.ts`/Props#a.
+//                                ^ reference local 10
+//                                    ^ reference local 4
+  }
+  
+  export function arrayDestructuring(): number[] {
+//                ^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`destructuring.ts`/arrayDestructuring().
+//                documentation ```ts\nfunction arrayDestructuring(): number[]\n```
+    const [b] = [props]
+//         ^ definition local 15
+//         documentation ```ts\nvar b: Props\n```
+//               ^^^^^ reference syntax 1.0.0 src/`destructuring.ts`/props.
+    return [[b]].map(([a]) => a.a)
+//           ^ reference local 15
+//               ^^^ reference typescript 4.8.4 lib/`lib.es5.d.ts`/Array#map().
+//                     ^ definition local 21
+//                     documentation ```ts\n(parameter) a: Props\n```
+//                            ^ reference local 21
+//                              ^ reference syntax 1.0.0 src/`destructuring.ts`/Props#a.
+  }
+  
+  export function nestedDestructuring(): number[] {
+//                ^^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`destructuring.ts`/nestedDestructuring().
+//                documentation ```ts\nfunction nestedDestructuring(): number[]\n```
+    const [[b]] = [[props]]
+//          ^ definition local 28
+//          documentation ```ts\nvar b: Props\n```
+//                  ^^^^^ reference syntax 1.0.0 src/`destructuring.ts`/props.
+    return [[props]].map(([{ a }]) => a + b.a)
+//           ^^^^^ reference syntax 1.0.0 src/`destructuring.ts`/props.
+//                   ^^^ reference typescript 4.8.4 lib/`lib.es5.d.ts`/Array#map().
+//                           ^ definition local 36
+//                           documentation ```ts\n(parameter) a: number\n```
+//                           ^ reference syntax 1.0.0 src/`destructuring.ts`/Props#a.
+//                                    ^ reference local 36
+//                                        ^ reference local 28
+//                                          ^ reference syntax 1.0.0 src/`destructuring.ts`/Props#a.
+  }
+  
+  export function forLoopObjectDestructuring(): number {
+//                ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`destructuring.ts`/forLoopObjectDestructuring().
+//                documentation ```ts\nfunction forLoopObjectDestructuring(): number\n```
+    for (const { a } of [props]) {
+//               ^ definition local 41
+//               documentation ```ts\nvar a: number\n```
+//               ^ reference syntax 1.0.0 src/`destructuring.ts`/Props#a.
+//                       ^^^^^ reference syntax 1.0.0 src/`destructuring.ts`/props.
+      return a
+//           ^ reference local 41
+    }
+    return 1
+  }
+  
+  export function forLoopArrayDestructuring(): number {
+//                ^^^^^^^^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`destructuring.ts`/forLoopArrayDestructuring().
+//                documentation ```ts\nfunction forLoopArrayDestructuring(): number\n```
+    for (const [{ a }] of [[props]]) {
+//                ^ definition local 48
+//                documentation ```ts\nvar a: number\n```
+//                ^ reference syntax 1.0.0 src/`destructuring.ts`/Props#a.
+//                          ^^^^^ reference syntax 1.0.0 src/`destructuring.ts`/props.
+      return a
+//           ^ reference local 48
+    }
+    return 1
+  }
+  

--- a/snapshots/output/syntax/src/structural-type.ts
+++ b/snapshots/output/syntax/src/structural-type.ts
@@ -1,0 +1,56 @@
+  export function foo(): Promise<{ member: number }> {
+// definition syntax 1.0.0 src/`structural-type.ts`/
+//documentation ```ts\nmodule "structural-type.ts"\n```
+//                ^^^ definition syntax 1.0.0 src/`structural-type.ts`/foo().
+//                documentation ```ts\nfunction foo(): Promise<{ member: number; }>\n```
+//                       ^^^^^^^ reference typescript 4.8.4 lib/`lib.es5.d.ts`/Promise#
+//                       ^^^^^^^ reference typescript 4.8.4 lib/`lib.es2015.iterable.d.ts`/Promise#
+//                       ^^^^^^^ reference typescript 4.8.4 lib/`lib.es2015.promise.d.ts`/Promise.
+//                       ^^^^^^^ reference typescript 4.8.4 lib/`lib.es2015.symbol.wellknown.d.ts`/Promise#
+//                       ^^^^^^^ reference typescript 4.8.4 lib/`lib.es2018.promise.d.ts`/Promise#
+//                                 ^^^^^^ definition syntax 1.0.0 src/`structural-type.ts`/foo().Promise:typeLiteral0:member.
+//                                 documentation ```ts\n(property) member: number\n```
+    return Promise.resolve({ member: 42 })
+//         ^^^^^^^ reference typescript 4.8.4 lib/`lib.es5.d.ts`/Promise#
+//         ^^^^^^^ reference typescript 4.8.4 lib/`lib.es2015.iterable.d.ts`/Promise#
+//         ^^^^^^^ reference typescript 4.8.4 lib/`lib.es2015.promise.d.ts`/Promise.
+//         ^^^^^^^ reference typescript 4.8.4 lib/`lib.es2015.symbol.wellknown.d.ts`/Promise#
+//         ^^^^^^^ reference typescript 4.8.4 lib/`lib.es2018.promise.d.ts`/Promise#
+//                 ^^^^^^^ reference typescript 4.8.4 lib/`lib.es2015.promise.d.ts`/PromiseConstructor#resolve().
+//                 ^^^^^^^ reference typescript 4.8.4 lib/`lib.es2015.promise.d.ts`/PromiseConstructor#resolve().
+//                           ^^^^^^ definition syntax 1.0.0 src/`structural-type.ts`/member0:
+//                           documentation ```ts\n(property) member: number\n```
+  }
+  export function bar(): Promise<number> {
+//                ^^^ definition syntax 1.0.0 src/`structural-type.ts`/bar().
+//                documentation ```ts\nfunction bar(): Promise<number>\n```
+//                       ^^^^^^^ reference typescript 4.8.4 lib/`lib.es5.d.ts`/Promise#
+//                       ^^^^^^^ reference typescript 4.8.4 lib/`lib.es2015.iterable.d.ts`/Promise#
+//                       ^^^^^^^ reference typescript 4.8.4 lib/`lib.es2015.promise.d.ts`/Promise.
+//                       ^^^^^^^ reference typescript 4.8.4 lib/`lib.es2015.symbol.wellknown.d.ts`/Promise#
+//                       ^^^^^^^ reference typescript 4.8.4 lib/`lib.es2018.promise.d.ts`/Promise#
+    return foo().then(x => x.member)
+//         ^^^ reference syntax 1.0.0 src/`structural-type.ts`/foo().
+//               ^^^^ reference typescript 4.8.4 lib/`lib.es5.d.ts`/Promise#then().
+//                    ^ definition local 4
+//                    documentation ```ts\n(parameter) x: { member: number; }\n```
+//                         ^ reference local 4
+//                           ^^^^^^ reference syntax 1.0.0 src/`structural-type.ts`/foo().Promise:typeLiteral0:member.
+  }
+  export function bar2(): Promise<number> {
+//                ^^^^ definition syntax 1.0.0 src/`structural-type.ts`/bar2().
+//                documentation ```ts\nfunction bar2(): Promise<number>\n```
+//                        ^^^^^^^ reference typescript 4.8.4 lib/`lib.es5.d.ts`/Promise#
+//                        ^^^^^^^ reference typescript 4.8.4 lib/`lib.es2015.iterable.d.ts`/Promise#
+//                        ^^^^^^^ reference typescript 4.8.4 lib/`lib.es2015.promise.d.ts`/Promise.
+//                        ^^^^^^^ reference typescript 4.8.4 lib/`lib.es2015.symbol.wellknown.d.ts`/Promise#
+//                        ^^^^^^^ reference typescript 4.8.4 lib/`lib.es2018.promise.d.ts`/Promise#
+    return foo().then(({ member }) => member)
+//         ^^^ reference syntax 1.0.0 src/`structural-type.ts`/foo().
+//               ^^^^ reference typescript 4.8.4 lib/`lib.es5.d.ts`/Promise#then().
+//                       ^^^^^^ definition local 10
+//                       documentation ```ts\n(parameter) member: number\n```
+//                       ^^^^^^ reference syntax 1.0.0 src/`structural-type.ts`/foo().Promise:typeLiteral0:member.
+//                                    ^^^^^^ reference local 10
+  }
+  

--- a/snapshots/output/syntax/src/structural-type.ts
+++ b/snapshots/output/syntax/src/structural-type.ts
@@ -54,3 +54,28 @@
 //                                    ^^^^^^ reference local 10
   }
   
+  type OptionsFlags<Type> = { [Property in keyof Type]: boolean }
+//     ^^^^^^^^^^^^ definition syntax 1.0.0 src/`structural-type.ts`/OptionsFlags#
+//     documentation ```ts\ntype OptionsFlags\n```
+//                  ^^^^ definition syntax 1.0.0 src/`structural-type.ts`/OptionsFlags#[Type]
+//                  documentation ```ts\nType: Type\n```
+//                             ^^^^^^^^ definition local 12
+//                             documentation ```ts\nProperty: Property\n```
+//                                               ^^^^ reference syntax 1.0.0 src/`structural-type.ts`/OptionsFlags#[Type]
+  type FeatureFlags = { darkMode: () => void }
+//     ^^^^^^^^^^^^ definition syntax 1.0.0 src/`structural-type.ts`/FeatureFlags#
+//     documentation ```ts\ntype FeatureFlags\n```
+//                      ^^^^^^^^ definition syntax 1.0.0 src/`structural-type.ts`/FeatureFlags#typeLiteral13:darkMode.
+//                      documentation ```ts\n(property) darkMode: () => void\n```
+  export type FeatureOptions = OptionsFlags<FeatureFlags> // implicitly // type FeatureOptions = { // darkMode: boolean; // } const fo: FeatureOptions = { darkMode: true }; // ^ go to def
+//            ^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`structural-type.ts`/FeatureOptions#
+//            documentation ```ts\ntype FeatureOptions\n```
+//                             ^^^^^^^^^^^^ reference syntax 1.0.0 src/`structural-type.ts`/OptionsFlags#
+//                                          ^^^^^^^^^^^^ reference syntax 1.0.0 src/`structural-type.ts`/FeatureFlags#
+  export const fo: FeatureOptions = { darkMode: true }
+//             ^^ definition syntax 1.0.0 src/`structural-type.ts`/fo.
+//             documentation ```ts\nvar fo: OptionsFlags<FeatureFlags>\n```
+//                 ^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`structural-type.ts`/FeatureOptions#
+//                                    ^^^^^^^^ definition syntax 1.0.0 src/`structural-type.ts`/darkMode0:
+//                                    documentation ```ts\n(property) darkMode: true\n```
+  

--- a/snapshots/output/syntax/src/typings.ts
+++ b/snapshots/output/syntax/src/typings.ts
@@ -1,0 +1,11 @@
+  export function process() {
+// definition syntax 1.0.0 src/`typings.ts`/
+//documentation ```ts\nmodule "typings.ts"\n```
+//                ^^^^^^^ definition syntax 1.0.0 src/`typings.ts`/process().
+//                documentation ```ts\nfunction process(): Process\n```
+    return window.process
+//         ^^^^^^ reference typescript 4.8.4 lib/`lib.dom.d.ts`/window.
+//                ^^^^^^^ reference @types/node 17.0.14 `globals.d.ts`/process.
+//                ^^^^^^^ reference @types/node 17.0.14 `process.d.ts`/`'process'`/global/process.
+  }
+  

--- a/src/FileIndexer.ts
+++ b/src/FileIndexer.ts
@@ -143,11 +143,11 @@ export class FileIndexer {
    * ```
    */
   private handleObjectBindingPattern(node: ts.Node, range: number[]): void {
-    if (
-      !ts.isIdentifier(node) ||
-      !ts.isBindingElement(node.parent) ||
-      !ts.isObjectBindingPattern(node.parent.parent)
-    ) {
+    const isObjectBindingPatternProperty =
+      ts.isIdentifier(node) &&
+      ts.isBindingElement(node.parent) &&
+      ts.isObjectBindingPattern(node.parent.parent)
+    if (!isObjectBindingPatternProperty) {
       return
     }
     const tpe = this.checker.getTypeAtLocation(node.parent.parent)

--- a/src/FileIndexer.ts
+++ b/src/FileIndexer.ts
@@ -110,6 +110,7 @@ export class FileIndexer {
     }
     for (const declaration of sym?.declarations || []) {
       const lsifSymbol = this.lsifSymbol(declaration)
+
       if (lsifSymbol.isEmpty()) {
         // Skip empty symbols
         continue
@@ -124,9 +125,44 @@ export class FileIndexer {
       if (isDefinition) {
         this.addSymbolInformation(node, sym, declaration, lsifSymbol)
         this.handleShorthandPropertyDefinition(declaration, range)
+        this.handleObjectBindingPattern(node, range)
         // Only emit one symbol for definitions sites, see https://github.com/sourcegraph/lsif-typescript/issues/45
         break
       }
+    }
+  }
+
+  /**
+   * Emits an additional definition occurrence when destructuring an object
+   * pattern. For example:
+   * ```
+   * interface Props { property: number}
+   * const props: Props[] = [{ property: 42 }]
+   * props.map(({property}) => property) = {a}
+   * //          ^^^^^^^^ references `Props.property` and defines a local parameter `property`
+   * ```
+   */
+  private handleObjectBindingPattern(node: ts.Node, range: number[]): void {
+    if (
+      !ts.isIdentifier(node) ||
+      !ts.isBindingElement(node.parent) ||
+      !ts.isObjectBindingPattern(node.parent.parent)
+    ) {
+      return
+    }
+    const tpe = this.checker.getTypeAtLocation(node.parent.parent)
+    const property = tpe.getProperty(node.getText())
+    for (const declaration of property?.declarations || []) {
+      const lsifSymbol = this.lsifSymbol(declaration)
+      if (lsifSymbol.isEmpty()) {
+        continue
+      }
+      this.document.occurrences.push(
+        new lsif.lib.codeintel.lsiftyped.Occurrence({
+          range,
+          symbol: lsifSymbol.value,
+        })
+      )
     }
   }
 
@@ -141,29 +177,29 @@ export class FileIndexer {
    * //          ^ reference to the property `a`, not the local const
    * ```
    */
-
   private handleShorthandPropertyDefinition(
     declaration: ts.Node,
     range: number[]
   ): void {
-    if (declaration.kind === ts.SyntaxKind.ShorthandPropertyAssignment) {
-      const valueSymbol =
-        this.checker.getShorthandAssignmentValueSymbol(declaration)
-      if (!valueSymbol) {
-        return
+    if (declaration.kind !== ts.SyntaxKind.ShorthandPropertyAssignment) {
+      return
+    }
+    const valueSymbol =
+      this.checker.getShorthandAssignmentValueSymbol(declaration)
+    if (!valueSymbol) {
+      return
+    }
+    for (const symbol of valueSymbol?.declarations || []) {
+      const lsifSymbol = this.lsifSymbol(symbol)
+      if (lsifSymbol.isEmpty()) {
+        continue
       }
-      for (const symbol of valueSymbol?.declarations || []) {
-        const lsifSymbol = this.lsifSymbol(symbol)
-        if (lsifSymbol.isEmpty()) {
-          continue
-        }
-        this.document.occurrences.push(
-          new lsif.lib.codeintel.lsiftyped.Occurrence({
-            range,
-            symbol: lsifSymbol.value,
-          })
-        )
-      }
+      this.document.occurrences.push(
+        new lsif.lib.codeintel.lsiftyped.Occurrence({
+          range,
+          symbol: lsifSymbol.value,
+        })
+      )
     }
   }
 
@@ -249,6 +285,7 @@ export class FileIndexer {
   }
   private declarationName(node: ts.Node): ts.Node | undefined {
     if (
+      ts.isBindingElement(node) ||
       ts.isEnumDeclaration(node) ||
       ts.isEnumMember(node) ||
       ts.isVariableDeclaration(node) ||
@@ -420,6 +457,12 @@ export class FileIndexer {
     }
     if (ts.isTypeParameterDeclaration(node)) {
       return typeParameterDescriptor(node.name.getText())
+    }
+    if (ts.isTypeReferenceNode(node)) {
+      return metaDescriptor(node.typeName.getText())
+    }
+    if (ts.isTypeLiteralNode(node)) {
+      return metaDescriptor('typeLiteral' + this.localCounter.next().toString())
     }
     return undefined
   }


### PR DESCRIPTION
Previously, scip-typescript didn't emit appropriate occurrences for `property` in the destructuring pattern below:
```ts
interface Props { property: number }
const prop = { property: 42 }
const { property } = prop
//      ^^^^^^^^ before: was a local reference
//               now: local definition + global reference
```
The solution works similarly to how to handle shorthand property definitions.

### Test plan

See the updated snapshot tests.
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
