### PR TITLE
chore: Bump version again

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/scip-typescript",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "SCIP indexer for TypeScript and JavaScript",
   "publisher": "sourcegraph",
   "bin": "dist/src/main.js",


### PR DESCRIPTION
0.3.10 tag is already used by a non-release, see https://github.com/sourcegraph/scip-typescript/issues/301#issue-2053452354

### Test plan

Not applicable
