### PR TITLE
Don't throw error when failing to parse tsconfig.json

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -41,6 +41,7 @@ First, make sure you are on the main branch and have no dirty changes.
 
 Next, run the `dev/bump-version` script to bump the version in package.json and
 push a git tag to trigger a CI job.
+
 ```
 ./dev/bump-version VERSION_TO_RELEASE
 # example: ./dev/bump-version 2.3.1

--- a/src/main.ts
+++ b/src/main.ts
@@ -196,9 +196,7 @@ function loadConfigFile(file: string): ts.ParsedCommandLine | undefined {
     errors.push(error)
   }
   if (errors.length > 0) {
-    console.log(
-      `error: ${ts.formatDiagnostics(errors, ts.createCompilerHost({}))}`
-    )
+    console.log(ts.formatDiagnostics(errors, ts.createCompilerHost({})))
     return undefined
   }
   return result

--- a/src/main.ts
+++ b/src/main.ts
@@ -132,7 +132,10 @@ function indexSingleProject(options: ProjectOptions, cache: GlobalCache): void {
         return
       }
     }
-    config = loadConfigFile(tsconfigFileName)
+    const loadedConfig = loadConfigFile(tsconfigFileName)
+    if (loadedConfig !== undefined) {
+      config = loadedConfig
+    }
   }
 
   for (const projectReference of config.projectReferences || []) {
@@ -155,7 +158,7 @@ if (require.main === module) {
   main()
 }
 
-function loadConfigFile(file: string): ts.ParsedCommandLine {
+function loadConfigFile(file: string): ts.ParsedCommandLine | undefined {
   const absolute = path.resolve(file)
 
   const readResult = ts.readConfigFile(absolute, path => ts.sys.readFile(path))
@@ -193,8 +196,10 @@ function loadConfigFile(file: string): ts.ParsedCommandLine {
     errors.push(error)
   }
   if (errors.length > 0) {
-    console.log({ absolute })
-    throw new Error(ts.formatDiagnostics(errors, ts.createCompilerHost({})))
+    console.log(
+      `error: ${ts.formatDiagnostics(errors, ts.createCompilerHost({}))}`
+    )
+    return undefined
   }
   return result
 }


### PR DESCRIPTION
Previously, `scip-typescript` failed fast if it failed to parse a single tsconfig.json file. Now, it prints out the error message and continues running instead.

### Test plan

Manually tested by running against a clean clone of sg/sg
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
