### PR TITLE
Don't emit duplicate subsequent occurrences

### DIFF
--- a/snapshots/output/pure-js/src/main.js
+++ b/snapshots/output/pure-js/src/main.js
@@ -68,7 +68,6 @@
   print_fib(a)
 //^^^^^^^^^ reference pure-js 1.0.0 src/`main.js`/print_fib().
 //          ^ reference pure-js 1.0.0 src/`main.js`/a.
-//          ^ reference pure-js 1.0.0 src/`main.js`/a.
   
   function forever() {
 //         ^^^^^^^ definition pure-js 1.0.0 src/`main.js`/forever().

--- a/snapshots/output/syntax/src/local.ts
+++ b/snapshots/output/syntax/src/local.ts
@@ -37,8 +37,6 @@
 //          ^ reference local 8
 //             ^^ reference local 9
 //                 ^^^^^^ reference typescript 4.8.4 lib/`lib.es5.d.ts`/Array#reduce().
-//                 ^^^^^^ reference typescript 4.8.4 lib/`lib.es5.d.ts`/Array#reduce().
-//                 ^^^^^^ reference typescript 4.8.4 lib/`lib.es5.d.ts`/Array#reduce().
 //                         ^^^^^^^^^^^^^ definition local 16
 //                         documentation ```ts\n(parameter) previousValue: string\n```
 //                                        ^^^^^^^^^^^^ definition local 17

--- a/snapshots/output/syntax/src/structural-type.ts
+++ b/snapshots/output/syntax/src/structural-type.ts
@@ -17,7 +17,6 @@
 //         ^^^^^^^ reference typescript 4.8.4 lib/`lib.es2015.symbol.wellknown.d.ts`/Promise#
 //         ^^^^^^^ reference typescript 4.8.4 lib/`lib.es2018.promise.d.ts`/Promise#
 //                 ^^^^^^^ reference typescript 4.8.4 lib/`lib.es2015.promise.d.ts`/PromiseConstructor#resolve().
-//                 ^^^^^^^ reference typescript 4.8.4 lib/`lib.es2015.promise.d.ts`/PromiseConstructor#resolve().
 //                           ^^^^^^ definition syntax 1.0.0 src/`structural-type.ts`/member0:
 //                           documentation ```ts\n(property) member: number\n```
   }

--- a/src/FileIndexer.ts
+++ b/src/FileIndexer.ts
@@ -45,7 +45,7 @@ export class FileIndexer {
     if (symbol.isEmpty()) {
       return
     }
-    this.document.occurrences.push(
+    this.pushOccurrence(
       new scip.scip.Occurrence({
         range: [0, 0, 0],
         symbol: symbol.value,
@@ -111,7 +111,7 @@ export class FileIndexer {
         // Skip empty symbols
         continue
       }
-      this.document.occurrences.push(
+      this.pushOccurrence(
         new scip.scip.Occurrence({
           range,
           symbol: scipSymbol.value,
@@ -153,7 +153,7 @@ export class FileIndexer {
       if (scipSymbol.isEmpty()) {
         continue
       }
-      this.document.occurrences.push(
+      this.pushOccurrence(
         new scip.scip.Occurrence({
           range,
           symbol: scipSymbol.value,
@@ -190,7 +190,7 @@ export class FileIndexer {
       if (scipSymbol.isEmpty()) {
         continue
       }
-      this.document.occurrences.push(
+      this.pushOccurrence(
         new scip.scip.Occurrence({
           range,
           symbol: scipSymbol.value,
@@ -225,6 +225,17 @@ export class FileIndexer {
         relationships: this.relationships(declaration, symbol),
       })
     )
+  }
+
+  private pushOccurrence(occurrence: scip.scip.Occurrence): void {
+    if (this.document.occurrences.length > 0) {
+      const lastOccurrence =
+        this.document.occurrences[this.document.occurrences.length - 1]
+      if (isEqualOccurrence(lastOccurrence, occurrence)) {
+        return
+      }
+    }
+    this.document.occurrences.push(occurrence)
   }
 
   private relationships(
@@ -672,4 +683,27 @@ function scriptElementKind(
     return ts.ScriptElementKind.memberVariableElement
   }
   return ts.ScriptElementKind.unknown
+}
+
+function isEqualOccurrence(
+  a: scip.scip.Occurrence,
+  b: scip.scip.Occurrence
+): boolean {
+  return (
+    a.symbol_roles === b.symbol_roles &&
+    a.symbol === b.symbol &&
+    isEqualArray(a.range, b.range)
+  )
+}
+
+function isEqualArray<T>(a: T[], b: T[]): boolean {
+  if (a.length !== b.length) {
+    return false
+  }
+  for (let index = 0; index < a.length; index++) {
+    if (a[index] !== b[index]) {
+      return false
+    }
+  }
+  return true
 }


### PR DESCRIPTION
Fixes #152. Supersedes #192. This fix doesn't prevent duplicate non-subsequent occurrences but that's fine because there are no functional differences between having more than one identical occurrences. It's still desirable to skip duplicate occurrences because 1) it makes the snapshot tests easier to review and 2) reduces the final index size, although I suspect it won't make a practical difference for the payload size.

### Test plan

See updated snapshot tests.
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
