### PR TITLE
test: Strip prefix from relationship symbol names

### DIFF
--- a/snapshots/output/syntax/src/conflicting-const-interface.ts
+++ b/snapshots/output/syntax/src/conflicting-const-interface.ts
@@ -6,7 +6,7 @@ export interface ConflictingConst {}
 //               ^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`conflicting-const-interface.ts`/ConflictingConst#
 export class ImplementsConflictingConst implements ConflictingConst {}
 //           ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`conflicting-const-interface.ts`/ImplementsConflictingConst#
-//           relationship implementation scip-typescript npm syntax 1.0.0 src/`conflicting-const-interface.ts`/ConflictingConst#
+//           relationship implementation syntax 1.0.0 src/`conflicting-const-interface.ts`/ConflictingConst#
 //                                                 ^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`conflicting-const-interface.ts`/ConflictingConst.
 //                                                 ^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`conflicting-const-interface.ts`/ConflictingConst#
 

--- a/snapshots/output/syntax/src/destructuring.ts
+++ b/snapshots/output/syntax/src/destructuring.ts
@@ -9,7 +9,7 @@ const props: Props = { a: 42 }
 //    ^^^^^ definition syntax 1.0.0 src/`destructuring.ts`/props.
 //           ^^^^^ reference syntax 1.0.0 src/`destructuring.ts`/Props#
 //                     ^ definition syntax 1.0.0 src/`destructuring.ts`/a0:
-//                     relationship implementation reference scip-typescript npm syntax 1.0.0 src/`destructuring.ts`/Props#a.
+//                     relationship implementation reference syntax 1.0.0 src/`destructuring.ts`/Props#a.
 
 export function objectDestructuring(): number[] {
 //              ^^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`destructuring.ts`/objectDestructuring().

--- a/snapshots/output/syntax/src/infer-relationship.ts
+++ b/snapshots/output/syntax/src/infer-relationship.ts
@@ -23,7 +23,7 @@ export function returnStatement(): Configuration {
     return {
       property: 41,
 //    ^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/property0:
-//    relationship implementation reference scip-typescript npm syntax 1.0.0 src/`infer-relationship.ts`/Configuration#property.
+//    relationship implementation reference syntax 1.0.0 src/`infer-relationship.ts`/Configuration#property.
     }
   }
   for (let i = 0; i < 9; i++) {
@@ -36,7 +36,7 @@ export function returnStatement(): Configuration {
       return {
         property: 41,
 //      ^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/property1:
-//      relationship implementation reference scip-typescript npm syntax 1.0.0 src/`infer-relationship.ts`/Configuration#property.
+//      relationship implementation reference syntax 1.0.0 src/`infer-relationship.ts`/Configuration#property.
       }
     }
   }
@@ -48,7 +48,7 @@ export function returnStatement(): Configuration {
       return {
         property: 41,
 //      ^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/property2:
-//      relationship implementation reference scip-typescript npm syntax 1.0.0 src/`infer-relationship.ts`/Configuration#property.
+//      relationship implementation reference syntax 1.0.0 src/`infer-relationship.ts`/Configuration#property.
       }
     }
   }
@@ -66,7 +66,7 @@ export function returnStatement(): Configuration {
       return {
         property: 41,
 //      ^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/property3:
-//      relationship implementation reference scip-typescript npm syntax 1.0.0 src/`infer-relationship.ts`/Configuration#property.
+//      relationship implementation reference syntax 1.0.0 src/`infer-relationship.ts`/Configuration#property.
       }
     }
   }
@@ -75,7 +75,7 @@ export function returnStatement(): Configuration {
     return {
       property: 41,
 //    ^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/property4:
-//    relationship implementation reference scip-typescript npm syntax 1.0.0 src/`infer-relationship.ts`/Configuration#property.
+//    relationship implementation reference syntax 1.0.0 src/`infer-relationship.ts`/Configuration#property.
     }
   }
   do {
@@ -84,7 +84,7 @@ export function returnStatement(): Configuration {
       return {
         property: 41,
 //      ^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/property5:
-//      relationship implementation reference scip-typescript npm syntax 1.0.0 src/`infer-relationship.ts`/Configuration#property.
+//      relationship implementation reference syntax 1.0.0 src/`infer-relationship.ts`/Configuration#property.
       }
     }
   } while (random() < 0)
@@ -93,7 +93,7 @@ export function returnStatement(): Configuration {
   return {
     property: 42,
 //  ^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/property6:
-//  relationship implementation reference scip-typescript npm syntax 1.0.0 src/`infer-relationship.ts`/Configuration#property.
+//  relationship implementation reference syntax 1.0.0 src/`infer-relationship.ts`/Configuration#property.
   }
 }
 

