### PR TITLE
Infer symbol relationship for object literals property in return statement

### DIFF
--- a/snapshots/input/syntax/src/infer-relationship.ts
+++ b/snapshots/input/syntax/src/infer-relationship.ts
@@ -2,7 +2,49 @@ interface Configuration {
   property: number
 }
 
+function random(): number {
+  return Math.random()
+}
 export function returnStatement(): Configuration {
+  if (random() > 0) {
+    return {
+      property: 41,
+    }
+  }
+  for (let i = 0; i < 9; i++) {
+    if (random() > i) {
+      return {
+        property: 41,
+      }
+    }
+  }
+  for (const i of [1, 2, 3]) {
+    if (random() > i) {
+      return {
+        property: 41,
+      }
+    }
+  }
+  for (const i in { '1': 2 }) {
+    if (random() > Number.parseInt(i)) {
+      return {
+        property: 41,
+      }
+    }
+  }
+  while (random() < 0) {
+    return {
+      property: 41,
+    }
+  }
+  do {
+    if (random() > 0) {
+      return {
+        property: 41,
+      }
+    }
+  } while (random() < 0)
+
   return {
     property: 42,
   }

--- a/snapshots/input/syntax/src/infer-relationship.ts
+++ b/snapshots/input/syntax/src/infer-relationship.ts
@@ -1,0 +1,18 @@
+interface Configuration {
+  property: number
+}
+
+export function returnStatement(): Configuration {
+  return {
+    property: 42,
+  }
+}
+
+export function returnStatementInsideArgumentExpression(): Configuration[] {
+  return [1].map<Configuration>(number => {
+    const incremented = number + 1
+    return {
+      property: incremented,
+    }
+  })
+}

--- a/snapshots/output/syntax/src/infer-relationship.ts
+++ b/snapshots/output/syntax/src/infer-relationship.ts
@@ -8,13 +8,105 @@
 //  documentation ```ts\n(property) property: number\n```
   }
   
