### PR TITLE
ci: Make release workflow more robust

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,37 @@ jobs:
   release-image:
     runs-on: ubuntu-latest
     steps:
+      - name: 'Check package.json in sync with tag'
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF/refs\/tags\//}"
+          PACKAGE_JSON_VERSION="$(jq -r '.version' package.json)"
+          if [[ "v$PACKAGE_JSON_VERSION" != "$TAG" ]]; then
+            echo "package.json version 'v$PACKAGE_JSON_VERSION' out of sync with tag '$TAG'"
+            echo "Run git tag --delete $TAG && git push --delete origin $TAG"
+            echo "Land a PR updating package.json, and re-tag the release"
+          fi
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build default Docker image
+        id: docker_build
+        uses: docker/build-push-action@v3
+        with:
+          push: false
+          tags: |
+            sourcegraph/scip-typescript:latest
+      - name: Build auto-indexing Docker image
+        id: docker_build_autoindex
+        uses: docker/build-push-action@v3
+        with:
+          file: Dockerfile.autoindex
+          push: false
+          tags: sourcegraph/scip-typescript:autoindex
       - uses: actions/setup-node@v3
         with:
           node-version: 20
@@ -20,27 +49,22 @@ jobs:
       - run: du -h dist/src/main.js
       - run: npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      - run: echo "PATCH=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
-      - run: echo "MINOR=${PATCH%.*}" >> $GITHUB_ENV
-      - run: echo "MAJOR=${MINOR%.*}" >> $GITHUB_ENV
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Build and push
-        id: docker_build
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: echo "PATCH=${GITHUB_REF/refs\/tags\//}" >> "$GITHUB_ENV"
+      - run: echo "MINOR=${PATCH%.*}" >> "$GITHUB_ENV"
+      - run: echo "MAJOR=${MINOR%.*}" >> "$GITHUB_ENV"
+      - name: Push default Docker image
+        id: docker_push
         uses: docker/build-push-action@v3
         with:
-          push: true
+          push: false
           tags: |
             sourcegraph/scip-typescript:latest
             sourcegraph/scip-typescript:${{ env.PATCH }}
             sourcegraph/scip-typescript:${{ env.MINOR }}
             sourcegraph/scip-typescript:${{ env.MAJOR }}
-      - name: Build and push
-        id: docker_build_autoindex
+      - name: Push auto-indexing Docker image
+        id: docker_push_autoindex
         uses: docker/build-push-action@v3
         with:
           file: Dockerfile.autoindex


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/scip-typescript/issues/301, https://github.com/sourcegraph/scip-typescript/issues/303

TODO: As-is, this workflow will build a container from an older release.
We should use `yarn pack` or similar, see the comments in https://github.com/sourcegraph/scip-typescript/issues/303


### Test plan

n/a
