### PR TITLE
codeintel: add ignore-engines based on yarn version

### DIFF
--- a/dev/lenient-yarn.sh
+++ b/dev/lenient-yarn.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 set -eux
 
+ADDITIONAL_ARGS="--ignore-engines"
+if [ "$(/usr/local/bin/actual-yarn --version | cut -d'.' -f1)" -gt 1 ]; then
+	ADDITIONAL_ARGS=""
+fi
+
 if [ $# -gt 1 ] && [ "$1" == "install" ]; then
-	/usr/local/bin/actual-yarn "$@" || echo "scip-typescript: ignoring yarn install failure, will try to auto-index the project with partial dependency information"
+	/usr/local/bin/actual-yarn $ADDITIONAL_ARGS "$@" || echo "scip-typescript: ignoring yarn install failure, will try to auto-index the project with partial dependency information"
 else
-	/usr/local/bin/actual-yarn "$@"
+	/usr/local/bin/actual-yarn $ADDITIONAL_ARGS "$@"
 fi


### PR DESCRIPTION
Previously, auto-indexing would fail in projects using Yarn version greater than 1.x.x with the error `➤ YN0050: The --ignore-engines option is deprecated; engine checking isn't a core feature anymore`. Example in the sg/sg repo: https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/code-graph/indexes/TFNJRkluZGV4Ojk1Mjk=.

As determining the Yarn version can only be done reliably by invoking yarn (Im miffed about this), we have to move the check from `typescript.lua` inference script to runtime instead.

Related PR in sourcegraph/sourcegraph: https://github.com/sourcegraph/sourcegraph/pull/43592
### Test plan

Before, based on `typescript.lua`:
```
$ docker run -v (pwd):/data -ti --rm --entrypoint /bin/bash sourcegraph/scip-typescript:autoindex
bash-5.1# cd data
bash-5.1# yarn --ignore-engines
+ '[' 1 -gt 1 ']'
+ /usr/local/bin/actual-yarn --ignore-engines
➤ YN0050: The --ignore-engines option is deprecated; engine checking isn't a core feature anymore
```

After, based on new `typescript.lua`:
```
$ docker run -v (pwd):/data -ti --rm --entrypoint /bin/bash sourcegraph/scip-typescript:autoindex
bash-5.1# cd data
bash-5.1# yarn
+ ADDITIONAL_ARGS=--ignore-engines
++ /usr/local/bin/actual-yarn --version
++ cut -d. -f1
+ '[' 3 -gt 1 ']'
+ ADDITIONAL_ARGS=
+ '[' 0 -gt 1 ']'
+ /usr/local/bin/actual-yarn
➤ YN0065: Yarn will periodically gather anonymous telemetry: https://yarnpkg.com/advanced/telemetry
➤ YN0065: Run yarn config set --home enableTelemetry 0 to disable

➤ YN0000: ┌ Resolution step
➤ YN0000: └ Completed in 0s 340ms
➤ YN0000: ┌ Fetch step
➤ YN0000: └ Completed in 0s 501ms
➤ YN0000: ┌ Link step
➤ YN0000: └ Completed in 0s 852ms
➤ YN0000: Done in 2s 152ms
bash-5.1# 
```
