### PR TITLE
Skip indexing large files above 1mb, add option `--max-file-byte-size`

### DIFF
--- a/src/FileIndexer.ts
+++ b/src/FileIndexer.ts
@@ -15,6 +15,7 @@ import {
 } from './Descriptor'
 import { Input } from './Input'
 import { Packages } from './Packages'
+import { formatByteSizeAsHumanReadable } from './parseHumanByteSizeIntoNumber'
 import { Range } from './Range'
 import * as scip from './scip'
 import { ScipSymbol } from './ScipSymbol'
@@ -43,12 +44,19 @@ export class FileIndexer {
     //   return
     // }
 
+    const byteSize = Buffer.from(this.sourceFile.getText()).length
     if (
       this.options.maxFileByteSizeNumber &&
-      Buffer.from(this.sourceFile.getText()).length >
-        this.options.maxFileByteSizeNumber
+      byteSize > this.options.maxFileByteSizeNumber
     ) {
-      // Skip files that exceed the --max-file-byte-size threshold.
+      const humanSize = formatByteSizeAsHumanReadable(byteSize)
+      const humanMaxSize = formatByteSizeAsHumanReadable(
+        this.options.maxFileByteSizeNumber
+      )
+      console.log(
+        `info: skipping file '${this.sourceFile.fileName}' because it has byte size ${humanSize} that exceeds the maximum threshold ${humanMaxSize}. ` +
+          'If you intended to index this file, use the flag --max-file-byte-size to configure the maximum file size threshold.'
+      )
       return
     }
 

--- a/src/FileIndexer.ts
+++ b/src/FileIndexer.ts
@@ -42,6 +42,16 @@ export class FileIndexer {
     // if (!this.sourceFile.fileName.includes('constructor')) {
     //   return
     // }
+
+    if (
+      this.options.maxFileByteSizeNumber &&
+      Buffer.from(this.sourceFile.getText()).length >
+        this.options.maxFileByteSizeNumber
+    ) {
+      // Skip files that exceed the --max-file-byte-size threshold.
+      return
+    }
+
     this.emitSourceFileOccurrence()
     this.visit(this.sourceFile)
   }

--- a/src/parseHumanByteSizeIntoNumber.test.ts
+++ b/src/parseHumanByteSizeIntoNumber.test.ts
@@ -1,0 +1,37 @@
+import { test } from 'uvu'
+import * as assert from 'uvu/assert'
+
+import { parseHumanByteSizeIntoNumber } from './parseHumanByteSizeIntoNumber'
+
+function checkHumanByteSize(
+  humanInput: string,
+  expectedByteNumber: number
+): void {
+  test(humanInput, () => {
+    const obtained = parseHumanByteSizeIntoNumber(humanInput)
+    assert.equal(obtained, expectedByteNumber)
+  })
+}
+
+// Invalid formats
+checkHumanByteSize('invalid', NaN)
+checkHumanByteSize('15tb', NaN)
+checkHumanByteSize('15b', NaN)
+
+// All numeral
+checkHumanByteSize('1001', 1001)
+
+// All lowercase
+checkHumanByteSize('1.2kb', 1_200)
+checkHumanByteSize('1.2mb', 1_200_000)
+checkHumanByteSize('1.2gb', 1_200_000_000)
+
+// All uppercase
+checkHumanByteSize('1.2KB', 1_200)
+checkHumanByteSize('1.2MB', 1_200_000)
+checkHumanByteSize('1.2GB', 1_200_000_000)
+
+// Mixed case
+checkHumanByteSize('1.2Kb', 1_200)
+checkHumanByteSize('1.2Mb', 1_200_000)
+checkHumanByteSize('1.2Gb', 1_200_000_000)

--- a/src/parseHumanByteSizeIntoNumber.ts
+++ b/src/parseHumanByteSizeIntoNumber.ts
@@ -1,15 +1,32 @@
+const kilo = 1_000
+const mega = 1_000_000
+const giga = 1_000_000_000
+
 export function parseHumanByteSizeIntoNumber(humanByteSize: string): number {
   let value = humanByteSize.toLowerCase()
   let multiplier = 1
   if (value.endsWith('kb')) {
-    multiplier = 1000
+    multiplier = kilo
     value = value.slice(0, -2)
   } else if (value.endsWith('mb')) {
-    multiplier = 1000000
+    multiplier = mega
     value = value.slice(0, -2)
   } else if (value.endsWith('gb')) {
-    multiplier = 1000000000
+    multiplier = giga
     value = value.slice(0, -2)
   }
   return Number.parseFloat(value) * multiplier
+}
+
+export function formatByteSizeAsHumanReadable(byteSize: number): string {
+  if (byteSize > giga) {
+    return `${byteSize / giga}gb`
+  }
+  if (byteSize > mega) {
+    return `${byteSize / mega}mb`
+  }
+  if (byteSize > kilo) {
+    return `${byteSize / kilo}kb`
+  }
+  return byteSize.toString()
 }

--- a/src/parseHumanByteSizeIntoNumber.ts
+++ b/src/parseHumanByteSizeIntoNumber.ts
@@ -1,0 +1,15 @@
+export function parseHumanByteSizeIntoNumber(humanByteSize: string): number {
+  let value = humanByteSize.toLowerCase()
+  let multiplier = 1
+  if (value.endsWith('kb')) {
+    multiplier = 1000
+    value = value.slice(0, -2)
+  } else if (value.endsWith('mb')) {
+    multiplier = 1000000
+    value = value.slice(0, -2)
+  } else if (value.endsWith('gb')) {
+    multiplier = 1000000000
+    value = value.slice(0, -2)
+  }
+  return Number.parseFloat(value) * multiplier
+}


### PR DESCRIPTION
Previously, scip-typescript indexed all files regardless of file size. This could result in scip-typescript stalling progress to index very large files that were (frequently) auto-generated. This commit changes the default behavior to skip indexing files that are larger than 1mb, and makes this threshold configurable via the new `--max-file-byte-size` flag.

### Test plan

- New unit tests for the parse function
- Manually tested in the sourcegraph/sourcegraph repo with the command `❯ ts-node ~/dev/sourcegraph/scip-typescript/src/main.ts index --pnpm-workspaces --max-file-byte-size 500kb`. Printed out skipped files and confirmed they all exceeded 500kb.
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
