### PR TITLE
Gracefully handle incomplete package.json files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .eslintcache
 yarn-error.log
 snapshots/output/**/*.scip
+tsconfig.tsbuildinfo

--- a/snapshots/input/invalid-package-json/package.json
+++ b/snapshots/input/invalid-package-json/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "invalid-package-json",
+  "version": "1.0.0",
+  "description": "Example TS/JS project",
+  "main": "src/main.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "private": true,
+  "packageManager": "pnpm@7.20.0"
+}

--- a/snapshots/input/invalid-package-json/packages/a/package.json
+++ b/snapshots/input/invalid-package-json/packages/a/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@example/a",
+  "description": "Example TS/JS project",
+  "main": "src/a.ts",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/snapshots/input/invalid-package-json/packages/a/src/a.ts
+++ b/snapshots/input/invalid-package-json/packages/a/src/a.ts
@@ -1,0 +1,3 @@
+export function a(): string {
+  return ''
+}

--- a/snapshots/input/invalid-package-json/packages/a/tsconfig.json
+++ b/snapshots/input/invalid-package-json/packages/a/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": ".",
+    "outDir": "dist"
+  },
+  "include": ["src/*"]
+}

--- a/snapshots/input/invalid-package-json/packages/b/package.json
+++ b/snapshots/input/invalid-package-json/packages/b/package.json
@@ -1,0 +1,12 @@
+{
+  "description": "Example TS/JS project",
+  "main": "src/b.ts",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@example/a": "1.0.0"
+  }
+}

--- a/snapshots/input/invalid-package-json/packages/b/src/b.ts
+++ b/snapshots/input/invalid-package-json/packages/b/src/b.ts
@@ -1,0 +1,5 @@
+import { a } from '@example/a'
+
+export function b() {
+  return a()
+}

--- a/snapshots/input/invalid-package-json/packages/b/tsconfig.json
+++ b/snapshots/input/invalid-package-json/packages/b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": "./src",
+    "sourceRoot": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/*"],
+  "references": [{ "path": "../a" }]
+}

--- a/snapshots/input/invalid-package-json/pnpm-lock.yaml
+++ b/snapshots/input/invalid-package-json/pnpm-lock.yaml
@@ -1,0 +1,15 @@
+lockfileVersion: 5.4
+
+importers:
+
+  .:
+    specifiers: {}
+
+  packages/a:
+    specifiers: {}
+
+  packages/b:
+    specifiers:
+      '@example/a': 1.0.0
+    dependencies:
+      '@example/a': link:../a

--- a/snapshots/input/invalid-package-json/pnpm-workspace.yaml
+++ b/snapshots/input/invalid-package-json/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'packages/*'

--- a/snapshots/input/invalid-package-json/tsconfig.json
+++ b/snapshots/input/invalid-package-json/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "extends": "@sourcegraph/tsconfig",
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "allowJs": false,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "lib": ["esnext", "dom", "dom.iterable"],
+    "sourceMap": true,
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true,
+    "skipDefaultLibCheck": true,
+    "noErrorTruncation": true,
+    "importHelpers": true,
+    "resolveJsonModule": true,
+    "composite": true,
+    "outDir": "out",
+    "rootDir": "."
+  },
+  "include": [],
+  "exclude": ["out", "node_modules", "dist"]
+}

--- a/snapshots/output/invalid-package-json/packages/a/src/a.ts
+++ b/snapshots/output/invalid-package-json/packages/a/src/a.ts
@@ -1,0 +1,8 @@
+  export function a(): string {
+// definition @example/a HEAD src/`a.ts`/
+//documentation ```ts\nmodule "a.ts"\n```
+//                ^ definition @example/a HEAD src/`a.ts`/a().
+//                documentation ```ts\nfunction a(): string\n```
+    return ''
+  }
+  

--- a/src/FileIndexer.ts
+++ b/src/FileIndexer.ts
@@ -319,8 +319,8 @@ export class FileIndexer {
     }
     if (ts.isSourceFile(node)) {
       const package_ = this.packages.symbol(node.fileName)
-      if (!package_) {
-        return this.cached(node, ScipSymbol.empty())
+      if (package_.isEmpty()) {
+        return this.cached(node, ScipSymbol.anonymousPackage())
       }
       return this.cached(node, package_)
     }

--- a/src/Packages.ts
+++ b/src/Packages.ts
@@ -32,7 +32,8 @@ export class Packages {
         const version = packageJson.version
         if (typeof name === 'string' && typeof version === 'string') {
           return this.cached(filePath, ScipSymbol.package(name, version))
-        } else if (typeof name === 'string') {
+        }
+        if (typeof name === 'string') {
           // The version field is missing so we fallback to `"HEAD"`
           return this.cached(filePath, ScipSymbol.package(name, 'HEAD'))
         }

--- a/src/Packages.ts
+++ b/src/Packages.ts
@@ -32,29 +32,35 @@ export class Packages {
         const version = packageJson.version
         if (typeof name === 'string' && typeof version === 'string') {
           return this.cached(filePath, ScipSymbol.package(name, version))
+        } else if (typeof name === 'string') {
+          // The version field is missing so we fallback to `"HEAD"`
+          return this.cached(filePath, ScipSymbol.package(name, 'HEAD'))
         }
+        // Fallback to an anonymous package because we found a package.json but
+        // were unable to parse the name and version.
+        return this.cached(filePath, ScipSymbol.anonymousPackage())
       }
     } catch (error) {
       console.error(`error parsing ${packageJsonPath}`, error)
-      return this.cached(filePath, ScipSymbol.empty())
+      return this.cached(filePath, ScipSymbol.anonymousPackage())
     }
 
     if (filePath === this.projectRoot) {
-      return this.cached(filePath, ScipSymbol.empty())
+      // Don't look for package.json in a parent directory of the root.
+      return this.cached(filePath, ScipSymbol.anonymousPackage())
     }
 
     const dirname = path.dirname(filePath)
     if (dirname === filePath) {
-      return this.cached(filePath, ScipSymbol.empty())
+      // Avoid infinite recursion when `path.dirname(path) === path`
+      return this.cached(filePath, ScipSymbol.anonymousPackage())
     }
+
     const owner = this.symbol(dirname)
-    if (owner) {
-      return this.cached(
-        filePath,
-        ScipSymbol.global(owner, packageDescriptor(path.basename(filePath)))
-      )
-    }
-    return this.cached(filePath, ScipSymbol.empty())
+    return this.cached(
+      filePath,
+      ScipSymbol.global(owner, packageDescriptor(path.basename(filePath)))
+    )
   }
 
   private cached(filePath: string, sym: ScipSymbol): ScipSymbol {

--- a/src/ScipSymbol.ts
+++ b/src/ScipSymbol.ts
@@ -24,6 +24,10 @@ export class ScipSymbol {
     return new ScipSymbol(`scip-typescript npm ${name} ${version} `)
   }
 
+  public static anonymousPackage(): ScipSymbol {
+    return ScipSymbol.package('.', '.')
+  }
+
   public static global(
     owner: ScipSymbol,
     descriptor: scip.scip.Descriptor


### PR DESCRIPTION
Previously, scip-typescript didn't emit the required `scip-typescript npm PACKAGE_NAME PACKAGE_VERSION` prefix for global symbols when a package.json file was missing either the `name` or `version` field. Now, scip-typescript guarantees that all global symbols have this prefix. When the `version` field is missing, we fallback to the version `"HEAD"`.

### Test plan

Updated snapshot tests with e2e tests.
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