+  function random(): number {
+//         ^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/random().
+//         documentation ```ts\nfunction random(): number\n```
+    return Math.random()
+//         ^^^^ reference typescript 4.8.4 lib/`lib.es5.d.ts`/Math#
+//         ^^^^ reference typescript 4.8.4 lib/`lib.es5.d.ts`/Math.
+//         ^^^^ reference typescript 4.8.4 lib/`lib.es2015.core.d.ts`/Math#
+//         ^^^^ reference typescript 4.8.4 lib/`lib.es2015.symbol.wellknown.d.ts`/Math#
+//              ^^^^^^ reference typescript 4.8.4 lib/`lib.es5.d.ts`/Math#random().
+  }
   export function returnStatement(): Configuration {
 //                ^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/returnStatement().
 //                documentation ```ts\nfunction returnStatement(): Configuration\n```
 //                                   ^^^^^^^^^^^^^ reference syntax 1.0.0 src/`infer-relationship.ts`/Configuration#
+    if (random() > 0) {
+//      ^^^^^^ reference syntax 1.0.0 src/`infer-relationship.ts`/random().
+      return {
+        property: 41,
+//      ^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/property0:
+//      documentation ```ts\n(property) property: number\n```
+//      relationship implementation reference scip-typescript npm syntax 1.0.0 src/`infer-relationship.ts`/Configuration#property.
+      }
+    }
+    for (let i = 0; i < 9; i++) {
+//           ^ definition local 2
+//           documentation ```ts\nvar i: number\n```
+//                  ^ reference local 2
+//                         ^ reference local 2
+      if (random() > i) {
+//        ^^^^^^ reference syntax 1.0.0 src/`infer-relationship.ts`/random().
+//                   ^ reference local 2
+        return {
+          property: 41,
+//        ^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/property1:
+//        documentation ```ts\n(property) property: number\n```
+//        relationship implementation reference scip-typescript npm syntax 1.0.0 src/`infer-relationship.ts`/Configuration#property.
+        }
+      }
+    }
+    for (const i of [1, 2, 3]) {
+//             ^ definition local 5
+//             documentation ```ts\nvar i: number\n```
+      if (random() > i) {
+//        ^^^^^^ reference syntax 1.0.0 src/`infer-relationship.ts`/random().
+//                   ^ reference local 5
+        return {
+          property: 41,
+//        ^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/property2:
+//        documentation ```ts\n(property) property: number\n```
+//        relationship implementation reference scip-typescript npm syntax 1.0.0 src/`infer-relationship.ts`/Configuration#property.
+        }
+      }
+    }
+    for (const i in { '1': 2 }) {
+//             ^ definition local 8
+//             documentation ```ts\nvar i: string\n```
+//                    ^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/`'1'0`:
+//                    documentation ```ts\n(property) '1': number\n```
+      if (random() > Number.parseInt(i)) {
+//        ^^^^^^ reference syntax 1.0.0 src/`infer-relationship.ts`/random().
+//                   ^^^^^^ reference typescript 4.8.4 lib/`lib.es5.d.ts`/Number#
+//                   ^^^^^^ reference typescript 4.8.4 lib/`lib.es5.d.ts`/Number.
+//                   ^^^^^^ reference typescript 4.8.4 lib/`lib.es5.d.ts`/Number#
+//                   ^^^^^^ reference typescript 4.8.4 lib/`lib.es2020.number.d.ts`/Number#
+//                          ^^^^^^^^ reference typescript 4.8.4 lib/`lib.es2015.core.d.ts`/NumberConstructor#parseInt().
+//                                   ^ reference local 8
+        return {
+          property: 41,
+//        ^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/property3:
+//        documentation ```ts\n(property) property: number\n```
+//        relationship implementation reference scip-typescript npm syntax 1.0.0 src/`infer-relationship.ts`/Configuration#property.
+        }
+      }
+    }
+    while (random() < 0) {
+//         ^^^^^^ reference syntax 1.0.0 src/`infer-relationship.ts`/random().
+      return {
+        property: 41,
+//      ^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/property4:
+//      documentation ```ts\n(property) property: number\n```
+//      relationship implementation reference scip-typescript npm syntax 1.0.0 src/`infer-relationship.ts`/Configuration#property.
+      }
+    }
+    do {
+      if (random() > 0) {
+//        ^^^^^^ reference syntax 1.0.0 src/`infer-relationship.ts`/random().
+        return {
+          property: 41,
+//        ^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/property5:
+//        documentation ```ts\n(property) property: number\n```
+//        relationship implementation reference scip-typescript npm syntax 1.0.0 src/`infer-relationship.ts`/Configuration#property.
+        }
+      }
+    } while (random() < 0)
+//           ^^^^^^ reference syntax 1.0.0 src/`infer-relationship.ts`/random().
+  
     return {
       property: 42,
-//    ^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/property0:
+//    ^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/property6:
 //    documentation ```ts\n(property) property: number\n```
 //    relationship implementation reference scip-typescript npm syntax 1.0.0 src/`infer-relationship.ts`/Configuration#property.
     }
@@ -27,17 +119,17 @@
     return [1].map<Configuration>(number => {
 //             ^^^ reference typescript 4.8.4 lib/`lib.es5.d.ts`/Array#map().
 //                 ^^^^^^^^^^^^^ reference syntax 1.0.0 src/`infer-relationship.ts`/Configuration#
-//                                ^^^^^^ definition local 3
+//                                ^^^^^^ definition local 12
 //                                documentation ```ts\n(parameter) number: number\n```
       const incremented = number + 1
-//          ^^^^^^^^^^^ definition local 6
+//          ^^^^^^^^^^^ definition local 15
 //          documentation ```ts\nvar incremented: number\n```
-//                        ^^^^^^ reference local 3
+//                        ^^^^^^ reference local 12
       return {
         property: incremented,
-//      ^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/property1:
+//      ^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/property7:
 //      documentation ```ts\n(property) property: number\n```
-//                ^^^^^^^^^^^ reference local 6
+//                ^^^^^^^^^^^ reference local 15
       }
     })
   }

