### PR TITLE
Update ChangeLog and bump version for releasing 0.3.4.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/scip-typescript",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "SCIP indexer for TypeScript and JavaScript",
   "publisher": "sourcegraph",
   "bin": "dist/src/main.js",


### PR DESCRIPTION
### Context

v.0.3.3 was released without a version bump in the `package.json`. We need to bump again to release the new version.
See failure here: https://github.com/sourcegraph/scip-typescript/actions/runs/3853453587/jobs/6566449835

### Test plan

Ran automated tests.