--- a/snapshots/output/syntax/src/inheritance.ts
+++ b/snapshots/output/syntax/src/inheritance.ts
@@ -24,11 +24,11 @@ export abstract class Superclass {
 }
 export abstract class IntermediateSuperclass extends Superclass {
 //                    ^^^^^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperclass#
-//                    relationship implementation scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superclass#
+//                    relationship implementation syntax 1.0.0 src/`inheritance.ts`/Superclass#
 //                                                   ^^^^^^^^^^ reference syntax 1.0.0 src/`inheritance.ts`/Superclass#
   public override overrideMethod(): string {
 //                ^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperclass#overrideMethod().
-//                relationship implementation reference scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superclass#overrideMethod().
+//                relationship implementation reference syntax 1.0.0 src/`inheritance.ts`/Superclass#overrideMethod().
     return 'this will get overridden'
   }
   public abstract intermediateOverrideMethod(): string
@@ -36,11 +36,11 @@ export abstract class IntermediateSuperclass extends Superclass {
 }
 export class Subclass
 //           ^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/Subclass#
-//           relationship implementation scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperclass#
-//           relationship implementation scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperinterface#
-//           relationship implementation scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superclass#
-//           relationship implementation scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superinterface#
-//           relationship implementation scip-typescript npm syntax 1.0.0 src/`overload.d.ts`/Overloader#
+//           relationship implementation syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperclass#
+//           relationship implementation syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperinterface#
+//           relationship implementation syntax 1.0.0 src/`inheritance.ts`/Superclass#
+//           relationship implementation syntax 1.0.0 src/`inheritance.ts`/Superinterface#
+//           relationship implementation syntax 1.0.0 src/`overload.d.ts`/Overloader#
   extends IntermediateSuperclass
 //        ^^^^^^^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperclass#
   implements IntermediateSuperinterface, Overloader
@@ -49,7 +49,7 @@ export class Subclass
 {
   public onLiteral(param: any): void {
 //       ^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/Subclass#onLiteral().
-//       relationship implementation reference scip-typescript npm syntax 1.0.0 src/`overload.d.ts`/Overloader#onLiteral().
+//       relationship implementation reference syntax 1.0.0 src/`overload.d.ts`/Overloader#onLiteral().
 //                 ^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/Subclass#onLiteral().(param)
     throw new Error('Method not implemented.' + param)
 //            ^^^^^ reference typescript 5.3.3 lib/`lib.es5.d.ts`/Error#
@@ -58,32 +58,32 @@ export class Subclass
   }
   property = 'property'
 //^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/Subclass#property.
-//relationship implementation reference scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superinterface#property.
+//relationship implementation reference syntax 1.0.0 src/`inheritance.ts`/Superinterface#property.
   public overrideMethod(): string {
 //       ^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/Subclass#overrideMethod().
-//       relationship implementation reference scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperclass#overrideMethod().
-//       relationship implementation reference scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superclass#overrideMethod().
+//       relationship implementation reference syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperclass#overrideMethod().
+//       relationship implementation reference syntax 1.0.0 src/`inheritance.ts`/Superclass#overrideMethod().
     throw new Error('Method not implemented.')
 //            ^^^^^ reference typescript 5.3.3 lib/`lib.es5.d.ts`/Error#
 //            ^^^^^ reference typescript 5.3.3 lib/`lib.es5.d.ts`/Error.
   }
   public intermediateOverrideMethod(): string {
 //       ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/Subclass#intermediateOverrideMethod().
-//       relationship implementation reference scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperclass#intermediateOverrideMethod().
+//       relationship implementation reference syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperclass#intermediateOverrideMethod().
     throw new Error('Method not implemented.')
 //            ^^^^^ reference typescript 5.3.3 lib/`lib.es5.d.ts`/Error#
 //            ^^^^^ reference typescript 5.3.3 lib/`lib.es5.d.ts`/Error.
   }
   public interfaceMethod(): string {
 //       ^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/Subclass#interfaceMethod().
-//       relationship implementation reference scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superinterface#interfaceMethod().
+//       relationship implementation reference syntax 1.0.0 src/`inheritance.ts`/Superinterface#interfaceMethod().
     throw new Error('Method not implemented.')
 //            ^^^^^ reference typescript 5.3.3 lib/`lib.es5.d.ts`/Error#
 //            ^^^^^ reference typescript 5.3.3 lib/`lib.es5.d.ts`/Error.
   }
   public intermediateInterfaceMethod(): string {
 //       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/Subclass#intermediateInterfaceMethod().
-//       relationship implementation reference scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperinterface#intermediateInterfaceMethod().
+//       relationship implementation reference syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperinterface#intermediateInterfaceMethod().
     throw new Error('Method not implemented.')
 //            ^^^^^ reference typescript 5.3.3 lib/`lib.es5.d.ts`/Error#
 //            ^^^^^ reference typescript 5.3.3 lib/`lib.es5.d.ts`/Error.
@@ -94,10 +94,10 @@ export const objectLiteralImplementation: Superinterface = {
 //                                        ^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`inheritance.ts`/Superinterface#
   property: 'property',
 //^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/property0:
-//relationship implementation reference scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superinterface#property.
+//relationship implementation reference syntax 1.0.0 src/`inheritance.ts`/Superinterface#property.
   interfaceMethod: (): string => {
 //^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/interfaceMethod0:
-//relationship implementation reference scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superinterface#interfaceMethod().
+//relationship implementation reference syntax 1.0.0 src/`inheritance.ts`/Superinterface#interfaceMethod().
     throw new Error('Function not implemented.')
 //            ^^^^^ reference typescript 5.3.3 lib/`lib.es5.d.ts`/Error#
 //            ^^^^^ reference typescript 5.3.3 lib/`lib.es5.d.ts`/Error.
@@ -113,10 +113,10 @@ export function infersInterface(): void {
 //^^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`inheritance.ts`/consumesInterface().
     interfaceMethod: (): string => 'inferred',
 //  ^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/interfaceMethod1:
-//  relationship implementation reference scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superinterface#interfaceMethod().
+//  relationship implementation reference syntax 1.0.0 src/`inheritance.ts`/Superinterface#interfaceMethod().
     property: 'inferred',
 //  ^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/property1:
-//  relationship implementation reference scip-typescript npm syntax 1.0.0 src/`inheritance.ts`/Superinterface#property.
+//  relationship implementation reference syntax 1.0.0 src/`inheritance.ts`/Superinterface#property.
   })
 }
 

--- a/snapshots/output/syntax/src/interface.ts
+++ b/snapshots/output/syntax/src/interface.ts
@@ -18,17 +18,17 @@ export function newInterface(): Interface {
   return {
     property: 'a',
 //  ^^^^^^^^ definition syntax 1.0.0 src/`interface.ts`/property0:
-//  relationship implementation reference scip-typescript npm syntax 1.0.0 src/`interface.ts`/Interface#property.
+//  relationship implementation reference syntax 1.0.0 src/`interface.ts`/Interface#property.
     methodSignature(param: string): string {
 //  ^^^^^^^^^^^^^^^ definition local 4
-//  relationship implementation reference scip-typescript npm syntax 1.0.0 src/`interface.ts`/Interface#methodSignature().
+//  relationship implementation reference syntax 1.0.0 src/`interface.ts`/Interface#methodSignature().
 //                  ^^^^^ definition local 5
       return param
 //           ^^^^^ reference local 5
     },
     methodSignature2: (param: string): string => {
 //  ^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`interface.ts`/methodSignature20:
-//  relationship implementation reference scip-typescript npm syntax 1.0.0 src/`interface.ts`/Interface#methodSignature2.
+//  relationship implementation reference syntax 1.0.0 src/`interface.ts`/Interface#methodSignature2.
 //                     ^^^^^ definition local 7
       return param
 //           ^^^^^ reference local 7

--- a/src/SnapshotTesting.ts
+++ b/src/SnapshotTesting.ts
@@ -48,10 +48,10 @@ function parseOptions(lines: string[]): {
   return formatOptions
 }
 
-function symbolNameForSnapshot(occurrence: scip.Occurrence): string {
-  return occurrence.symbol.startsWith(stripIndexerPrefix)
-    ? occurrence.symbol.slice(stripIndexerPrefix.length)
-    : occurrence.symbol
+function symbolNameForSnapshot(fullName: string): string {
+  return fullName.startsWith(stripIndexerPrefix)
+    ? fullName.slice(stripIndexerPrefix.length)
+    : fullName
 }
 
 export function formatSnapshot(
@@ -144,7 +144,7 @@ export function formatSnapshot(
         if (relationship.is_type_definition) {
           out.push(' type_definition')
         }
-        out.push(' ' + relationship.symbol)
+        out.push(' ' + symbolNameForSnapshot(relationship.symbol))
       }
     }
 
@@ -181,7 +181,7 @@ export function formatSnapshot(
         out.push(' < ')
         out.push(isDefinition ? 'definition' : 'reference')
         out.push(' ')
-        out.push(symbolNameForSnapshot(occurrence))
+        out.push(symbolNameForSnapshot(occurrence.symbol))
         pushDoc(range, occurrence.symbol, isDefinition, true)
         out.push('\n')
 
@@ -230,7 +230,7 @@ export function formatSnapshot(
         (occurrence.symbol_roles & scip.SymbolRole.Definition) > 0
       out.push(isDefinition ? 'definition' : 'reference')
       out.push(' ')
-      const symbol = symbolNameForSnapshot(occurrence)
+      const symbol = symbolNameForSnapshot(occurrence.symbol)
       out.push(symbol.replace('\n', '|'))
 
       pushDoc(range, occurrence.symbol, isDefinition, isStartOfLine)


### PR DESCRIPTION
In the previous PR https://github.com/sourcegraph/scip-typescript/pull/306,
I forgot to modify one place in the snapshot formatting logic.

### Test plan

Covered by existing tests.