--- a/snapshots/output/syntax/src/infer-relationship.ts
+++ b/snapshots/output/syntax/src/infer-relationship.ts
@@ -1,0 +1,44 @@
+  interface Configuration {
+// definition syntax 1.0.0 src/`infer-relationship.ts`/
+//documentation ```ts\nmodule "infer-relationship.ts"\n```
+//          ^^^^^^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/Configuration#
+//          documentation ```ts\ninterface Configuration\n```
+    property: number
+//  ^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/Configuration#property.
+//  documentation ```ts\n(property) property: number\n```
+  }
+  
+  export function returnStatement(): Configuration {
+//                ^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/returnStatement().
+//                documentation ```ts\nfunction returnStatement(): Configuration\n```
+//                                   ^^^^^^^^^^^^^ reference syntax 1.0.0 src/`infer-relationship.ts`/Configuration#
+    return {
+      property: 42,
+//    ^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/property0:
+//    documentation ```ts\n(property) property: number\n```
+//    relationship implementation reference scip-typescript npm syntax 1.0.0 src/`infer-relationship.ts`/Configuration#property.
+    }
+  }
+  
+  export function returnStatementInsideArgumentExpression(): Configuration[] {
+//                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/returnStatementInsideArgumentExpression().
+//                documentation ```ts\nfunction returnStatementInsideArgumentExpression(): Configuration[]\n```
+//                                                           ^^^^^^^^^^^^^ reference syntax 1.0.0 src/`infer-relationship.ts`/Configuration#
+    return [1].map<Configuration>(number => {
+//             ^^^ reference typescript 4.8.4 lib/`lib.es5.d.ts`/Array#map().
+//                 ^^^^^^^^^^^^^ reference syntax 1.0.0 src/`infer-relationship.ts`/Configuration#
+//                                ^^^^^^ definition local 3
+//                                documentation ```ts\n(parameter) number: number\n```
+      const incremented = number + 1
+//          ^^^^^^^^^^^ definition local 6
+//          documentation ```ts\nvar incremented: number\n```
+//                        ^^^^^^ reference local 3
+      return {
+        property: incremented,
+//      ^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/property1:
+//      documentation ```ts\n(property) property: number\n```
+//                ^^^^^^^^^^^ reference local 6
+      }
+    })
+  }
+  

--- a/snapshots/output/syntax/src/interface.ts
+++ b/snapshots/output/syntax/src/interface.ts
@@ -26,9 +26,11 @@
       property: 'a',
 //    ^^^^^^^^ definition syntax 1.0.0 src/`interface.ts`/property0:
 //    documentation ```ts\n(property) property: string\n```
+//    relationship implementation reference scip-typescript npm syntax 1.0.0 src/`interface.ts`/Interface#property.
       methodSignature(param: string): string {
 //    ^^^^^^^^^^^^^^^ definition local 4
 //    documentation ```ts\n(method) methodSignature(param: string): string\n```
+//    relationship implementation reference scip-typescript npm syntax 1.0.0 src/`interface.ts`/Interface#methodSignature().
 //                    ^^^^^ definition local 5
 //                    documentation ```ts\n(parameter) param: string\n```
         return param
@@ -37,6 +39,7 @@
       methodSignature2: (param: string): string => {
 //    ^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`interface.ts`/methodSignature20:
 //    documentation ```ts\n(property) methodSignature2: (param: string) => string\n```
+//    relationship implementation reference scip-typescript npm syntax 1.0.0 src/`interface.ts`/Interface#methodSignature2.
 //                       ^^^^^ definition local 7
 //                       documentation ```ts\n(parameter) param: string\n```
         return param

--- a/src/FileIndexer.ts
+++ b/src/FileIndexer.ts
@@ -598,7 +598,16 @@ export class FileIndexer {
     node: ts.Node,
     literal: ts.ObjectLiteralExpression
   ): ts.Type {
-    if (ts.isReturnStatement(node) || ts.isBlock(node)) {
+    if (
+      ts.isIfStatement(node) ||
+      ts.isForStatement(node) ||
+      ts.isForInStatement(node) ||
+      ts.isForOfStatement(node) ||
+      ts.isWhileStatement(node) ||
+      ts.isDoStatement(node) ||
+      ts.isReturnStatement(node) ||
+      ts.isBlock(node)
+    ) {
       return this.inferredTypeOfObjectLiteral(node.parent, literal)
     }
 


### PR DESCRIPTION
Previously, scip-typescript didn't infer correct relationships between the object literel property and interface property in return statements like below:

```ts
interface Configuration {
  property: number
}

export function returnStatement(): Configuration {
  return {
    property: 42,
  }
}
```

This commit fixes this specific issue. This commit also adds a test case for a situation where scip-typescript doesn't infer the relationship today but tsserver does. We should fix that in the future.

### Test plan

See updated snapshot tests.
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
