### PR TITLE
chore: Fix .gitignore to ignore .scip test outputs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ dist
 node_modules
 .eslintcache
 yarn-error.log
-snapshots/output/**/*.lsif-typed
+snapshots/output/**/*.scip


### PR DESCRIPTION
### Test plan

n/a