### PR TITLE
Fix bug where an interface definition had a conflicting symbol with a const in the same file

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -20,6 +20,12 @@ npm run update-snapshots
 
 Generate snapshots and update.
 
+## Skipping files/test for local development
+
+Search for the query `"Uncomment below if you want to skip` to find places where
+you can uncomment code to skip tests/files for a faster edit/test/debug feedback
+loop during local development.
+
 ## Snapshotting arbitrary projects
 
 ```sh

--- a/snapshots/input/syntax/src/conflicting-const-interface.ts
+++ b/snapshots/input/syntax/src/conflicting-const-interface.ts
@@ -1,2 +1,3 @@
 export const ConflictingConst = 42
 export interface ConflictingConst {}
+export class ImplementsConflictingConst implements ConflictingConst {}

--- a/snapshots/input/syntax/src/conflicting-const-interface.ts
+++ b/snapshots/input/syntax/src/conflicting-const-interface.ts
@@ -1,0 +1,2 @@
+export const ConflictingConst = 42
+export interface ConflictingConst {}

--- a/snapshots/output/pure-js/src/main.js
+++ b/snapshots/output/pure-js/src/main.js
@@ -106,7 +106,7 @@
     if (forever()) {
 //      ^^^^^^^ reference pure-js 1.0.0 src/`main.js`/forever().
       var k = 1
-//        ^ definition local 14
+//        ^ definition local 17
 //        documentation ```ts\nvar k: number\n```
     }
     print_fib(k)

--- a/snapshots/output/syntax/src/accessors.ts
+++ b/snapshots/output/syntax/src/accessors.ts
@@ -13,7 +13,7 @@
 //                ^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/C#_length.
     }
     set length(value: number) {
-//      ^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/C#`<get>length`().
+//      ^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/C#`<set>length`().
 //      documentation ```ts\nget length: number\n```
 //             ^^^^^ definition syntax 1.0.0 src/`accessors.ts`/C#`<set>length`().(value)
 //             documentation ```ts\n(parameter) value: number\n```
@@ -46,7 +46,7 @@
 //                ^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/D#_length.
     }
     public set length(value: number) {
-//             ^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#`<get>length`().
+//             ^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#`<set>length`().
 //             documentation ```ts\nget length: number\n```
 //                    ^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#`<set>length`().(value)
 //                    documentation ```ts\n(parameter) value: number\n```
@@ -65,7 +65,7 @@
 //                ^^^^^^^^^ reference syntax 1.0.0 src/`accessors.ts`/D#_capacity.
     }
     private set capacity(value: number) {
-//              ^^^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#`<get>capacity`().
+//              ^^^^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#`<set>capacity`().
 //              documentation ```ts\nget capacity: number\n```
 //                       ^^^^^ definition syntax 1.0.0 src/`accessors.ts`/D#`<set>capacity`().(value)
 //                       documentation ```ts\n(parameter) value: number\n```

--- a/snapshots/output/syntax/src/conflicting-const-interface.ts
+++ b/snapshots/output/syntax/src/conflicting-const-interface.ts
@@ -4,6 +4,12 @@
 //             ^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`conflicting-const-interface.ts`/ConflictingConst.
 //             documentation ```ts\ninterface ConflictingConst\n```
   export interface ConflictingConst {}
-//                 ^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`conflicting-const-interface.ts`/ConflictingConst.
+//                 ^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`conflicting-const-interface.ts`/ConflictingConst#
 //                 documentation ```ts\ninterface ConflictingConst\n```
+  export class ImplementsConflictingConst implements ConflictingConst {}
+//             ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`conflicting-const-interface.ts`/ImplementsConflictingConst#
+//             documentation ```ts\nclass ImplementsConflictingConst\n```
+//             relationship implementation scip-typescript npm syntax 1.0.0 src/`conflicting-const-interface.ts`/ConflictingConst#
+//                                                   ^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`conflicting-const-interface.ts`/ConflictingConst.
+//                                                   ^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`conflicting-const-interface.ts`/ConflictingConst#
   

--- a/snapshots/output/syntax/src/conflicting-const-interface.ts
+++ b/snapshots/output/syntax/src/conflicting-const-interface.ts
@@ -1,0 +1,9 @@
+  export const ConflictingConst = 42
+// definition syntax 1.0.0 src/`conflicting-const-interface.ts`/
+//documentation ```ts\nmodule "conflicting-const-interface.ts"\n```
+//             ^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`conflicting-const-interface.ts`/ConflictingConst.
+//             documentation ```ts\ninterface ConflictingConst\n```
+  export interface ConflictingConst {}
+//                 ^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`conflicting-const-interface.ts`/ConflictingConst.
+//                 documentation ```ts\ninterface ConflictingConst\n```
+  

--- a/src/FileIndexer.ts
+++ b/src/FileIndexer.ts
@@ -109,7 +109,14 @@ export class FileIndexer {
       role |= scip.scip.SymbolRole.Definition
     }
     const declarations = isDefinitionNode
-      ? [node.parent] // Don't emit ambiguous definition at definition-site
+      ? // Don't emit ambiguous definition at definition-site. You can reproduce
+        // ambiguous results by triggering "Go to definition" in VS Code on `Conflict`
+        // in the example below:
+        // export const Conflict = 42
+        // export interface Conflict {}
+        //                  ^^^^^^^^ "Go to definition" shows two results: const and interface.
+        // See https://github.com/sourcegraph/scip-typescript/pull/206 for more details.
+        [node.parent]
       : sym?.declarations || []
     for (const declaration of declarations) {
       const scipSymbol = this.scipSymbol(declaration)

--- a/src/FileIndexer.ts
+++ b/src/FileIndexer.ts
@@ -37,6 +37,9 @@ export class FileIndexer {
     this.workingDirectoryRegExp = new RegExp(options.cwd, 'g')
   }
   public index(): void {
+    // if (!this.sourceFile.fileName.includes('conflicting-const')) {
+    //   return
+    // }
     this.emitSourceFileOccurrence()
     this.visit(this.sourceFile)
   }
@@ -104,7 +107,10 @@ export class FileIndexer {
     if (isDefinitionNode) {
       role |= scip.scip.SymbolRole.Definition
     }
-    for (const declaration of sym?.declarations || []) {
+    const declarations = isDefinitionNode
+      ? [node.parent] // Don't emit ambiguous definition at definition-site
+      : sym?.declarations || []
+    for (const declaration of declarations) {
       const scipSymbol = this.scipSymbol(declaration)
 
       if (scipSymbol.isEmpty()) {

--- a/src/FileIndexer.ts
+++ b/src/FileIndexer.ts
@@ -37,6 +37,7 @@ export class FileIndexer {
     this.workingDirectoryRegExp = new RegExp(options.cwd, 'g')
   }
   public index(): void {
+    // Uncomment below if you want to skip certain files for local development.
     // if (!this.sourceFile.fileName.includes('conflicting-const')) {
     //   return
     // }

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -33,6 +33,9 @@ interface PackageJson {
   workspaces: string[]
 }
 for (const snapshotDirectory of snapshotDirectories) {
+  // if (!snapshotDirectory.includes('syntax')) {
+  //   continue
+  // }
   const inputRoot = join(inputDirectory, snapshotDirectory)
   const outputRoot = join(outputDirectory, snapshotDirectory)
   if (!fs.statSync(inputRoot).isDirectory()) {

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -33,6 +33,7 @@ interface PackageJson {
   workspaces: string[]
 }
 for (const snapshotDirectory of snapshotDirectories) {
+  // Uncomment below if you want to skip certain tests for local development.
   // if (!snapshotDirectory.includes('syntax')) {
   //   continue
   // }


### PR DESCRIPTION
Reported via Slack https://sourcegraph.slack.com/archives/CHXHX7XAS/p1668157176918589?thread_ts=1668128629.962219&cid=CHXHX7XAS


### Test plan
See the snapshot test for a minimized reproduction. I also manually verified the bug has been fixed by indexing microsoft/vscode with a local build and uploading the index to https://sourcegraph.com/github.com/microsoft/vscode@9984da1/-/blob/src/vs/workbench/services/workspaces/common/workspaceEditing.ts?L13:18#tab=implementations_typescript

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
