### PR TITLE
Add support for `SymbolInformation.signature`

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-nodejs 20.8.1
+nodejs 20.4.0
 pnpm 8.9.2

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "editor.formatOnSave": true
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
 }

--- a/snapshots/input/syntax/package.json
+++ b/snapshots/input/syntax/package.json
@@ -8,5 +8,8 @@
   },
   "author": "",
   "license": "ISC",
-  "private": true
+  "private": true,
+  "devDependencies": {
+    "@types/vscode": "1.86.0"
+  }
 }

--- a/snapshots/input/syntax/src/definition-file-signatures.d.ts
+++ b/snapshots/input/syntax/src/definition-file-signatures.d.ts
@@ -1,0 +1,14 @@
+// format-options: showSignatures
+export namespace minimized {
+  export enum NumericLiteralEnum {
+    One = 1,
+    TwoThousand = 2_000,
+  }
+
+  export const doubleConstant = 3.14
+
+  export enum StringLiteralEnum {
+    Saturday = 'saturday',
+    Sunday = 'sunday',
+  }
+}

--- a/snapshots/input/syntax/src/minimized-signatures.ts
+++ b/snapshots/input/syntax/src/minimized-signatures.ts
@@ -1,0 +1,4 @@
+// format-options: showSignatures
+
+export type CompletionItemID = string & { _opaque: typeof CompletionItemID }
+declare const CompletionItemID: unique symbol

--- a/snapshots/input/syntax/src/minimized-signatures.ts
+++ b/snapshots/input/syntax/src/minimized-signatures.ts
@@ -1,4 +1,8 @@
 // format-options: showSignatures
 
-export type CompletionItemID = string & { _opaque: typeof CompletionItemID }
-declare const CompletionItemID: unique symbol
+export interface OptionalProperty {
+  optional1?: string
+  optional2?: number | null
+  optional3?: number | undefined
+  optional4?: undefined
+}

--- a/snapshots/input/syntax/src/signatures.ts
+++ b/snapshots/input/syntax/src/signatures.ts
@@ -1,0 +1,99 @@
+// format-options: showSignatures
+
+export type Requests = {
+  'workspace/edit': [WorkspaceEditParams, boolean]
+  'chat/submitMessage': [WorkspaceEditParams, boolean]
+}
+
+export type Notifications = {
+  'workspace/edit': [WorkspaceEditParams]
+}
+
+export type Intersection = { uri: string } & { size: number }
+export type Union = { uri: string } | { size: number }
+export type Builtin = Pick<WorkspaceEditParams, 'changes'>
+export type Builtin2 = Partial<WorkspaceEditParams>
+export interface WorkspaceEditParams {
+  changes: { uri: string }[]
+}
+
+export interface ExampleSuperInterface<T> {
+  a: T
+  b: string
+}
+export interface ExampleInterface<T> extends ExampleSuperInterface<T> {
+  c: number
+}
+export class ExampleSuperClass<T> {
+  constructor(
+    public a: T,
+    public b: string
+  ) {}
+}
+
+export class ExampleClass<T>
+  extends ExampleSuperClass<T>
+  implements ExampleSuperInterface<T>, ExampleInterface<T>
+{
+  public d: Record<string, any>
+
+  #e = true
+
+  constructor(
+    public a: T,
+    public b: string,
+    public c: number,
+    d: Record<string, any>
+  ) {
+    super(a, b)
+    this.d = d
+  }
+  public getC(): number {
+    return this.c
+  }
+
+  get e(): boolean {
+    return this.#e
+  }
+
+  set setB(b: string) {
+    this.#e = true
+    this.b = b
+  }
+}
+
+export function basicFunction<T>(a: T, b: number): string {
+  return `${a}${b}`
+}
+export const constant = 42
+export const variable: <T>(a: T, b: number) => string = (a, b) => `${a}${b}`
+
+export interface User {
+  name: string
+  age: number
+  customHeaders: Record<string, string>
+}
+
+export interface ChatHistory {
+  chatID: User
+  [a: number]: User
+  [_: string]: User
+}
+
+export class ModelProvider {
+  default = true
+}
+
+export enum NumericLiteralEnum {
+  MinusOne = -1,
+  Expression = 1 + 23 - 2,
+  One = 1,
+  TwoThousand = 2_000,
+}
+
+export const doubleConstant = 3.14
+
+export enum StringLiteralEnum {
+  Saturday = 'saturday',
+  Sunday = 'sunday',
+}

--- a/snapshots/input/syntax/src/signatures.ts
+++ b/snapshots/input/syntax/src/signatures.ts
@@ -17,6 +17,13 @@ export interface WorkspaceEditParams {
   changes: { uri: string }[]
 }
 
+export interface OptionalProperty {
+  optional1?: string
+  optional2?: number | null
+  optional3?: number | undefined
+  optional4?: undefined
+}
+
 export interface ExampleSuperInterface<T> {
   a: T
   b: string

--- a/snapshots/input/syntax/src/structural-type.ts
+++ b/snapshots/input/syntax/src/structural-type.ts
@@ -10,5 +10,8 @@ export function bar2(): Promise<number> {
 
 type OptionsFlags<Type> = { [Property in keyof Type]: boolean }
 type FeatureFlags = { darkMode: () => void }
+export type PropertySignature = {
+  'chat/submit': [{ text: { value: string } }]
+}
 export type FeatureOptions = OptionsFlags<FeatureFlags> // implicitly // type FeatureOptions = { // darkMode: boolean; // } const fo: FeatureOptions = { darkMode: true }; // ^ go to def
 export const fo: FeatureOptions = { darkMode: true }

--- a/snapshots/output/enclosing-ranges-ts/index.ts
+++ b/snapshots/output/enclosing-ranges-ts/index.ts
@@ -7,9 +7,9 @@
 interface Foo {
 //        ^^^ definition enclosing-ranges-ts 1.0.0 `index.ts`/Foo#
   bar: string
-//^^^ definition enclosing-ranges-ts 1.0.0 `index.ts`/Foo#bar.
+//^^^ definition enclosing-ranges-ts 1.0.0 `index.ts`/bar0:
   test: () => void
-//^^^^ definition enclosing-ranges-ts 1.0.0 `index.ts`/Foo#test.
+//^^^^ definition enclosing-ranges-ts 1.0.0 `index.ts`/test0:
 }
 // < end enclosing_range enclosing-ranges-ts 1.0.0 `index.ts`/Foo#
 
@@ -18,7 +18,7 @@ interface Single<T> {
 //        ^^^^^^ definition enclosing-ranges-ts 1.0.0 `index.ts`/Single#
 //               ^ definition enclosing-ranges-ts 1.0.0 `index.ts`/Single#[T]
   t: T
-//^ definition enclosing-ranges-ts 1.0.0 `index.ts`/Single#t.
+//^ definition enclosing-ranges-ts 1.0.0 `index.ts`/t0:
 //   ^ reference enclosing-ranges-ts 1.0.0 `index.ts`/Single#[T]
 }
 // < end enclosing_range enclosing-ranges-ts 1.0.0 `index.ts`/Single#

--- a/snapshots/output/pure-js/src/main.js
+++ b/snapshots/output/pure-js/src/main.js
@@ -20,10 +20,10 @@ function print_fib(a) {
   console.log(fib(a))
 //^^^^^^^ reference typescript 5.3.3 lib/`lib.dom.d.ts`/console.
 //^^^^^^^ reference @types/node 20.10.5 `globals.d.ts`/global/console.
-//^^^^^^^ reference @types/node 20.10.5 `console.d.ts`/`"node:console"`/global/console/
-//^^^^^^^ reference @types/node 20.10.5 `console.d.ts`/`"node:console"`/global/console.
+//^^^^^^^ reference @types/node 20.10.5 `console.d.ts`/`node:console`/global/console/
+//^^^^^^^ reference @types/node 20.10.5 `console.d.ts`/`node:console`/global/console.
 //        ^^^ reference typescript 5.3.3 lib/`lib.dom.d.ts`/Console#log().
-//        ^^^ reference @types/node 20.10.5 `console.d.ts`/`"node:console"`/global/Console#log().
+//        ^^^ reference @types/node 20.10.5 `console.d.ts`/`node:console`/global/Console#log().
 //            ^^^ reference pure-js 1.0.0 src/`main.js`/fib().
 //                ^ reference pure-js 1.0.0 src/`main.js`/print_fib().(a)
 }
@@ -42,12 +42,12 @@ const capture_lambda = () => {
 }
 
 for (var i = 0; i <= 10; i++) {}
-//       ^ definition local 2
-//              ^ reference local 2
-//                       ^ reference local 2
+//       ^ definition local 4
+//              ^ reference local 4
+//                       ^ reference local 4
 
 for (const x of [1, 2, 3]) {
-//         ^ definition local 5
+//         ^ definition local 7
 }
 
 var a = 0
@@ -68,32 +68,32 @@ function use_before_def() {
 //       ^^^^^^^^^^^^^^ definition pure-js 1.0.0 src/`main.js`/use_before_def().
   print_fib(n)
 //^^^^^^^^^ reference pure-js 1.0.0 src/`main.js`/print_fib().
-//          ^ reference local 8
+//          ^ reference local 10
   var n = 10
-//    ^ definition local 8
+//    ^ definition local 10
 
   if (forever()) {
 //    ^^^^^^^ reference pure-js 1.0.0 src/`main.js`/forever().
     var m = 10
-//      ^ definition local 11
+//      ^ definition local 13
   }
   print_fib(m)
 //^^^^^^^^^ reference pure-js 1.0.0 src/`main.js`/print_fib().
-//          ^ reference local 11
+//          ^ reference local 13
 }
 
 function var_function_scope() {
 //       ^^^^^^^^^^^^^^^^^^ definition pure-js 1.0.0 src/`main.js`/var_function_scope().
   var k = 0
-//    ^ definition local 14
+//    ^ definition local 16
   if (forever()) {
 //    ^^^^^^^ reference pure-js 1.0.0 src/`main.js`/forever().
     var k = 1
-//      ^ definition local 17
+//      ^ definition local 19
   }
   print_fib(k)
 //^^^^^^^^^ reference pure-js 1.0.0 src/`main.js`/print_fib().
-//          ^ reference local 14
-//          ^ reference local 17
+//          ^ reference local 16
+//          ^ reference local 19
 }
 

--- a/snapshots/output/react/src/LoaderInput.tsx
+++ b/snapshots/output/react/src/LoaderInput.tsx
@@ -8,9 +8,9 @@ import React from 'react'
 interface Props {
 //        ^^^^^ definition react-example 1.0.0 src/`LoaderInput.tsx`/Props#
   loading: boolean
-//^^^^^^^ definition react-example 1.0.0 src/`LoaderInput.tsx`/Props#loading.
+//^^^^^^^ definition react-example 1.0.0 src/`LoaderInput.tsx`/loading0:
   children: React.ReactNode
-//^^^^^^^^ definition react-example 1.0.0 src/`LoaderInput.tsx`/Props#children.
+//^^^^^^^^ definition react-example 1.0.0 src/`LoaderInput.tsx`/children0:
 //          ^^^^^ reference @types/react 18.2.39 `index.d.ts`/React/
 //                ^^^^^^^^^ reference @types/react 18.2.39 `index.d.ts`/React/ReactNode#
 }
@@ -21,23 +21,23 @@ export const LoaderInput: React.FunctionComponent<Props> = ({
 //                              ^^^^^^^^^^^^^^^^^ reference @types/react 18.2.39 `index.d.ts`/React/FunctionComponent#
 //                                                ^^^^^ reference react-example 1.0.0 src/`LoaderInput.tsx`/Props#
   loading,
-//^^^^^^^ definition local 3
-//^^^^^^^ reference react-example 1.0.0 src/`LoaderInput.tsx`/Props#loading.
+//^^^^^^^ definition local 4
+//^^^^^^^ reference react-example 1.0.0 src/`LoaderInput.tsx`/loading0:
   children,
-//^^^^^^^^ definition local 4
-//^^^^^^^^ reference react-example 1.0.0 src/`LoaderInput.tsx`/Props#children.
+//^^^^^^^^ definition local 5
+//^^^^^^^^ reference react-example 1.0.0 src/`LoaderInput.tsx`/children0:
 }) => (
   <div className="hello">
-// ^^^ reference @types/react 18.2.39 `index.d.ts`/global/JSX/IntrinsicElements#div.
-//     ^^^^^^^^^ reference @types/react 18.2.39 `index.d.ts`/React/HTMLAttributes#className.
+// ^^^ reference @types/react 18.2.39 `index.d.ts`/div0:
+//     ^^^^^^^^^ reference @types/react 18.2.39 `index.d.ts`/className0:
     {children}
-//   ^^^^^^^^ reference local 4
+//   ^^^^^^^^ reference local 5
     {loading && <p>spinner</p>}
-//   ^^^^^^^ reference local 3
-//               ^ reference @types/react 18.2.39 `index.d.ts`/global/JSX/IntrinsicElements#p.
-//                          ^ reference @types/react 18.2.39 `index.d.ts`/global/JSX/IntrinsicElements#p.
+//   ^^^^^^^ reference local 4
+//               ^ reference @types/react 18.2.39 `index.d.ts`/p0:
+//                          ^ reference @types/react 18.2.39 `index.d.ts`/p0:
   </div>
-//  ^^^ reference @types/react 18.2.39 `index.d.ts`/global/JSX/IntrinsicElements#div.
+//  ^^^ reference @types/react 18.2.39 `index.d.ts`/div0:
 )
 
 export const LoaderInput2: React.FunctionComponent<Props> = props => {
@@ -45,13 +45,13 @@ export const LoaderInput2: React.FunctionComponent<Props> = props => {
 //                         ^^^^^ reference @types/react 18.2.39 `index.d.ts`/React/
 //                               ^^^^^^^^^^^^^^^^^ reference @types/react 18.2.39 `index.d.ts`/React/FunctionComponent#
 //                                                 ^^^^^ reference react-example 1.0.0 src/`LoaderInput.tsx`/Props#
-//                                                          ^^^^^ definition local 6
+//                                                          ^^^^^ definition local 705
   return <LoaderInput loading={true} key="key" children={props.children} />
 //        ^^^^^^^^^^^ reference react-example 1.0.0 src/`LoaderInput.tsx`/LoaderInput.
-//                    ^^^^^^^ reference react-example 1.0.0 src/`LoaderInput.tsx`/Props#loading.
-//                                   ^^^ reference local 10
-//                                             ^^^^^^^^ reference react-example 1.0.0 src/`LoaderInput.tsx`/Props#children.
-//                                                       ^^^^^ reference local 6
-//                                                             ^^^^^^^^ reference react-example 1.0.0 src/`LoaderInput.tsx`/Props#children.
+//                    ^^^^^^^ reference react-example 1.0.0 src/`LoaderInput.tsx`/loading0:
+//                                   ^^^ reference local 709
+//                                             ^^^^^^^^ reference react-example 1.0.0 src/`LoaderInput.tsx`/children0:
+//                                                       ^^^^^ reference local 705
+//                                                             ^^^^^^^^ reference react-example 1.0.0 src/`LoaderInput.tsx`/children0:
 }
 

--- a/snapshots/output/react/src/MyTSXElement.tsx
+++ b/snapshots/output/react/src/MyTSXElement.tsx
@@ -12,5 +12,5 @@ export const MyTSXElement: React.FunctionComponent<MyProps> = ({}) => (<p></p>)
 //                         ^^^^^ reference @types/react 18.2.39 `index.d.ts`/React/
 //                               ^^^^^^^^^^^^^^^^^ reference @types/react 18.2.39 `index.d.ts`/React/FunctionComponent#
 //                                                 ^^^^^^^ reference react-example 1.0.0 src/`MyTSXElement.tsx`/MyProps#
-//                                                                      ^ reference @types/react 18.2.39 `index.d.ts`/global/JSX/IntrinsicElements#p.
-//                                                                          ^ reference @types/react 18.2.39 `index.d.ts`/global/JSX/IntrinsicElements#p.
+//                                                                      ^ reference @types/react 18.2.39 `index.d.ts`/p0:
+//                                                                          ^ reference @types/react 18.2.39 `index.d.ts`/p0:

--- a/snapshots/output/syntax/src/accessors.ts
+++ b/snapshots/output/syntax/src/accessors.ts
@@ -115,6 +115,6 @@ function f() {
   g(D.length)
 //^ reference syntax 1.0.0 src/`accessors.ts`/g().
 //  ^ reference syntax 1.0.0 src/`accessors.ts`/D#
-//    ^^^^^^ reference typescript 5.3.3 lib/`lib.es5.d.ts`/Function#length.
+//    ^^^^^^ reference typescript 5.3.3 lib/`lib.es5.d.ts`/length0:
 }
 

--- a/snapshots/output/syntax/src/definition-file-signatures.d.ts
+++ b/snapshots/output/syntax/src/definition-file-signatures.d.ts
@@ -1,0 +1,195 @@
+// < definition syntax 1.0.0 src/`definition-file-signatures.d.ts`/
+
+// format-options: showSignatures
+export namespace minimized {
+//               ^^^^^^^^^ definition syntax 1.0.0 src/`definition-file-signatures.d.ts`/minimized/
+//               info {
+//               |   "symbol": "scip-typescript npm syntax 1.0.0 src/`definition-file-signatures.d.ts`/minimized/",
+//               |   "documentation": [
+//               |     "```ts\nminimized: typeof minimized\n```"
+//               |   ],
+//               |   "relationships": [],
+//               |   "kind": 0,
+//               |   "display_name": "minimized",
+//               |   "enclosing_symbol": "",
+//               |   "signature": {}
+//               | }
+  export enum NumericLiteralEnum {
+//            ^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`definition-file-signatures.d.ts`/minimized/NumericLiteralEnum#
+//            info {
+//            |   "symbol": "scip-typescript npm syntax 1.0.0 src/`definition-file-signatures.d.ts`/minimized/NumericLiteralEnum#",
+//            |   "documentation": [
+//            |     "```ts\nenum NumericLiteralEnum\n```"
+//            |   ],
+//            |   "relationships": [],
+//            |   "kind": 11,
+//            |   "display_name": "NumericLiteralEnum",
+//            |   "enclosing_symbol": "",
+//            |   "signature": {
+//            |     "class_signature": {
+//            |       "parents": [],
+//            |       "declarations": {
+//            |         "symlinks": [
+//            |           "scip-typescript npm syntax 1.0.0 src/`definition-file-signatures.d.ts`/minimized/NumericLiteralEnum#One.",
+//            |           "scip-typescript npm syntax 1.0.0 src/`definition-file-signatures.d.ts`/minimized/NumericLiteralEnum#TwoThousand."
+//            |         ],
+//            |         "hardlinks": []
+//            |       }
+//            |     }
+//            |   }
+//            | }
+    One = 1,
+//  ^^^ definition syntax 1.0.0 src/`definition-file-signatures.d.ts`/minimized/NumericLiteralEnum#One.
+//  info {
+//  |   "symbol": "scip-typescript npm syntax 1.0.0 src/`definition-file-signatures.d.ts`/minimized/NumericLiteralEnum#One.",
+//  |   "documentation": [
+//  |     "```ts\n(enum member) One = 1\n```"
+//  |   ],
+//  |   "relationships": [],
+//  |   "kind": 12,
+//  |   "display_name": "One",
+//  |   "enclosing_symbol": "",
+//  |   "signature": {
+//  |     "value_signature": {
+//  |       "tpe": {
+//  |         "constant_type": {
+//  |           "constant": {
+//  |             "int_constant": {
+//  |               "value": 1
+//  |             }
+//  |           }
+//  |         }
+//  |       }
+//  |     }
+//  |   }
+//  | }
+    TwoThousand = 2_000,
+//  ^^^^^^^^^^^ definition syntax 1.0.0 src/`definition-file-signatures.d.ts`/minimized/NumericLiteralEnum#TwoThousand.
+//  info {
+//  |   "symbol": "scip-typescript npm syntax 1.0.0 src/`definition-file-signatures.d.ts`/minimized/NumericLiteralEnum#TwoThousand.",
+//  |   "documentation": [
+//  |     "```ts\n(enum member) TwoThousand = 2000\n```"
+//  |   ],
+//  |   "relationships": [],
+//  |   "kind": 12,
+//  |   "display_name": "TwoThousand",
+//  |   "enclosing_symbol": "",
+//  |   "signature": {
+//  |     "value_signature": {
+//  |       "tpe": {
+//  |         "constant_type": {
+//  |           "constant": {
+//  |             "int_constant": {
+//  |               "value": 2000
+//  |             }
+//  |           }
+//  |         }
+//  |       }
+//  |     }
+//  |   }
+//  | }
+  }
+
+  export const doubleConstant = 3.14
+//             ^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`definition-file-signatures.d.ts`/minimized/doubleConstant.
+//             info {
+//             |   "symbol": "scip-typescript npm syntax 1.0.0 src/`definition-file-signatures.d.ts`/minimized/doubleConstant.",
+//             |   "documentation": [
+//             |     "```ts\nvar doubleConstant: 3.14\n```"
+//             |   ],
+//             |   "relationships": [],
+//             |   "kind": 61,
+//             |   "display_name": "doubleConstant",
+//             |   "enclosing_symbol": "",
+//             |   "signature": {
+//             |     "value_signature": {
+//             |       "tpe": {
+//             |         "constant_type": {
+//             |           "constant": {
+//             |             "double_constant": {
+//             |               "value": 3.14
+//             |             }
+//             |           }
+//             |         }
+//             |       }
+//             |     }
+//             |   }
+//             | }
+
+  export enum StringLiteralEnum {
+//            ^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`definition-file-signatures.d.ts`/minimized/StringLiteralEnum#
+//            info {
+//            |   "symbol": "scip-typescript npm syntax 1.0.0 src/`definition-file-signatures.d.ts`/minimized/StringLiteralEnum#",
+//            |   "documentation": [
+//            |     "```ts\nenum StringLiteralEnum\n```"
+//            |   ],
+//            |   "relationships": [],
+//            |   "kind": 11,
+//            |   "display_name": "StringLiteralEnum",
+//            |   "enclosing_symbol": "",
+//            |   "signature": {
+//            |     "class_signature": {
+//            |       "parents": [],
+//            |       "declarations": {
+//            |         "symlinks": [
+//            |           "scip-typescript npm syntax 1.0.0 src/`definition-file-signatures.d.ts`/minimized/StringLiteralEnum#Saturday.",
+//            |           "scip-typescript npm syntax 1.0.0 src/`definition-file-signatures.d.ts`/minimized/StringLiteralEnum#Sunday."
+//            |         ],
+//            |         "hardlinks": []
+//            |       }
+//            |     }
+//            |   }
+//            | }
+    Saturday = 'saturday',
+//  ^^^^^^^^ definition syntax 1.0.0 src/`definition-file-signatures.d.ts`/minimized/StringLiteralEnum#Saturday.
+//  info {
+//  |   "symbol": "scip-typescript npm syntax 1.0.0 src/`definition-file-signatures.d.ts`/minimized/StringLiteralEnum#Saturday.",
+//  |   "documentation": [
+//  |     "```ts\n(enum member) Saturday = saturday\n```"
+//  |   ],
+//  |   "relationships": [],
+//  |   "kind": 12,
+//  |   "display_name": "Saturday",
+//  |   "enclosing_symbol": "",
+//  |   "signature": {
+//  |     "value_signature": {
+//  |       "tpe": {
+//  |         "constant_type": {
+//  |           "constant": {
+//  |             "string_constant": {
+//  |               "value": "saturday"
+//  |             }
+//  |           }
+//  |         }
+//  |       }
+//  |     }
+//  |   }
+//  | }
+    Sunday = 'sunday',
+//  ^^^^^^ definition syntax 1.0.0 src/`definition-file-signatures.d.ts`/minimized/StringLiteralEnum#Sunday.
+//  info {
+//  |   "symbol": "scip-typescript npm syntax 1.0.0 src/`definition-file-signatures.d.ts`/minimized/StringLiteralEnum#Sunday.",
+//  |   "documentation": [
+//  |     "```ts\n(enum member) Sunday = sunday\n```"
+//  |   ],
+//  |   "relationships": [],
+//  |   "kind": 12,
+//  |   "display_name": "Sunday",
+//  |   "enclosing_symbol": "",
+//  |   "signature": {
+//  |     "value_signature": {
+//  |       "tpe": {
+//  |         "constant_type": {
+//  |           "constant": {
+//  |             "string_constant": {
+//  |               "value": "sunday"
+//  |             }
+//  |           }
+//  |         }
+//  |       }
+//  |     }
+//  |   }
+//  | }
+  }
+}
+

--- a/snapshots/output/syntax/src/destructuring.ts
+++ b/snapshots/output/syntax/src/destructuring.ts
@@ -3,25 +3,25 @@
 interface Props {
 //        ^^^^^ definition syntax 1.0.0 src/`destructuring.ts`/Props#
   a: number
-//^ definition syntax 1.0.0 src/`destructuring.ts`/Props#a.
+//^ definition syntax 1.0.0 src/`destructuring.ts`/a0:
 }
 const props: Props = { a: 42 }
 //    ^^^^^ definition syntax 1.0.0 src/`destructuring.ts`/props.
 //           ^^^^^ reference syntax 1.0.0 src/`destructuring.ts`/Props#
-//                     ^ definition syntax 1.0.0 src/`destructuring.ts`/a0:
-//                     relationship implementation reference syntax 1.0.0 src/`destructuring.ts`/Props#a.
+//                     ^ definition syntax 1.0.0 src/`destructuring.ts`/a1:
+//                     relationship implementation reference syntax 1.0.0 src/`destructuring.ts`/a0:
 
 export function objectDestructuring(): number[] {
 //              ^^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`destructuring.ts`/objectDestructuring().
   const { a: b } = props
-//        ^ reference syntax 1.0.0 src/`destructuring.ts`/Props#a.
+//        ^ reference syntax 1.0.0 src/`destructuring.ts`/a0:
 //           ^ definition local 4
 //                 ^^^^^ reference syntax 1.0.0 src/`destructuring.ts`/props.
   return [props].map(({ a }) => a + b)
 //        ^^^^^ reference syntax 1.0.0 src/`destructuring.ts`/props.
 //               ^^^ reference typescript 5.3.3 lib/`lib.es5.d.ts`/Array#map().
 //                      ^ definition local 10
-//                      ^ reference syntax 1.0.0 src/`destructuring.ts`/Props#a.
+//                      ^ reference syntax 1.0.0 src/`destructuring.ts`/a0:
 //                              ^ reference local 10
 //                                  ^ reference local 4
 }
@@ -36,7 +36,7 @@ export function arrayDestructuring(): number[] {
 //             ^^^ reference typescript 5.3.3 lib/`lib.es5.d.ts`/Array#map().
 //                   ^ definition local 21
 //                          ^ reference local 21
-//                            ^ reference syntax 1.0.0 src/`destructuring.ts`/Props#a.
+//                            ^ reference syntax 1.0.0 src/`destructuring.ts`/a0:
 }
 
 export function nestedDestructuring(): number[] {
@@ -48,17 +48,17 @@ export function nestedDestructuring(): number[] {
 //         ^^^^^ reference syntax 1.0.0 src/`destructuring.ts`/props.
 //                 ^^^ reference typescript 5.3.3 lib/`lib.es5.d.ts`/Array#map().
 //                         ^ definition local 36
-//                         ^ reference syntax 1.0.0 src/`destructuring.ts`/Props#a.
+//                         ^ reference syntax 1.0.0 src/`destructuring.ts`/a0:
 //                                  ^ reference local 36
 //                                      ^ reference local 28
-//                                        ^ reference syntax 1.0.0 src/`destructuring.ts`/Props#a.
+//                                        ^ reference syntax 1.0.0 src/`destructuring.ts`/a0:
 }
 
 export function forLoopObjectDestructuring(): number {
 //              ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`destructuring.ts`/forLoopObjectDestructuring().
   for (const { a } of [props]) {
 //             ^ definition local 41
-//             ^ reference syntax 1.0.0 src/`destructuring.ts`/Props#a.
+//             ^ reference syntax 1.0.0 src/`destructuring.ts`/a0:
 //                     ^^^^^ reference syntax 1.0.0 src/`destructuring.ts`/props.
     return a
 //         ^ reference local 41
@@ -70,7 +70,7 @@ export function forLoopArrayDestructuring(): number {
 //              ^^^^^^^^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`destructuring.ts`/forLoopArrayDestructuring().
   for (const [{ a }] of [[props]]) {
 //              ^ definition local 48
-//              ^ reference syntax 1.0.0 src/`destructuring.ts`/Props#a.
+//              ^ reference syntax 1.0.0 src/`destructuring.ts`/a0:
 //                        ^^^^^ reference syntax 1.0.0 src/`destructuring.ts`/props.
     return a
 //         ^ reference local 48
@@ -81,7 +81,7 @@ export function forLoopArrayDestructuring(): number {
 export function parameterDestructuring({ a }: Props): number {
 //              ^^^^^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`destructuring.ts`/parameterDestructuring().
 //                                       ^ definition local 50
-//                                       ^ reference syntax 1.0.0 src/`destructuring.ts`/Props#a.
+//                                       ^ reference syntax 1.0.0 src/`destructuring.ts`/a0:
 //                                            ^^^^^ reference syntax 1.0.0 src/`destructuring.ts`/Props#
   return a
 //       ^ reference local 50

--- a/snapshots/output/syntax/src/infer-relationship.ts
+++ b/snapshots/output/syntax/src/infer-relationship.ts
@@ -3,7 +3,7 @@
 interface Configuration {
 //        ^^^^^^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/Configuration#
   property: number
-//^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/Configuration#property.
+//^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/property0:
 }
 
 function random(): number {
@@ -22,8 +22,8 @@ export function returnStatement(): Configuration {
 //    ^^^^^^ reference syntax 1.0.0 src/`infer-relationship.ts`/random().
     return {
       property: 41,
-//    ^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/property0:
-//    relationship implementation reference syntax 1.0.0 src/`infer-relationship.ts`/Configuration#property.
+//    ^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/property1:
+//    relationship implementation reference syntax 1.0.0 src/`infer-relationship.ts`/property0:
     }
   }
   for (let i = 0; i < 9; i++) {
@@ -35,8 +35,8 @@ export function returnStatement(): Configuration {
 //                 ^ reference local 2
       return {
         property: 41,
-//      ^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/property1:
-//      relationship implementation reference syntax 1.0.0 src/`infer-relationship.ts`/Configuration#property.
+//      ^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/property2:
+//      relationship implementation reference syntax 1.0.0 src/`infer-relationship.ts`/property0:
       }
     }
   }
@@ -47,14 +47,14 @@ export function returnStatement(): Configuration {
 //                 ^ reference local 5
       return {
         property: 41,
-//      ^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/property2:
-//      relationship implementation reference syntax 1.0.0 src/`infer-relationship.ts`/Configuration#property.
+//      ^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/property3:
+//      relationship implementation reference syntax 1.0.0 src/`infer-relationship.ts`/property0:
       }
     }
   }
   for (const i in { '1': 2 }) {
 //           ^ definition local 8
-//                  ^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/`'1'0`:
+//                  ^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/10:
     if (random() > Number.parseInt(i)) {
 //      ^^^^^^ reference syntax 1.0.0 src/`infer-relationship.ts`/random().
 //                 ^^^^^^ reference typescript 5.3.3 lib/`lib.es5.d.ts`/Number#
@@ -65,8 +65,8 @@ export function returnStatement(): Configuration {
 //                                 ^ reference local 8
       return {
         property: 41,
-//      ^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/property3:
-//      relationship implementation reference syntax 1.0.0 src/`infer-relationship.ts`/Configuration#property.
+//      ^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/property4:
+//      relationship implementation reference syntax 1.0.0 src/`infer-relationship.ts`/property0:
       }
     }
   }
@@ -74,8 +74,8 @@ export function returnStatement(): Configuration {
 //       ^^^^^^ reference syntax 1.0.0 src/`infer-relationship.ts`/random().
     return {
       property: 41,
-//    ^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/property4:
-//    relationship implementation reference syntax 1.0.0 src/`infer-relationship.ts`/Configuration#property.
+//    ^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/property5:
+//    relationship implementation reference syntax 1.0.0 src/`infer-relationship.ts`/property0:
     }
   }
   do {
@@ -83,8 +83,8 @@ export function returnStatement(): Configuration {
 //      ^^^^^^ reference syntax 1.0.0 src/`infer-relationship.ts`/random().
       return {
         property: 41,
-//      ^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/property5:
-//      relationship implementation reference syntax 1.0.0 src/`infer-relationship.ts`/Configuration#property.
+//      ^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/property6:
+//      relationship implementation reference syntax 1.0.0 src/`infer-relationship.ts`/property0:
       }
     }
   } while (random() < 0)
@@ -92,8 +92,8 @@ export function returnStatement(): Configuration {
 
   return {
     property: 42,
-//  ^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/property6:
-//  relationship implementation reference syntax 1.0.0 src/`infer-relationship.ts`/Configuration#property.
+//  ^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/property7:
+//  relationship implementation reference syntax 1.0.0 src/`infer-relationship.ts`/property0:
   }
 }
 
@@ -103,14 +103,14 @@ export function returnStatementInsideArgumentExpression(): Configuration[] {
   return [1].map<Configuration>(number => {
 //           ^^^ reference typescript 5.3.3 lib/`lib.es5.d.ts`/Array#map().
 //               ^^^^^^^^^^^^^ reference syntax 1.0.0 src/`infer-relationship.ts`/Configuration#
-//                              ^^^^^^ definition local 12
+//                              ^^^^^^ definition local 14
     const incremented = number + 1
-//        ^^^^^^^^^^^ definition local 15
-//                      ^^^^^^ reference local 12
+//        ^^^^^^^^^^^ definition local 17
+//                      ^^^^^^ reference local 14
     return {
       property: incremented,
-//    ^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/property7:
-//              ^^^^^^^^^^^ reference local 15
+//    ^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/property8:
+//              ^^^^^^^^^^^ reference local 17
     }
   })
 }

--- a/snapshots/output/syntax/src/inheritance.ts
+++ b/snapshots/output/syntax/src/inheritance.ts
@@ -7,7 +7,7 @@ import { Overloader } from './overload'
 export interface Superinterface {
 //               ^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/Superinterface#
   property: string
-//^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/Superinterface#property.
+//^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/property0:
   interfaceMethod(): string
 //^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/Superinterface#interfaceMethod().
 }
@@ -58,7 +58,7 @@ export class Subclass
   }
   property = 'property'
 //^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/Subclass#property.
-//relationship implementation reference syntax 1.0.0 src/`inheritance.ts`/Superinterface#property.
+//relationship implementation reference syntax 1.0.0 src/`inheritance.ts`/property0:
   public overrideMethod(): string {
 //       ^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/Subclass#overrideMethod().
 //       relationship implementation reference syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperclass#overrideMethod().
@@ -93,8 +93,8 @@ export const objectLiteralImplementation: Superinterface = {
 //           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/objectLiteralImplementation.
 //                                        ^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`inheritance.ts`/Superinterface#
   property: 'property',
-//^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/property0:
-//relationship implementation reference syntax 1.0.0 src/`inheritance.ts`/Superinterface#property.
+//^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/property1:
+//relationship implementation reference syntax 1.0.0 src/`inheritance.ts`/property0:
   interfaceMethod: (): string => {
 //^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/interfaceMethod0:
 //relationship implementation reference syntax 1.0.0 src/`inheritance.ts`/Superinterface#interfaceMethod().
@@ -115,8 +115,8 @@ export function infersInterface(): void {
 //  ^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/interfaceMethod1:
 //  relationship implementation reference syntax 1.0.0 src/`inheritance.ts`/Superinterface#interfaceMethod().
     property: 'inferred',
-//  ^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/property1:
-//  relationship implementation reference syntax 1.0.0 src/`inheritance.ts`/Superinterface#property.
+//  ^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/property2:
+//  relationship implementation reference syntax 1.0.0 src/`inheritance.ts`/property0:
   })
 }
 

--- a/snapshots/output/syntax/src/interface.ts
+++ b/snapshots/output/syntax/src/interface.ts
@@ -3,12 +3,12 @@
 export interface Interface {
 //               ^^^^^^^^^ definition syntax 1.0.0 src/`interface.ts`/Interface#
   property: string
-//^^^^^^^^ definition syntax 1.0.0 src/`interface.ts`/Interface#property.
+//^^^^^^^^ definition syntax 1.0.0 src/`interface.ts`/property0:
   methodSignature(param: string): string
 //^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`interface.ts`/Interface#methodSignature().
 //                ^^^^^ definition syntax 1.0.0 src/`interface.ts`/Interface#methodSignature().(param)
   methodSignature2: (param: string) => string
-//^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`interface.ts`/Interface#methodSignature2.
+//^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`interface.ts`/methodSignature20:
 //                   ^^^^^ definition local 1
 }
 
@@ -17,8 +17,8 @@ export function newInterface(): Interface {
 //                              ^^^^^^^^^ reference syntax 1.0.0 src/`interface.ts`/Interface#
   return {
     property: 'a',
-//  ^^^^^^^^ definition syntax 1.0.0 src/`interface.ts`/property0:
-//  relationship implementation reference syntax 1.0.0 src/`interface.ts`/Interface#property.
+//  ^^^^^^^^ definition syntax 1.0.0 src/`interface.ts`/property1:
+//  relationship implementation reference syntax 1.0.0 src/`interface.ts`/property0:
     methodSignature(param: string): string {
 //  ^^^^^^^^^^^^^^^ definition local 4
 //  relationship implementation reference syntax 1.0.0 src/`interface.ts`/Interface#methodSignature().
@@ -27,11 +27,11 @@ export function newInterface(): Interface {
 //           ^^^^^ reference local 5
     },
     methodSignature2: (param: string): string => {
-//  ^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`interface.ts`/methodSignature20:
-//  relationship implementation reference syntax 1.0.0 src/`interface.ts`/Interface#methodSignature2.
-//                     ^^^^^ definition local 7
+//  ^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`interface.ts`/methodSignature21:
+//  relationship implementation reference syntax 1.0.0 src/`interface.ts`/methodSignature20:
+//                     ^^^^^ definition local 8
       return param
-//           ^^^^^ reference local 7
+//           ^^^^^ reference local 8
     },
   }
 }

--- a/snapshots/output/syntax/src/local.ts
+++ b/snapshots/output/syntax/src/local.ts
@@ -17,7 +17,7 @@ export function local(): string {
 //         ^ definition local 12
 //                ^ reference local 12
 //                    ^ reference local 8
-//                      ^^^^^^ reference typescript 5.3.3 lib/`lib.es5.d.ts`/String#length.
+//                      ^^^^^^ reference typescript 5.3.3 lib/`lib.es5.d.ts`/length0:
 //                              ^ reference local 12
     c += d
 //  ^ reference local 8
@@ -25,7 +25,7 @@ export function local(): string {
     c2 += c.length
 //  ^^ reference local 9
 //        ^ reference local 8
-//          ^^^^^^ reference typescript 5.3.3 lib/`lib.es5.d.ts`/String#length.
+//          ^^^^^^ reference typescript 5.3.3 lib/`lib.es5.d.ts`/length0:
   }
   return [c, c2].reduce((previousValue, currentValue, currentIndex) => {
 //        ^ reference local 8

--- a/snapshots/output/syntax/src/minimized-signatures.ts
+++ b/snapshots/output/syntax/src/minimized-signatures.ts
@@ -2,86 +2,165 @@
 
 // format-options: showSignatures
 
-export type CompletionItemID = string & { _opaque: typeof CompletionItemID }
-//          ^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`minimized-signatures.ts`/CompletionItemID#
-//          info {
-//          |   "symbol": "scip-typescript npm syntax 1.0.0 src/`minimized-signatures.ts`/CompletionItemID#",
-//          |   "documentation": [
-//          |     "```ts\ntype CompletionItemID\n```"
-//          |   ],
-//          |   "relationships": [],
-//          |   "kind": 55,
-//          |   "display_name": "CompletionItemID",
-//          |   "enclosing_symbol": "",
-//          |   "signature": {
-//          |     "type_signature": {
-//          |       "type_parameters": {
-//          |         "symlinks": [],
-//          |         "hardlinks": []
-//          |       },
-//          |       "lower_bound": {
-//          |         "intersection_type": {
-//          |           "types": [
-//          |             {
-//          |               "type_ref": {
-//          |                 "symbol": "scip-typescript npm typescript . string#",
-//          |                 "type_arguments": []
-//          |               }
-//          |             },
-//          |             {
-//          |               "structural_type": {
-//          |                 "declarations": {
-//          |                   "symlinks": [
-//          |                     "scip-typescript npm syntax 1.0.0 src/`minimized-signatures.ts`/_opaque0:"
-//          |                   ],
-//          |                   "hardlinks": []
-//          |                 }
-//          |               }
-//          |             }
-//          |           ]
-//          |         }
-//          |       }
-//          |     }
-//          |   }
-//          | }
-//                                        ^^^^^^^ definition syntax 1.0.0 src/`minimized-signatures.ts`/_opaque0:
-//                                        info {
-//                                        |   "symbol": "scip-typescript npm syntax 1.0.0 src/`minimized-signatures.ts`/_opaque0:",
-//                                        |   "documentation": [
-//                                        |     "```ts\n(property) _opaque: unique symbol\n```"
-//                                        |   ],
-//                                        |   "relationships": [],
-//                                        |   "kind": 41,
-//                                        |   "display_name": "_opaque",
-//                                        |   "enclosing_symbol": "",
-//                                        |   "signature": {
-//                                        |     "value_signature": {
-//                                        |       "tpe": {}
-//                                        |     }
-//                                        |   }
-//                                        | }
-//                                                        ^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`minimized-signatures.ts`/CompletionItemID#
-//                                                        ^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`minimized-signatures.ts`/CompletionItemID.
-declare const CompletionItemID: unique symbol
-//            ^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`minimized-signatures.ts`/CompletionItemID.
-//            info {
-//            |   "symbol": "scip-typescript npm syntax 1.0.0 src/`minimized-signatures.ts`/CompletionItemID.",
-//            |   "documentation": [
-//            |     "```ts\nvar CompletionItemID: unique symbol\n```"
-//            |   ],
-//            |   "relationships": [],
-//            |   "kind": 61,
-//            |   "display_name": "CompletionItemID",
-//            |   "enclosing_symbol": "",
-//            |   "signature": {
-//            |     "value_signature": {
-//            |       "tpe": {
-//            |         "type_ref": {
-//            |           "symbol": "scip-typescript npm typescript . symbol#",
-//            |           "type_arguments": []
-//            |         }
-//            |       }
-//            |     }
-//            |   }
-//            | }
+export interface OptionalProperty {
+//               ^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`minimized-signatures.ts`/OptionalProperty#
+//               info {
+//               |   "symbol": "scip-typescript npm syntax 1.0.0 src/`minimized-signatures.ts`/OptionalProperty#",
+//               |   "documentation": [
+//               |     "```ts\ninterface OptionalProperty\n```"
+//               |   ],
+//               |   "relationships": [],
+//               |   "kind": 21,
+//               |   "display_name": "OptionalProperty",
+//               |   "enclosing_symbol": "",
+//               |   "signature": {
+//               |     "class_signature": {
+//               |       "type_parameters": {
+//               |         "symlinks": [],
+//               |         "hardlinks": []
+//               |       },
+//               |       "parents": [],
+//               |       "declarations": {
+//               |         "symlinks": [
+//               |           "scip-typescript npm syntax 1.0.0 src/`minimized-signatures.ts`/optional10:",
+//               |           "scip-typescript npm syntax 1.0.0 src/`minimized-signatures.ts`/optional20:",
+//               |           "scip-typescript npm syntax 1.0.0 src/`minimized-signatures.ts`/optional30:",
+//               |           "scip-typescript npm syntax 1.0.0 src/`minimized-signatures.ts`/optional40:"
+//               |         ],
+//               |         "hardlinks": []
+//               |       }
+//               |     }
+//               |   }
+//               | }
+  optional1?: string
+//^^^^^^^^^ definition syntax 1.0.0 src/`minimized-signatures.ts`/optional10:
+// info {
+// |   "symbol": "scip-typescript npm syntax 1.0.0 src/`minimized-signatures.ts`/optional10:",
+// |   "documentation": [
+// |     "```ts\n(property) optional1: string\n```"
+// |   ],
+// |   "relationships": [],
+// |   "kind": 41,
+// |   "display_name": "optional1",
+// |   "enclosing_symbol": "",
+// |   "signature": {
+// |     "value_signature": {
+// |       "tpe": {
+// |         "union_type": {
+// |           "types": [
+// |             {
+// |               "type_ref": {
+// |                 "symbol": "scip-typescript npm typescript . string#",
+// |                 "type_arguments": []
+// |               }
+// |             },
+// |             {
+// |               "type_ref": {
+// |                 "symbol": "scip-typescript npm typescript . undefined#",
+// |                 "type_arguments": []
+// |               }
+// |             }
+// |           ]
+// |         }
+// |       }
+// |     }
+// |   }
+// | }
+  optional2?: number | null
+//^^^^^^^^^ definition syntax 1.0.0 src/`minimized-signatures.ts`/optional20:
+// info {
+// |   "symbol": "scip-typescript npm syntax 1.0.0 src/`minimized-signatures.ts`/optional20:",
+// |   "documentation": [
+// |     "```ts\n(property) optional2: number\n```"
+// |   ],
+// |   "relationships": [],
+// |   "kind": 41,
+// |   "display_name": "optional2",
+// |   "enclosing_symbol": "",
+// |   "signature": {
+// |     "value_signature": {
+// |       "tpe": {
+// |         "union_type": {
+// |           "types": [
+// |             {
+// |               "type_ref": {
+// |                 "symbol": "scip-typescript npm typescript . number#",
+// |                 "type_arguments": []
+// |               }
+// |             },
+// |             {
+// |               "type_ref": {
+// |                 "symbol": "scip-typescript npm typescript . null#",
+// |                 "type_arguments": []
+// |               }
+// |             },
+// |             {
+// |               "type_ref": {
+// |                 "symbol": "scip-typescript npm typescript . undefined#",
+// |                 "type_arguments": []
+// |               }
+// |             }
+// |           ]
+// |         }
+// |       }
+// |     }
+// |   }
+// | }
+  optional3?: number | undefined
+//^^^^^^^^^ definition syntax 1.0.0 src/`minimized-signatures.ts`/optional30:
+// info {
+// |   "symbol": "scip-typescript npm syntax 1.0.0 src/`minimized-signatures.ts`/optional30:",
+// |   "documentation": [
+// |     "```ts\n(property) optional3: number\n```"
+// |   ],
+// |   "relationships": [],
+// |   "kind": 41,
+// |   "display_name": "optional3",
+// |   "enclosing_symbol": "",
+// |   "signature": {
+// |     "value_signature": {
+// |       "tpe": {
+// |         "union_type": {
+// |           "types": [
+// |             {
+// |               "type_ref": {
+// |                 "symbol": "scip-typescript npm typescript . number#",
+// |                 "type_arguments": []
+// |               }
+// |             },
+// |             {
+// |               "type_ref": {
+// |                 "symbol": "scip-typescript npm typescript . undefined#",
+// |                 "type_arguments": []
+// |               }
+// |             }
+// |           ]
+// |         }
+// |       }
+// |     }
+// |   }
+// | }
+  optional4?: undefined
+//^^^^^^^^^ definition syntax 1.0.0 src/`minimized-signatures.ts`/optional40:
+// info {
+// |   "symbol": "scip-typescript npm syntax 1.0.0 src/`minimized-signatures.ts`/optional40:",
+// |   "documentation": [
+// |     "```ts\n(property) optional4: undefined\n```"
+// |   ],
+// |   "relationships": [],
+// |   "kind": 41,
+// |   "display_name": "optional4",
+// |   "enclosing_symbol": "",
+// |   "signature": {
+// |     "value_signature": {
+// |       "tpe": {
+// |         "type_ref": {
+// |           "symbol": "scip-typescript npm typescript . undefined#",
+// |           "type_arguments": []
+// |         }
+// |       }
+// |     }
+// |   }
+// | }
+}
 

--- a/snapshots/output/syntax/src/minimized-signatures.ts
+++ b/snapshots/output/syntax/src/minimized-signatures.ts
@@ -1,0 +1,87 @@
+// < definition syntax 1.0.0 src/`minimized-signatures.ts`/
+
+// format-options: showSignatures
+
+export type CompletionItemID = string & { _opaque: typeof CompletionItemID }
+//          ^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`minimized-signatures.ts`/CompletionItemID#
+//          info {
+//          |   "symbol": "scip-typescript npm syntax 1.0.0 src/`minimized-signatures.ts`/CompletionItemID#",
+//          |   "documentation": [
+//          |     "```ts\ntype CompletionItemID\n```"
+//          |   ],
+//          |   "relationships": [],
+//          |   "kind": 55,
+//          |   "display_name": "CompletionItemID",
+//          |   "enclosing_symbol": "",
+//          |   "signature": {
+//          |     "type_signature": {
+//          |       "type_parameters": {
+//          |         "symlinks": [],
+//          |         "hardlinks": []
+//          |       },
+//          |       "lower_bound": {
+//          |         "intersection_type": {
+//          |           "types": [
+//          |             {
+//          |               "type_ref": {
+//          |                 "symbol": "scip-typescript npm typescript . string#",
+//          |                 "type_arguments": []
+//          |               }
+//          |             },
+//          |             {
+//          |               "structural_type": {
+//          |                 "declarations": {
+//          |                   "symlinks": [
+//          |                     "scip-typescript npm syntax 1.0.0 src/`minimized-signatures.ts`/_opaque0:"
+//          |                   ],
+//          |                   "hardlinks": []
+//          |                 }
+//          |               }
+//          |             }
+//          |           ]
+//          |         }
+//          |       }
+//          |     }
+//          |   }
+//          | }
+//                                        ^^^^^^^ definition syntax 1.0.0 src/`minimized-signatures.ts`/_opaque0:
+//                                        info {
+//                                        |   "symbol": "scip-typescript npm syntax 1.0.0 src/`minimized-signatures.ts`/_opaque0:",
+//                                        |   "documentation": [
+//                                        |     "```ts\n(property) _opaque: unique symbol\n```"
+//                                        |   ],
+//                                        |   "relationships": [],
+//                                        |   "kind": 41,
+//                                        |   "display_name": "_opaque",
+//                                        |   "enclosing_symbol": "",
+//                                        |   "signature": {
+//                                        |     "value_signature": {
+//                                        |       "tpe": {}
+//                                        |     }
+//                                        |   }
+//                                        | }
+//                                                        ^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`minimized-signatures.ts`/CompletionItemID#
+//                                                        ^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`minimized-signatures.ts`/CompletionItemID.
+declare const CompletionItemID: unique symbol
+//            ^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`minimized-signatures.ts`/CompletionItemID.
+//            info {
+//            |   "symbol": "scip-typescript npm syntax 1.0.0 src/`minimized-signatures.ts`/CompletionItemID.",
+//            |   "documentation": [
+//            |     "```ts\nvar CompletionItemID: unique symbol\n```"
+//            |   ],
+//            |   "relationships": [],
+//            |   "kind": 61,
+//            |   "display_name": "CompletionItemID",
+//            |   "enclosing_symbol": "",
+//            |   "signature": {
+//            |     "value_signature": {
+//            |       "tpe": {
+//            |         "type_ref": {
+//            |           "symbol": "scip-typescript npm typescript . symbol#",
+//            |           "type_arguments": []
+//            |         }
+//            |       }
+//            |     }
+//            |   }
+//            | }
+

--- a/snapshots/output/syntax/src/module.d.ts
+++ b/snapshots/output/syntax/src/module.d.ts
@@ -1,8 +1,8 @@
 // < definition syntax 1.0.0 src/`module.d.ts`/
 
 declare module 'a:b' {
-//             ^^^^^ definition syntax 1.0.0 src/`module.d.ts`/`'a:b'`/
+//             ^^^^^ definition syntax 1.0.0 src/`module.d.ts`/`a:b`/
   function hello(): string
-//         ^^^^^ definition syntax 1.0.0 src/`module.d.ts`/`'a:b'`/hello().
+//         ^^^^^ definition syntax 1.0.0 src/`module.d.ts`/`a:b`/hello().
 }
 

--- a/snapshots/output/syntax/src/namespace.ts
+++ b/snapshots/output/syntax/src/namespace.ts
@@ -7,7 +7,7 @@ export declare namespace a {
   interface Interface {
 //          ^^^^^^^^^ definition syntax 1.0.0 src/`namespace.ts`/a/Interface#
     hello: string
-//  ^^^^^ definition syntax 1.0.0 src/`namespace.ts`/a/Interface#hello.
+//  ^^^^^ definition syntax 1.0.0 src/`namespace.ts`/hello0:
   }
   var i: Interface
 //    ^ definition syntax 1.0.0 src/`namespace.ts`/a/i.

--- a/snapshots/output/syntax/src/signatures.ts
+++ b/snapshots/output/syntax/src/signatures.ts
@@ -507,6 +507,168 @@ export interface WorkspaceEditParams {
 //           | }
 }
 
+export interface OptionalProperty {
+//               ^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`signatures.ts`/OptionalProperty#
+//               info {
+//               |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/OptionalProperty#",
+//               |   "documentation": [
+//               |     "```ts\ninterface OptionalProperty\n```"
+//               |   ],
+//               |   "relationships": [],
+//               |   "kind": 21,
+//               |   "display_name": "OptionalProperty",
+//               |   "enclosing_symbol": "",
+//               |   "signature": {
+//               |     "class_signature": {
+//               |       "type_parameters": {
+//               |         "symlinks": [],
+//               |         "hardlinks": []
+//               |       },
+//               |       "parents": [],
+//               |       "declarations": {
+//               |         "symlinks": [
+//               |           "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/optional10:",
+//               |           "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/optional20:",
+//               |           "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/optional30:",
+//               |           "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/optional40:"
+//               |         ],
+//               |         "hardlinks": []
+//               |       }
+//               |     }
+//               |   }
+//               | }
+  optional1?: string
+//^^^^^^^^^ definition syntax 1.0.0 src/`signatures.ts`/optional10:
+// info {
+// |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/optional10:",
+// |   "documentation": [
+// |     "```ts\n(property) optional1: string\n```"
+// |   ],
+// |   "relationships": [],
+// |   "kind": 41,
+// |   "display_name": "optional1",
+// |   "enclosing_symbol": "",
+// |   "signature": {
+// |     "value_signature": {
+// |       "tpe": {
+// |         "union_type": {
+// |           "types": [
+// |             {
+// |               "type_ref": {
+// |                 "symbol": "scip-typescript npm typescript . string#",
+// |                 "type_arguments": []
+// |               }
+// |             },
+// |             {
+// |               "type_ref": {
+// |                 "symbol": "scip-typescript npm typescript . undefined#",
+// |                 "type_arguments": []
+// |               }
+// |             }
+// |           ]
+// |         }
+// |       }
+// |     }
+// |   }
+// | }
+  optional2?: number | null
+//^^^^^^^^^ definition syntax 1.0.0 src/`signatures.ts`/optional20:
+// info {
+// |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/optional20:",
+// |   "documentation": [
+// |     "```ts\n(property) optional2: number\n```"
+// |   ],
+// |   "relationships": [],
+// |   "kind": 41,
+// |   "display_name": "optional2",
+// |   "enclosing_symbol": "",
+// |   "signature": {
+// |     "value_signature": {
+// |       "tpe": {
+// |         "union_type": {
+// |           "types": [
+// |             {
+// |               "type_ref": {
+// |                 "symbol": "scip-typescript npm typescript . number#",
+// |                 "type_arguments": []
+// |               }
+// |             },
+// |             {
+// |               "type_ref": {
+// |                 "symbol": "scip-typescript npm typescript . null#",
+// |                 "type_arguments": []
+// |               }
+// |             },
+// |             {
+// |               "type_ref": {
+// |                 "symbol": "scip-typescript npm typescript . undefined#",
+// |                 "type_arguments": []
+// |               }
+// |             }
+// |           ]
+// |         }
+// |       }
+// |     }
+// |   }
+// | }
+  optional3?: number | undefined
+//^^^^^^^^^ definition syntax 1.0.0 src/`signatures.ts`/optional30:
+// info {
+// |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/optional30:",
+// |   "documentation": [
+// |     "```ts\n(property) optional3: number\n```"
+// |   ],
+// |   "relationships": [],
+// |   "kind": 41,
+// |   "display_name": "optional3",
+// |   "enclosing_symbol": "",
+// |   "signature": {
+// |     "value_signature": {
+// |       "tpe": {
+// |         "union_type": {
+// |           "types": [
+// |             {
+// |               "type_ref": {
+// |                 "symbol": "scip-typescript npm typescript . number#",
+// |                 "type_arguments": []
+// |               }
+// |             },
+// |             {
+// |               "type_ref": {
+// |                 "symbol": "scip-typescript npm typescript . undefined#",
+// |                 "type_arguments": []
+// |               }
+// |             }
+// |           ]
+// |         }
+// |       }
+// |     }
+// |   }
+// | }
+  optional4?: undefined
+//^^^^^^^^^ definition syntax 1.0.0 src/`signatures.ts`/optional40:
+// info {
+// |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/optional40:",
+// |   "documentation": [
+// |     "```ts\n(property) optional4: undefined\n```"
+// |   ],
+// |   "relationships": [],
+// |   "kind": 41,
+// |   "display_name": "optional4",
+// |   "enclosing_symbol": "",
+// |   "signature": {
+// |     "value_signature": {
+// |       "tpe": {
+// |         "type_ref": {
+// |           "symbol": "scip-typescript npm typescript . undefined#",
+// |           "type_arguments": []
+// |         }
+// |       }
+// |     }
+// |   }
+// | }
+}
+
 export interface ExampleSuperInterface<T> {
 //               ^^^^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`signatures.ts`/ExampleSuperInterface#
 //               info {

--- a/snapshots/output/syntax/src/signatures.ts
+++ b/snapshots/output/syntax/src/signatures.ts
@@ -1,0 +1,1981 @@
+// < definition syntax 1.0.0 src/`signatures.ts`/
+
+// format-options: showSignatures
+
+export type Requests = {
+//          ^^^^^^^^ definition syntax 1.0.0 src/`signatures.ts`/Requests#
+//          info {
+//          |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/Requests#",
+//          |   "documentation": [
+//          |     "```ts\ntype Requests\n```"
+//          |   ],
+//          |   "relationships": [],
+//          |   "kind": 55,
+//          |   "display_name": "Requests",
+//          |   "enclosing_symbol": "",
+//          |   "signature": {
+//          |     "type_signature": {
+//          |       "type_parameters": {
+//          |         "symlinks": [],
+//          |         "hardlinks": []
+//          |       },
+//          |       "lower_bound": {
+//          |         "structural_type": {
+//          |           "declarations": {
+//          |             "symlinks": [
+//          |               "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/`workspace/edit0`:",
+//          |               "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/`chat/submitMessage0`:"
+//          |             ],
+//          |             "hardlinks": []
+//          |           }
+//          |         }
+//          |       }
+//          |     }
+//          |   }
+//          | }
+  'workspace/edit': [WorkspaceEditParams, boolean]
+//^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`signatures.ts`/`workspace/edit0`:
+// info {
+// |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/`workspace/edit0`:",
+// |   "documentation": [
+// |     "```ts\n(property) 'workspace/edit': [WorkspaceEditParams, boolean]\n```"
+// |   ],
+// |   "relationships": [],
+// |   "kind": 41,
+// |   "display_name": "workspace/edit",
+// |   "enclosing_symbol": "",
+// |   "signature": {
+// |     "value_signature": {
+// |       "tpe": {
+// |         "type_ref": {
+// |           "symbol": "scip-typescript npm typescript . tuple#",
+// |           "type_arguments": [
+// |             {
+// |               "type_ref": {
+// |                 "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/WorkspaceEditParams#",
+// |                 "type_arguments": []
+// |               }
+// |             },
+// |             {
+// |               "type_ref": {
+// |                 "symbol": "scip-typescript npm typescript . boolean#",
+// |                 "type_arguments": []
+// |               }
+// |             }
+// |           ]
+// |         }
+// |       }
+// |     }
+// |   }
+// | }
+//                   ^^^^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`signatures.ts`/WorkspaceEditParams#
+  'chat/submitMessage': [WorkspaceEditParams, boolean]
+//^^^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`signatures.ts`/`chat/submitMessage0`:
+// info {
+// |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/`chat/submitMessage0`:",
+// |   "documentation": [
+// |     "```ts\n(property) 'chat/submitMessage': [WorkspaceEditParams, boolean]\n```"
+// |   ],
+// |   "relationships": [],
+// |   "kind": 41,
+// |   "display_name": "chat/submitMessage",
+// |   "enclosing_symbol": "",
+// |   "signature": {
+// |     "value_signature": {
+// |       "tpe": {
+// |         "type_ref": {
+// |           "symbol": "scip-typescript npm typescript . tuple#",
+// |           "type_arguments": [
+// |             {
+// |               "type_ref": {
+// |                 "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/WorkspaceEditParams#",
+// |                 "type_arguments": []
+// |               }
+// |             },
+// |             {
+// |               "type_ref": {
+// |                 "symbol": "scip-typescript npm typescript . boolean#",
+// |                 "type_arguments": []
+// |               }
+// |             }
+// |           ]
+// |         }
+// |       }
+// |     }
+// |   }
+// | }
+//                       ^^^^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`signatures.ts`/WorkspaceEditParams#
+}
+
+export type Notifications = {
+//          ^^^^^^^^^^^^^ definition syntax 1.0.0 src/`signatures.ts`/Notifications#
+//          info {
+//          |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/Notifications#",
+//          |   "documentation": [
+//          |     "```ts\ntype Notifications\n```"
+//          |   ],
+//          |   "relationships": [],
+//          |   "kind": 55,
+//          |   "display_name": "Notifications",
+//          |   "enclosing_symbol": "",
+//          |   "signature": {
+//          |     "type_signature": {
+//          |       "type_parameters": {
+//          |         "symlinks": [],
+//          |         "hardlinks": []
+//          |       },
+//          |       "lower_bound": {
+//          |         "structural_type": {
+//          |           "declarations": {
+//          |             "symlinks": [
+//          |               "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/`workspace/edit1`:"
+//          |             ],
+//          |             "hardlinks": []
+//          |           }
+//          |         }
+//          |       }
+//          |     }
+//          |   }
+//          | }
+  'workspace/edit': [WorkspaceEditParams]
+//^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`signatures.ts`/`workspace/edit1`:
+// info {
+// |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/`workspace/edit1`:",
+// |   "documentation": [
+// |     "```ts\n(property) 'workspace/edit': [WorkspaceEditParams]\n```"
+// |   ],
+// |   "relationships": [],
+// |   "kind": 41,
+// |   "display_name": "workspace/edit",
+// |   "enclosing_symbol": "",
+// |   "signature": {
+// |     "value_signature": {
+// |       "tpe": {
+// |         "type_ref": {
+// |           "symbol": "scip-typescript npm typescript . tuple#",
+// |           "type_arguments": [
+// |             {
+// |               "type_ref": {
+// |                 "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/WorkspaceEditParams#",
+// |                 "type_arguments": []
+// |               }
+// |             }
+// |           ]
+// |         }
+// |       }
+// |     }
+// |   }
+// | }
+//                   ^^^^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`signatures.ts`/WorkspaceEditParams#
+}
+
+export type Intersection = { uri: string } & { size: number }
+//          ^^^^^^^^^^^^ definition syntax 1.0.0 src/`signatures.ts`/Intersection#
+//          info {
+//          |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/Intersection#",
+//          |   "documentation": [
+//          |     "```ts\ntype Intersection\n```"
+//          |   ],
+//          |   "relationships": [],
+//          |   "kind": 55,
+//          |   "display_name": "Intersection",
+//          |   "enclosing_symbol": "",
+//          |   "signature": {
+//          |     "type_signature": {
+//          |       "type_parameters": {
+//          |         "symlinks": [],
+//          |         "hardlinks": []
+//          |       },
+//          |       "lower_bound": {
+//          |         "intersection_type": {
+//          |           "types": [
+//          |             {
+//          |               "structural_type": {
+//          |                 "declarations": {
+//          |                   "symlinks": [
+//          |                     "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/uri0:"
+//          |                   ],
+//          |                   "hardlinks": []
+//          |                 }
+//          |               }
+//          |             },
+//          |             {
+//          |               "structural_type": {
+//          |                 "declarations": {
+//          |                   "symlinks": [
+//          |                     "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/size0:"
+//          |                   ],
+//          |                   "hardlinks": []
+//          |                 }
+//          |               }
+//          |             }
+//          |           ]
+//          |         }
+//          |       }
+//          |     }
+//          |   }
+//          | }
+//                           ^^^ definition syntax 1.0.0 src/`signatures.ts`/uri0:
+//                           info {
+//                           |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/uri0:",
+//                           |   "documentation": [
+//                           |     "```ts\n(property) uri: string\n```"
+//                           |   ],
+//                           |   "relationships": [],
+//                           |   "kind": 41,
+//                           |   "display_name": "uri",
+//                           |   "enclosing_symbol": "",
+//                           |   "signature": {
+//                           |     "value_signature": {
+//                           |       "tpe": {
+//                           |         "type_ref": {
+//                           |           "symbol": "scip-typescript npm typescript . string#",
+//                           |           "type_arguments": []
+//                           |         }
+//                           |       }
+//                           |     }
+//                           |   }
+//                           | }
+//                                             ^^^^ definition syntax 1.0.0 src/`signatures.ts`/size0:
+//                                             info {
+//                                             |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/size0:",
+//                                             |   "documentation": [
+//                                             |     "```ts\n(property) size: number\n```"
+//                                             |   ],
+//                                             |   "relationships": [],
+//                                             |   "kind": 41,
+//                                             |   "display_name": "size",
+//                                             |   "enclosing_symbol": "",
+//                                             |   "signature": {
+//                                             |     "value_signature": {
+//                                             |       "tpe": {
+//                                             |         "type_ref": {
+//                                             |           "symbol": "scip-typescript npm typescript . number#",
+//                                             |           "type_arguments": []
+//                                             |         }
+//                                             |       }
+//                                             |     }
+//                                             |   }
+//                                             | }
+export type Union = { uri: string } | { size: number }
+//          ^^^^^ definition syntax 1.0.0 src/`signatures.ts`/Union#
+//          info {
+//          |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/Union#",
+//          |   "documentation": [
+//          |     "```ts\ntype Union\n```"
+//          |   ],
+//          |   "relationships": [],
+//          |   "kind": 55,
+//          |   "display_name": "Union",
+//          |   "enclosing_symbol": "",
+//          |   "signature": {
+//          |     "type_signature": {
+//          |       "type_parameters": {
+//          |         "symlinks": [],
+//          |         "hardlinks": []
+//          |       },
+//          |       "lower_bound": {
+//          |         "union_type": {
+//          |           "types": [
+//          |             {
+//          |               "structural_type": {
+//          |                 "declarations": {
+//          |                   "symlinks": [
+//          |                     "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/uri1:"
+//          |                   ],
+//          |                   "hardlinks": []
+//          |                 }
+//          |               }
+//          |             },
+//          |             {
+//          |               "structural_type": {
+//          |                 "declarations": {
+//          |                   "symlinks": [
+//          |                     "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/size1:"
+//          |                   ],
+//          |                   "hardlinks": []
+//          |                 }
+//          |               }
+//          |             }
+//          |           ]
+//          |         }
+//          |       }
+//          |     }
+//          |   }
+//          | }
+//                    ^^^ definition syntax 1.0.0 src/`signatures.ts`/uri1:
+//                    info {
+//                    |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/uri1:",
+//                    |   "documentation": [
+//                    |     "```ts\n(property) uri: string\n```"
+//                    |   ],
+//                    |   "relationships": [],
+//                    |   "kind": 41,
+//                    |   "display_name": "uri",
+//                    |   "enclosing_symbol": "",
+//                    |   "signature": {
+//                    |     "value_signature": {
+//                    |       "tpe": {
+//                    |         "type_ref": {
+//                    |           "symbol": "scip-typescript npm typescript . string#",
+//                    |           "type_arguments": []
+//                    |         }
+//                    |       }
+//                    |     }
+//                    |   }
+//                    | }
+//                                      ^^^^ definition syntax 1.0.0 src/`signatures.ts`/size1:
+//                                      info {
+//                                      |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/size1:",
+//                                      |   "documentation": [
+//                                      |     "```ts\n(property) size: number\n```"
+//                                      |   ],
+//                                      |   "relationships": [],
+//                                      |   "kind": 41,
+//                                      |   "display_name": "size",
+//                                      |   "enclosing_symbol": "",
+//                                      |   "signature": {
+//                                      |     "value_signature": {
+//                                      |       "tpe": {
+//                                      |         "type_ref": {
+//                                      |           "symbol": "scip-typescript npm typescript . number#",
+//                                      |           "type_arguments": []
+//                                      |         }
+//                                      |       }
+//                                      |     }
+//                                      |   }
+//                                      | }
+export type Builtin = Pick<WorkspaceEditParams, 'changes'>
+//          ^^^^^^^ definition syntax 1.0.0 src/`signatures.ts`/Builtin#
+//          info {
+//          |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/Builtin#",
+//          |   "documentation": [
+//          |     "```ts\ntype Builtin\n```"
+//          |   ],
+//          |   "relationships": [],
+//          |   "kind": 55,
+//          |   "display_name": "Builtin",
+//          |   "enclosing_symbol": "",
+//          |   "signature": {
+//          |     "type_signature": {
+//          |       "type_parameters": {
+//          |         "symlinks": [],
+//          |         "hardlinks": []
+//          |       },
+//          |       "lower_bound": {
+//          |         "type_ref": {
+//          |           "symbol": "scip-typescript npm typescript 5.3.3 lib/`lib.es5.d.ts`/Pick#",
+//          |           "type_arguments": [
+//          |             {
+//          |               "type_ref": {
+//          |                 "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/WorkspaceEditParams#",
+//          |                 "type_arguments": []
+//          |               }
+//          |             },
+//          |             {
+//          |               "constant_type": {
+//          |                 "constant": {
+//          |                   "string_constant": {
+//          |                     "value": "changes"
+//          |                   }
+//          |                 }
+//          |               }
+//          |             }
+//          |           ]
+//          |         }
+//          |       }
+//          |     }
+//          |   }
+//          | }
+//                    ^^^^ reference typescript 5.3.3 lib/`lib.es5.d.ts`/Pick#
+//                         ^^^^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`signatures.ts`/WorkspaceEditParams#
+export type Builtin2 = Partial<WorkspaceEditParams>
+//          ^^^^^^^^ definition syntax 1.0.0 src/`signatures.ts`/Builtin2#
+//          info {
+//          |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/Builtin2#",
+//          |   "documentation": [
+//          |     "```ts\ntype Builtin2\n```"
+//          |   ],
+//          |   "relationships": [],
+//          |   "kind": 55,
+//          |   "display_name": "Builtin2",
+//          |   "enclosing_symbol": "",
+//          |   "signature": {
+//          |     "type_signature": {
+//          |       "type_parameters": {
+//          |         "symlinks": [],
+//          |         "hardlinks": []
+//          |       },
+//          |       "lower_bound": {
+//          |         "type_ref": {
+//          |           "symbol": "scip-typescript npm typescript 5.3.3 lib/`lib.es5.d.ts`/Partial#",
+//          |           "type_arguments": [
+//          |             {
+//          |               "type_ref": {
+//          |                 "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/WorkspaceEditParams#",
+//          |                 "type_arguments": []
+//          |               }
+//          |             }
+//          |           ]
+//          |         }
+//          |       }
+//          |     }
+//          |   }
+//          | }
+//                     ^^^^^^^ reference typescript 5.3.3 lib/`lib.es5.d.ts`/Partial#
+//                             ^^^^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`signatures.ts`/WorkspaceEditParams#
+export interface WorkspaceEditParams {
+//               ^^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`signatures.ts`/WorkspaceEditParams#
+//               info {
+//               |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/WorkspaceEditParams#",
+//               |   "documentation": [
+//               |     "```ts\ninterface WorkspaceEditParams\n```"
+//               |   ],
+//               |   "relationships": [],
+//               |   "kind": 21,
+//               |   "display_name": "WorkspaceEditParams",
+//               |   "enclosing_symbol": "",
+//               |   "signature": {
+//               |     "class_signature": {
+//               |       "type_parameters": {
+//               |         "symlinks": [],
+//               |         "hardlinks": []
+//               |       },
+//               |       "parents": [],
+//               |       "declarations": {
+//               |         "symlinks": [
+//               |           "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/changes0:"
+//               |         ],
+//               |         "hardlinks": []
+//               |       }
+//               |     }
+//               |   }
+//               | }
+  changes: { uri: string }[]
+//^^^^^^^ definition syntax 1.0.0 src/`signatures.ts`/changes0:
+// info {
+// |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/changes0:",
+// |   "documentation": [
+// |     "```ts\n(property) changes: { uri: string; }[]\n```"
+// |   ],
+// |   "relationships": [],
+// |   "kind": 41,
+// |   "display_name": "changes",
+// |   "enclosing_symbol": "",
+// |   "signature": {
+// |     "value_signature": {
+// |       "tpe": {
+// |         "type_ref": {
+// |           "symbol": "scip-typescript npm typescript . array#",
+// |           "type_arguments": [
+// |             {
+// |               "structural_type": {
+// |                 "declarations": {
+// |                   "symlinks": [
+// |                     "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/uri2:"
+// |                   ],
+// |                   "hardlinks": []
+// |                 }
+// |               }
+// |             }
+// |           ]
+// |         }
+// |       }
+// |     }
+// |   }
+// | }
+//           ^^^ definition syntax 1.0.0 src/`signatures.ts`/uri2:
+//           info {
+//           |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/uri2:",
+//           |   "documentation": [
+//           |     "```ts\n(property) uri: string\n```"
+//           |   ],
+//           |   "relationships": [],
+//           |   "kind": 41,
+//           |   "display_name": "uri",
+//           |   "enclosing_symbol": "",
+//           |   "signature": {
+//           |     "value_signature": {
+//           |       "tpe": {
+//           |         "type_ref": {
+//           |           "symbol": "scip-typescript npm typescript . string#",
+//           |           "type_arguments": []
+//           |         }
+//           |       }
+//           |     }
+//           |   }
+//           | }
+}
+
+export interface ExampleSuperInterface<T> {
+//               ^^^^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`signatures.ts`/ExampleSuperInterface#
+//               info {
+//               |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleSuperInterface#",
+//               |   "documentation": [
+//               |     "```ts\ninterface ExampleSuperInterface\n```"
+//               |   ],
+//               |   "relationships": [],
+//               |   "kind": 21,
+//               |   "display_name": "ExampleSuperInterface",
+//               |   "enclosing_symbol": "",
+//               |   "signature": {
+//               |     "class_signature": {
+//               |       "type_parameters": {
+//               |         "symlinks": [
+//               |           "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleSuperInterface#[T]"
+//               |         ],
+//               |         "hardlinks": []
+//               |       },
+//               |       "parents": [],
+//               |       "declarations": {
+//               |         "symlinks": [
+//               |           "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/a0:",
+//               |           "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/b0:"
+//               |         ],
+//               |         "hardlinks": []
+//               |       }
+//               |     }
+//               |   }
+//               | }
+//                                     ^ definition syntax 1.0.0 src/`signatures.ts`/ExampleSuperInterface#[T]
+//                                     info {
+//                                     |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleSuperInterface#[T]",
+//                                     |   "documentation": [
+//                                     |     "```ts\nT: T\n```"
+//                                     |   ],
+//                                     |   "relationships": [],
+//                                     |   "kind": 58,
+//                                     |   "display_name": "T",
+//                                     |   "enclosing_symbol": "",
+//                                     |   "signature": {}
+//                                     | }
+  a: T
+//^ definition syntax 1.0.0 src/`signatures.ts`/a0:
+// info {
+// |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/a0:",
+// |   "documentation": [
+// |     "```ts\n(property) a: T\n```"
+// |   ],
+// |   "relationships": [],
+// |   "kind": 41,
+// |   "display_name": "a",
+// |   "enclosing_symbol": "",
+// |   "signature": {
+// |     "value_signature": {
+// |       "tpe": {
+// |         "type_ref": {
+// |           "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleSuperInterface#[T]",
+// |           "type_arguments": []
+// |         }
+// |       }
+// |     }
+// |   }
+// | }
+//   ^ reference syntax 1.0.0 src/`signatures.ts`/ExampleSuperInterface#[T]
+  b: string
+//^ definition syntax 1.0.0 src/`signatures.ts`/b0:
+// info {
+// |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/b0:",
+// |   "documentation": [
+// |     "```ts\n(property) b: string\n```"
+// |   ],
+// |   "relationships": [],
+// |   "kind": 41,
+// |   "display_name": "b",
+// |   "enclosing_symbol": "",
+// |   "signature": {
+// |     "value_signature": {
+// |       "tpe": {
+// |         "type_ref": {
+// |           "symbol": "scip-typescript npm typescript . string#",
+// |           "type_arguments": []
+// |         }
+// |       }
+// |     }
+// |   }
+// | }
+}
+export interface ExampleInterface<T> extends ExampleSuperInterface<T> {
+//               ^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`signatures.ts`/ExampleInterface#
+//               info {
+//               |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleInterface#",
+//               |   "documentation": [
+//               |     "```ts\ninterface ExampleInterface\n```"
+//               |   ],
+//               |   "relationships": [],
+//               |   "kind": 21,
+//               |   "display_name": "ExampleInterface",
+//               |   "enclosing_symbol": "",
+//               |   "signature": {
+//               |     "class_signature": {
+//               |       "type_parameters": {
+//               |         "symlinks": [
+//               |           "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleInterface#[T]"
+//               |         ],
+//               |         "hardlinks": []
+//               |       },
+//               |       "parents": [
+//               |         {
+//               |           "type_ref": {
+//               |             "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleSuperInterface#",
+//               |             "type_arguments": [
+//               |               {
+//               |                 "type_ref": {
+//               |                   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleInterface#[T]",
+//               |                   "type_arguments": []
+//               |                 }
+//               |               }
+//               |             ]
+//               |           }
+//               |         }
+//               |       ],
+//               |       "declarations": {
+//               |         "symlinks": [
+//               |           "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/c0:"
+//               |         ],
+//               |         "hardlinks": []
+//               |       }
+//               |     }
+//               |   }
+//               | }
+//                                ^ definition syntax 1.0.0 src/`signatures.ts`/ExampleInterface#[T]
+//                                info {
+//                                |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleInterface#[T]",
+//                                |   "documentation": [
+//                                |     "```ts\nT: T\n```"
+//                                |   ],
+//                                |   "relationships": [],
+//                                |   "kind": 58,
+//                                |   "display_name": "T",
+//                                |   "enclosing_symbol": "",
+//                                |   "signature": {}
+//                                | }
+//                                           ^^^^^^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`signatures.ts`/ExampleSuperInterface#
+//                                                                 ^ reference syntax 1.0.0 src/`signatures.ts`/ExampleInterface#[T]
+  c: number
+//^ definition syntax 1.0.0 src/`signatures.ts`/c0:
+// info {
+// |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/c0:",
+// |   "documentation": [
+// |     "```ts\n(property) c: number\n```"
+// |   ],
+// |   "relationships": [],
+// |   "kind": 41,
+// |   "display_name": "c",
+// |   "enclosing_symbol": "",
+// |   "signature": {
+// |     "value_signature": {
+// |       "tpe": {
+// |         "type_ref": {
+// |           "symbol": "scip-typescript npm typescript . number#",
+// |           "type_arguments": []
+// |         }
+// |       }
+// |     }
+// |   }
+// | }
+}
+export class ExampleSuperClass<T> {
+//           ^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`signatures.ts`/ExampleSuperClass#
+//           info {
+//           |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleSuperClass#",
+//           |   "documentation": [
+//           |     "```ts\nclass ExampleSuperClass\n```"
+//           |   ],
+//           |   "relationships": [],
+//           |   "kind": 7,
+//           |   "display_name": "ExampleSuperClass",
+//           |   "enclosing_symbol": "",
+//           |   "signature": {
+//           |     "class_signature": {
+//           |       "type_parameters": {
+//           |         "symlinks": [
+//           |           "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleSuperClass#[T]"
+//           |         ],
+//           |         "hardlinks": []
+//           |       },
+//           |       "parents": [],
+//           |       "declarations": {
+//           |         "symlinks": [
+//           |           "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleSuperClass#`<constructor>`()."
+//           |         ],
+//           |         "hardlinks": []
+//           |       }
+//           |     }
+//           |   }
+//           | }
+//                             ^ definition syntax 1.0.0 src/`signatures.ts`/ExampleSuperClass#[T]
+//                             info {
+//                             |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleSuperClass#[T]",
+//                             |   "documentation": [
+//                             |     "```ts\nT: T\n```"
+//                             |   ],
+//                             |   "relationships": [],
+//                             |   "kind": 58,
+//                             |   "display_name": "T",
+//                             |   "enclosing_symbol": "",
+//                             |   "signature": {}
+//                             | }
+  constructor(
+//^^^^^^^^^^^ definition syntax 1.0.0 src/`signatures.ts`/ExampleSuperClass#`<constructor>`().
+// info {
+// |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleSuperClass#`<constructor>`().",
+// |   "documentation": [
+// |     "```ts\nconstructor<T>(a: T, b: string): ExampleSuperClass<T>\n```"
+// |   ],
+// |   "relationships": [],
+// |   "kind": 9,
+// |   "display_name": "",
+// |   "enclosing_symbol": "",
+// |   "signature": {
+// |     "method_signature": {
+// |       "type_parameters": {
+// |         "symlinks": [],
+// |         "hardlinks": []
+// |       },
+// |       "parameter_lists": [
+// |         {
+// |           "symlinks": [
+// |             "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleSuperClass#`<constructor>`().(a)",
+// |             "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleSuperClass#`<constructor>`().(b)"
+// |           ],
+// |           "hardlinks": []
+// |         }
+// |       ]
+// |     }
+// |   }
+// | }
+    public a: T,
+//         ^ definition syntax 1.0.0 src/`signatures.ts`/ExampleSuperClass#`<constructor>`().(a)
+//         info {
+//         |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleSuperClass#`<constructor>`().(a)",
+//         |   "documentation": [
+//         |     "```ts\n(property) a: T\n```"
+//         |   ],
+//         |   "relationships": [],
+//         |   "kind": 37,
+//         |   "display_name": "a",
+//         |   "enclosing_symbol": "",
+//         |   "signature": {
+//         |     "value_signature": {
+//         |       "tpe": {
+//         |         "type_ref": {
+//         |           "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleSuperClass#[T]",
+//         |           "type_arguments": []
+//         |         }
+//         |       }
+//         |     }
+//         |   }
+//         | }
+//            ^ reference syntax 1.0.0 src/`signatures.ts`/ExampleSuperClass#[T]
+    public b: string
+//         ^ definition syntax 1.0.0 src/`signatures.ts`/ExampleSuperClass#`<constructor>`().(b)
+//         info {
+//         |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleSuperClass#`<constructor>`().(b)",
+//         |   "documentation": [
+//         |     "```ts\n(property) b: string\n```"
+//         |   ],
+//         |   "relationships": [],
+//         |   "kind": 37,
+//         |   "display_name": "b",
+//         |   "enclosing_symbol": "",
+//         |   "signature": {
+//         |     "value_signature": {
+//         |       "tpe": {
+//         |         "type_ref": {
+//         |           "symbol": "scip-typescript npm typescript . string#",
+//         |           "type_arguments": []
+//         |         }
+//         |       }
+//         |     }
+//         |   }
+//         | }
+  ) {}
+}
+
+export class ExampleClass<T>
+//           ^^^^^^^^^^^^ definition syntax 1.0.0 src/`signatures.ts`/ExampleClass#
+//           relationship implementation syntax 1.0.0 src/`signatures.ts`/ExampleInterface#
+//           relationship implementation syntax 1.0.0 src/`signatures.ts`/ExampleSuperClass#
+//           relationship implementation syntax 1.0.0 src/`signatures.ts`/ExampleSuperInterface#
+//           info {
+//           |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleClass#",
+//           |   "documentation": [
+//           |     "```ts\nclass ExampleClass\n```"
+//           |   ],
+//           |   "relationships": [
+//           |     {
+//           |       "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleInterface#",
+//           |       "is_reference": false,
+//           |       "is_implementation": true,
+//           |       "is_type_definition": false,
+//           |       "is_definition": false
+//           |     },
+//           |     {
+//           |       "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleSuperClass#",
+//           |       "is_reference": false,
+//           |       "is_implementation": true,
+//           |       "is_type_definition": false,
+//           |       "is_definition": false
+//           |     },
+//           |     {
+//           |       "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleSuperInterface#",
+//           |       "is_reference": false,
+//           |       "is_implementation": true,
+//           |       "is_type_definition": false,
+//           |       "is_definition": false
+//           |     }
+//           |   ],
+//           |   "kind": 7,
+//           |   "display_name": "ExampleClass",
+//           |   "enclosing_symbol": "",
+//           |   "signature": {
+//           |     "class_signature": {
+//           |       "type_parameters": {
+//           |         "symlinks": [
+//           |           "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleClass#[T]"
+//           |         ],
+//           |         "hardlinks": []
+//           |       },
+//           |       "parents": [
+//           |         {
+//           |           "type_ref": {
+//           |             "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleSuperClass#",
+//           |             "type_arguments": [
+//           |               {
+//           |                 "type_ref": {
+//           |                   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleClass#[T]",
+//           |                   "type_arguments": []
+//           |                 }
+//           |               }
+//           |             ]
+//           |           }
+//           |         },
+//           |         {
+//           |           "type_ref": {
+//           |             "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleSuperInterface#",
+//           |             "type_arguments": [
+//           |               {
+//           |                 "type_ref": {
+//           |                   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleClass#[T]",
+//           |                   "type_arguments": []
+//           |                 }
+//           |               }
+//           |             ]
+//           |           }
+//           |         },
+//           |         {
+//           |           "type_ref": {
+//           |             "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleInterface#",
+//           |             "type_arguments": [
+//           |               {
+//           |                 "type_ref": {
+//           |                   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleClass#[T]",
+//           |                   "type_arguments": []
+//           |                 }
+//           |               }
+//           |             ]
+//           |           }
+//           |         }
+//           |       ],
+//           |       "declarations": {
+//           |         "symlinks": [
+//           |           "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleClass#d.",
+//           |           "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleClass#`#e`.",
+//           |           "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleClass#`<constructor>`().",
+//           |           "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleClass#getC().",
+//           |           "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleClass#`<get>e`().",
+//           |           "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleClass#`<set>setB`()."
+//           |         ],
+//           |         "hardlinks": []
+//           |       }
+//           |     }
+//           |   }
+//           | }
+//                        ^ definition syntax 1.0.0 src/`signatures.ts`/ExampleClass#[T]
+//                        info {
+//                        |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleClass#[T]",
+//                        |   "documentation": [
+//                        |     "```ts\nT: T\n```"
+//                        |   ],
+//                        |   "relationships": [],
+//                        |   "kind": 58,
+//                        |   "display_name": "T",
+//                        |   "enclosing_symbol": "",
+//                        |   "signature": {}
+//                        | }
+  extends ExampleSuperClass<T>
+//        ^^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`signatures.ts`/ExampleSuperClass#
+//                          ^ reference syntax 1.0.0 src/`signatures.ts`/ExampleClass#[T]
+  implements ExampleSuperInterface<T>, ExampleInterface<T>
+//           ^^^^^^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`signatures.ts`/ExampleSuperInterface#
+//                                 ^ reference syntax 1.0.0 src/`signatures.ts`/ExampleClass#[T]
+//                                     ^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`signatures.ts`/ExampleInterface#
+//                                                      ^ reference syntax 1.0.0 src/`signatures.ts`/ExampleClass#[T]
+{
+  public d: Record<string, any>
+//       ^ definition syntax 1.0.0 src/`signatures.ts`/ExampleClass#d.
+//       info {
+//       |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleClass#d.",
+//       |   "documentation": [
+//       |     "```ts\n(property) d: Record<string, any>\n```"
+//       |   ],
+//       |   "relationships": [],
+//       |   "kind": 41,
+//       |   "display_name": "d",
+//       |   "enclosing_symbol": "",
+//       |   "signature": {
+//       |     "value_signature": {
+//       |       "tpe": {
+//       |         "type_ref": {
+//       |           "symbol": "scip-typescript npm typescript 5.3.3 lib/`lib.es5.d.ts`/Record#",
+//       |           "type_arguments": [
+//       |             {
+//       |               "type_ref": {
+//       |                 "symbol": "scip-typescript npm typescript . string#",
+//       |                 "type_arguments": []
+//       |               }
+//       |             },
+//       |             {
+//       |               "type_ref": {
+//       |                 "symbol": "scip-typescript npm typescript . any#",
+//       |                 "type_arguments": []
+//       |               }
+//       |             }
+//       |           ]
+//       |         }
+//       |       }
+//       |     }
+//       |   }
+//       | }
+//          ^^^^^^ reference typescript 5.3.3 lib/`lib.es5.d.ts`/Record#
+
+  #e = true
+//^^ definition syntax 1.0.0 src/`signatures.ts`/ExampleClass#`#e`.
+// info {
+// |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleClass#`#e`.",
+// |   "documentation": [
+// |     "```ts\n(property) #e: boolean\n```"
+// |   ],
+// |   "relationships": [],
+// |   "kind": 41,
+// |   "display_name": "#e",
+// |   "enclosing_symbol": "",
+// |   "signature": {
+// |     "value_signature": {
+// |       "tpe": {
+// |         "type_ref": {
+// |           "symbol": "scip-typescript npm typescript . true#",
+// |           "type_arguments": []
+// |         }
+// |       }
+// |     }
+// |   }
+// | }
+
+  constructor(
+//^^^^^^^^^^^ definition syntax 1.0.0 src/`signatures.ts`/ExampleClass#`<constructor>`().
+// info {
+// |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleClass#`<constructor>`().",
+// |   "documentation": [
+// |     "```ts\nconstructor<T>(a: T, b: string, c: number, d: Record<string, any>): ExampleClass<T>\n```"
+// |   ],
+// |   "relationships": [],
+// |   "kind": 9,
+// |   "display_name": "",
+// |   "enclosing_symbol": "",
+// |   "signature": {
+// |     "method_signature": {
+// |       "type_parameters": {
+// |         "symlinks": [],
+// |         "hardlinks": []
+// |       },
+// |       "parameter_lists": [
+// |         {
+// |           "symlinks": [
+// |             "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleClass#`<constructor>`().(a)",
+// |             "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleClass#`<constructor>`().(b)",
+// |             "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleClass#`<constructor>`().(c)",
+// |             "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleClass#`<constructor>`().(d)"
+// |           ],
+// |           "hardlinks": []
+// |         }
+// |       ]
+// |     }
+// |   }
+// | }
+    public a: T,
+//         ^ definition syntax 1.0.0 src/`signatures.ts`/ExampleClass#`<constructor>`().(a)
+//         info {
+//         |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleClass#`<constructor>`().(a)",
+//         |   "documentation": [
+//         |     "```ts\n(property) a: T\n```"
+//         |   ],
+//         |   "relationships": [],
+//         |   "kind": 37,
+//         |   "display_name": "a",
+//         |   "enclosing_symbol": "",
+//         |   "signature": {
+//         |     "value_signature": {
+//         |       "tpe": {
+//         |         "type_ref": {
+//         |           "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleClass#[T]",
+//         |           "type_arguments": []
+//         |         }
+//         |       }
+//         |     }
+//         |   }
+//         | }
+//            ^ reference syntax 1.0.0 src/`signatures.ts`/ExampleClass#[T]
+    public b: string,
+//         ^ definition syntax 1.0.0 src/`signatures.ts`/ExampleClass#`<constructor>`().(b)
+//         info {
+//         |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleClass#`<constructor>`().(b)",
+//         |   "documentation": [
+//         |     "```ts\n(property) b: string\n```"
+//         |   ],
+//         |   "relationships": [],
+//         |   "kind": 37,
+//         |   "display_name": "b",
+//         |   "enclosing_symbol": "",
+//         |   "signature": {
+//         |     "value_signature": {
+//         |       "tpe": {
+//         |         "type_ref": {
+//         |           "symbol": "scip-typescript npm typescript . string#",
+//         |           "type_arguments": []
+//         |         }
+//         |       }
+//         |     }
+//         |   }
+//         | }
+    public c: number,
+//         ^ definition syntax 1.0.0 src/`signatures.ts`/ExampleClass#`<constructor>`().(c)
+//         info {
+//         |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleClass#`<constructor>`().(c)",
+//         |   "documentation": [
+//         |     "```ts\n(property) c: number\n```"
+//         |   ],
+//         |   "relationships": [],
+//         |   "kind": 37,
+//         |   "display_name": "c",
+//         |   "enclosing_symbol": "",
+//         |   "signature": {
+//         |     "value_signature": {
+//         |       "tpe": {
+//         |         "type_ref": {
+//         |           "symbol": "scip-typescript npm typescript . number#",
+//         |           "type_arguments": []
+//         |         }
+//         |       }
+//         |     }
+//         |   }
+//         | }
+    d: Record<string, any>
+//  ^ definition syntax 1.0.0 src/`signatures.ts`/ExampleClass#`<constructor>`().(d)
+//  info {
+//  |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleClass#`<constructor>`().(d)",
+//  |   "documentation": [
+//  |     "```ts\n(parameter) d: Record<string, any>\n```"
+//  |   ],
+//  |   "relationships": [],
+//  |   "kind": 37,
+//  |   "display_name": "d",
+//  |   "enclosing_symbol": "",
+//  |   "signature": {
+//  |     "value_signature": {
+//  |       "tpe": {
+//  |         "type_ref": {
+//  |           "symbol": "scip-typescript npm typescript 5.3.3 lib/`lib.es5.d.ts`/Record#",
+//  |           "type_arguments": [
+//  |             {
+//  |               "type_ref": {
+//  |                 "symbol": "scip-typescript npm typescript . string#",
+//  |                 "type_arguments": []
+//  |               }
+//  |             },
+//  |             {
+//  |               "type_ref": {
+//  |                 "symbol": "scip-typescript npm typescript . any#",
+//  |                 "type_arguments": []
+//  |               }
+//  |             }
+//  |           ]
+//  |         }
+//  |       }
+//  |     }
+//  |   }
+//  | }
+//     ^^^^^^ reference typescript 5.3.3 lib/`lib.es5.d.ts`/Record#
+  ) {
+    super(a, b)
+//        ^ reference syntax 1.0.0 src/`signatures.ts`/ExampleClass#`<constructor>`().(a)
+//           ^ reference syntax 1.0.0 src/`signatures.ts`/ExampleClass#`<constructor>`().(b)
+    this.d = d
+//       ^ reference syntax 1.0.0 src/`signatures.ts`/ExampleClass#d.
+//           ^ reference syntax 1.0.0 src/`signatures.ts`/ExampleClass#`<constructor>`().(d)
+  }
+  public getC(): number {
+//       ^^^^ definition syntax 1.0.0 src/`signatures.ts`/ExampleClass#getC().
+//       info {
+//       |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleClass#getC().",
+//       |   "documentation": [
+//       |     "```ts\n(method) getC(): number\n```"
+//       |   ],
+//       |   "relationships": [],
+//       |   "kind": 26,
+//       |   "display_name": "getC",
+//       |   "enclosing_symbol": "",
+//       |   "signature": {
+//       |     "method_signature": {
+//       |       "type_parameters": {
+//       |         "symlinks": [],
+//       |         "hardlinks": []
+//       |       },
+//       |       "parameter_lists": [
+//       |         {
+//       |           "symlinks": [],
+//       |           "hardlinks": []
+//       |         }
+//       |       ],
+//       |       "return_type": {
+//       |         "type_ref": {
+//       |           "symbol": "scip-typescript npm typescript . number#",
+//       |           "type_arguments": []
+//       |         }
+//       |       }
+//       |     }
+//       |   }
+//       | }
+    return this.c
+//              ^ reference syntax 1.0.0 src/`signatures.ts`/ExampleClass#`<constructor>`().(c)
+  }
+
+  get e(): boolean {
+//    ^ definition syntax 1.0.0 src/`signatures.ts`/ExampleClass#`<get>e`().
+//    info {
+//    |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleClass#`<get>e`().",
+//    |   "documentation": [
+//    |     "```ts\nget e: boolean\n```"
+//    |   ],
+//    |   "relationships": [],
+//    |   "kind": 26,
+//    |   "display_name": "e",
+//    |   "enclosing_symbol": "",
+//    |   "signature": {
+//    |     "method_signature": {
+//    |       "type_parameters": {
+//    |         "symlinks": [],
+//    |         "hardlinks": []
+//    |       },
+//    |       "parameter_lists": [
+//    |         {
+//    |           "symlinks": [],
+//    |           "hardlinks": []
+//    |         }
+//    |       ],
+//    |       "return_type": {
+//    |         "type_ref": {
+//    |           "symbol": "scip-typescript npm typescript . boolean#",
+//    |           "type_arguments": []
+//    |         }
+//    |       }
+//    |     }
+//    |   }
+//    | }
+    return this.#e
+//              ^^ reference syntax 1.0.0 src/`signatures.ts`/ExampleClass#`#e`.
+  }
+
+  set setB(b: string) {
+//    ^^^^ definition syntax 1.0.0 src/`signatures.ts`/ExampleClass#`<set>setB`().
+//    info {
+//    |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleClass#`<set>setB`().",
+//    |   "documentation": [
+//    |     "```ts\nset setBstring\n```"
+//    |   ],
+//    |   "relationships": [],
+//    |   "kind": 26,
+//    |   "display_name": "setB",
+//    |   "enclosing_symbol": "",
+//    |   "signature": {
+//    |     "method_signature": {
+//    |       "type_parameters": {
+//    |         "symlinks": [],
+//    |         "hardlinks": []
+//    |       },
+//    |       "parameter_lists": [
+//    |         {
+//    |           "symlinks": [
+//    |             "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleClass#`<set>setB`().(b)"
+//    |           ],
+//    |           "hardlinks": []
+//    |         }
+//    |       ]
+//    |     }
+//    |   }
+//    | }
+//         ^ definition syntax 1.0.0 src/`signatures.ts`/ExampleClass#`<set>setB`().(b)
+//         info {
+//         |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ExampleClass#`<set>setB`().(b)",
+//         |   "documentation": [
+//         |     "```ts\n(parameter) b: string\n```"
+//         |   ],
+//         |   "relationships": [],
+//         |   "kind": 37,
+//         |   "display_name": "b",
+//         |   "enclosing_symbol": "",
+//         |   "signature": {
+//         |     "value_signature": {
+//         |       "tpe": {
+//         |         "type_ref": {
+//         |           "symbol": "scip-typescript npm typescript . string#",
+//         |           "type_arguments": []
+//         |         }
+//         |       }
+//         |     }
+//         |   }
+//         | }
+    this.#e = true
+//       ^^ reference syntax 1.0.0 src/`signatures.ts`/ExampleClass#`#e`.
+    this.b = b
+//       ^ reference syntax 1.0.0 src/`signatures.ts`/ExampleClass#`<constructor>`().(b)
+//           ^ reference syntax 1.0.0 src/`signatures.ts`/ExampleClass#`<set>setB`().(b)
+  }
+}
+
+export function basicFunction<T>(a: T, b: number): string {
+//              ^^^^^^^^^^^^^ definition syntax 1.0.0 src/`signatures.ts`/basicFunction().
+//              info {
+//              |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/basicFunction().",
+//              |   "documentation": [
+//              |     "```ts\nfunction basicFunction<T>(a: T, b: number): string\n```"
+//              |   ],
+//              |   "relationships": [],
+//              |   "kind": 17,
+//              |   "display_name": "basicFunction",
+//              |   "enclosing_symbol": "",
+//              |   "signature": {
+//              |     "method_signature": {
+//              |       "type_parameters": {
+//              |         "symlinks": [
+//              |           "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/basicFunction().[T]"
+//              |         ],
+//              |         "hardlinks": []
+//              |       },
+//              |       "parameter_lists": [
+//              |         {
+//              |           "symlinks": [
+//              |             "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/basicFunction().(a)",
+//              |             "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/basicFunction().(b)"
+//              |           ],
+//              |           "hardlinks": []
+//              |         }
+//              |       ],
+//              |       "return_type": {
+//              |         "type_ref": {
+//              |           "symbol": "scip-typescript npm typescript . string#",
+//              |           "type_arguments": []
+//              |         }
+//              |       }
+//              |     }
+//              |   }
+//              | }
+//                            ^ definition syntax 1.0.0 src/`signatures.ts`/basicFunction().[T]
+//                            info {
+//                            |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/basicFunction().[T]",
+//                            |   "documentation": [
+//                            |     "```ts\nT: T\n```"
+//                            |   ],
+//                            |   "relationships": [],
+//                            |   "kind": 58,
+//                            |   "display_name": "T",
+//                            |   "enclosing_symbol": "",
+//                            |   "signature": {}
+//                            | }
+//                               ^ definition syntax 1.0.0 src/`signatures.ts`/basicFunction().(a)
+//                               info {
+//                               |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/basicFunction().(a)",
+//                               |   "documentation": [
+//                               |     "```ts\n(parameter) a: T\n```"
+//                               |   ],
+//                               |   "relationships": [],
+//                               |   "kind": 37,
+//                               |   "display_name": "a",
+//                               |   "enclosing_symbol": "",
+//                               |   "signature": {
+//                               |     "value_signature": {
+//                               |       "tpe": {
+//                               |         "type_ref": {
+//                               |           "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/basicFunction().[T]",
+//                               |           "type_arguments": []
+//                               |         }
+//                               |       }
+//                               |     }
+//                               |   }
+//                               | }
+//                                  ^ reference syntax 1.0.0 src/`signatures.ts`/basicFunction().[T]
+//                                     ^ definition syntax 1.0.0 src/`signatures.ts`/basicFunction().(b)
+//                                     info {
+//                                     |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/basicFunction().(b)",
+//                                     |   "documentation": [
+//                                     |     "```ts\n(parameter) b: number\n```"
+//                                     |   ],
+//                                     |   "relationships": [],
+//                                     |   "kind": 37,
+//                                     |   "display_name": "b",
+//                                     |   "enclosing_symbol": "",
+//                                     |   "signature": {
+//                                     |     "value_signature": {
+//                                     |       "tpe": {
+//                                     |         "type_ref": {
+//                                     |           "symbol": "scip-typescript npm typescript . number#",
+//                                     |           "type_arguments": []
+//                                     |         }
+//                                     |       }
+//                                     |     }
+//                                     |   }
+//                                     | }
+  return `${a}${b}`
+//          ^ reference syntax 1.0.0 src/`signatures.ts`/basicFunction().(a)
+//              ^ reference syntax 1.0.0 src/`signatures.ts`/basicFunction().(b)
+}
+export const constant = 42
+//           ^^^^^^^^ definition syntax 1.0.0 src/`signatures.ts`/constant.
+//           info {
+//           |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/constant.",
+//           |   "documentation": [
+//           |     "```ts\nvar constant: 42\n```"
+//           |   ],
+//           |   "relationships": [],
+//           |   "kind": 61,
+//           |   "display_name": "constant",
+//           |   "enclosing_symbol": "",
+//           |   "signature": {
+//           |     "value_signature": {
+//           |       "tpe": {
+//           |         "constant_type": {
+//           |           "constant": {
+//           |             "int_constant": {
+//           |               "value": 42
+//           |             }
+//           |           }
+//           |         }
+//           |       }
+//           |     }
+//           |   }
+//           | }
+export const variable: <T>(a: T, b: number) => string = (a, b) => `${a}${b}`
+//           ^^^^^^^^ definition syntax 1.0.0 src/`signatures.ts`/variable.
+//           info {
+//           |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/variable.",
+//           |   "documentation": [
+//           |     "```ts\nvar variable: <T>(a: T, b: number) => string\n```"
+//           |   ],
+//           |   "relationships": [],
+//           |   "kind": 61,
+//           |   "display_name": "variable",
+//           |   "enclosing_symbol": "",
+//           |   "signature": {
+//           |     "value_signature": {
+//           |       "tpe": {
+//           |         "lambda_type": {
+//           |           "type_parameters": {
+//           |             "symlinks": [
+//           |               "local 1"
+//           |             ],
+//           |             "hardlinks": []
+//           |           },
+//           |           "parameters": {
+//           |             "symlinks": [
+//           |               "local 2",
+//           |               "local 3"
+//           |             ],
+//           |             "hardlinks": []
+//           |           },
+//           |           "return_type": {
+//           |             "type_ref": {
+//           |               "symbol": "scip-typescript npm typescript . string#",
+//           |               "type_arguments": []
+//           |             }
+//           |           }
+//           |         }
+//           |       }
+//           |     }
+//           |   }
+//           | }
+//                      ^ definition local 1
+//                      info {
+//                      |   "symbol": "local 1",
+//                      |   "documentation": [
+//                      |     "```ts\nT: T\n```"
+//                      |   ],
+//                      |   "relationships": [],
+//                      |   "kind": 58,
+//                      |   "display_name": "T",
+//                      |   "enclosing_symbol": "",
+//                      |   "signature": {}
+//                      | }
+//                         ^ definition local 2
+//                         info {
+//                         |   "symbol": "local 2",
+//                         |   "documentation": [
+//                         |     "```ts\n(parameter) a: T\n```"
+//                         |   ],
+//                         |   "relationships": [],
+//                         |   "kind": 37,
+//                         |   "display_name": "a",
+//                         |   "enclosing_symbol": "",
+//                         |   "signature": {
+//                         |     "value_signature": {
+//                         |       "tpe": {
+//                         |         "type_ref": {
+//                         |           "symbol": "local 1",
+//                         |           "type_arguments": []
+//                         |         }
+//                         |       }
+//                         |     }
+//                         |   }
+//                         | }
+//                            ^ reference local 1
+//                               ^ definition local 3
+//                               info {
+//                               |   "symbol": "local 3",
+//                               |   "documentation": [
+//                               |     "```ts\n(parameter) b: number\n```"
+//                               |   ],
+//                               |   "relationships": [],
+//                               |   "kind": 37,
+//                               |   "display_name": "b",
+//                               |   "enclosing_symbol": "",
+//                               |   "signature": {
+//                               |     "value_signature": {
+//                               |       "tpe": {
+//                               |         "type_ref": {
+//                               |           "symbol": "scip-typescript npm typescript . number#",
+//                               |           "type_arguments": []
+//                               |         }
+//                               |       }
+//                               |     }
+//                               |   }
+//                               | }
+//                                                       ^ definition local 5
+//                                                       info {
+//                                                       |   "symbol": "local 5",
+//                                                       |   "documentation": [
+//                                                       |     "```ts\n(parameter) a: T\n```"
+//                                                       |   ],
+//                                                       |   "relationships": [],
+//                                                       |   "kind": 37,
+//                                                       |   "display_name": "a",
+//                                                       |   "enclosing_symbol": "",
+//                                                       |   "signature": {
+//                                                       |     "value_signature": {}
+//                                                       |   }
+//                                                       | }
+//                                                          ^ definition local 6
+//                                                          info {
+//                                                          |   "symbol": "local 6",
+//                                                          |   "documentation": [
+//                                                          |     "```ts\n(parameter) b: number\n```"
+//                                                          |   ],
+//                                                          |   "relationships": [],
+//                                                          |   "kind": 37,
+//                                                          |   "display_name": "b",
+//                                                          |   "enclosing_symbol": "",
+//                                                          |   "signature": {
+//                                                          |     "value_signature": {}
+//                                                          |   }
+//                                                          | }
+//                                                                   ^ reference local 5
+//                                                                       ^ reference local 6
+
+export interface User {
+//               ^^^^ definition syntax 1.0.0 src/`signatures.ts`/User#
+//               info {
+//               |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/User#",
+//               |   "documentation": [
+//               |     "```ts\ninterface User\n```"
+//               |   ],
+//               |   "relationships": [],
+//               |   "kind": 21,
+//               |   "display_name": "User",
+//               |   "enclosing_symbol": "",
+//               |   "signature": {
+//               |     "class_signature": {
+//               |       "type_parameters": {
+//               |         "symlinks": [],
+//               |         "hardlinks": []
+//               |       },
+//               |       "parents": [],
+//               |       "declarations": {
+//               |         "symlinks": [
+//               |           "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/name0:",
+//               |           "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/age0:",
+//               |           "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/customHeaders0:"
+//               |         ],
+//               |         "hardlinks": []
+//               |       }
+//               |     }
+//               |   }
+//               | }
+  name: string
+//^^^^ definition syntax 1.0.0 src/`signatures.ts`/name0:
+// info {
+// |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/name0:",
+// |   "documentation": [
+// |     "```ts\n(property) name: string\n```"
+// |   ],
+// |   "relationships": [],
+// |   "kind": 41,
+// |   "display_name": "name",
+// |   "enclosing_symbol": "",
+// |   "signature": {
+// |     "value_signature": {
+// |       "tpe": {
+// |         "type_ref": {
+// |           "symbol": "scip-typescript npm typescript . string#",
+// |           "type_arguments": []
+// |         }
+// |       }
+// |     }
+// |   }
+// | }
+  age: number
+//^^^ definition syntax 1.0.0 src/`signatures.ts`/age0:
+// info {
+// |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/age0:",
+// |   "documentation": [
+// |     "```ts\n(property) age: number\n```"
+// |   ],
+// |   "relationships": [],
+// |   "kind": 41,
+// |   "display_name": "age",
+// |   "enclosing_symbol": "",
+// |   "signature": {
+// |     "value_signature": {
+// |       "tpe": {
+// |         "type_ref": {
+// |           "symbol": "scip-typescript npm typescript . number#",
+// |           "type_arguments": []
+// |         }
+// |       }
+// |     }
+// |   }
+// | }
+  customHeaders: Record<string, string>
+//^^^^^^^^^^^^^ definition syntax 1.0.0 src/`signatures.ts`/customHeaders0:
+// info {
+// |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/customHeaders0:",
+// |   "documentation": [
+// |     "```ts\n(property) customHeaders: Record<string, string>\n```"
+// |   ],
+// |   "relationships": [],
+// |   "kind": 41,
+// |   "display_name": "customHeaders",
+// |   "enclosing_symbol": "",
+// |   "signature": {
+// |     "value_signature": {
+// |       "tpe": {
+// |         "type_ref": {
+// |           "symbol": "scip-typescript npm typescript 5.3.3 lib/`lib.es5.d.ts`/Record#",
+// |           "type_arguments": [
+// |             {
+// |               "type_ref": {
+// |                 "symbol": "scip-typescript npm typescript . string#",
+// |                 "type_arguments": []
+// |               }
+// |             },
+// |             {
+// |               "type_ref": {
+// |                 "symbol": "scip-typescript npm typescript . string#",
+// |                 "type_arguments": []
+// |               }
+// |             }
+// |           ]
+// |         }
+// |       }
+// |     }
+// |   }
+// | }
+//               ^^^^^^ reference typescript 5.3.3 lib/`lib.es5.d.ts`/Record#
+}
+
+export interface ChatHistory {
+//               ^^^^^^^^^^^ definition syntax 1.0.0 src/`signatures.ts`/ChatHistory#
+//               info {
+//               |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ChatHistory#",
+//               |   "documentation": [
+//               |     "```ts\ninterface ChatHistory\n```"
+//               |   ],
+//               |   "relationships": [],
+//               |   "kind": 21,
+//               |   "display_name": "ChatHistory",
+//               |   "enclosing_symbol": "",
+//               |   "signature": {
+//               |     "class_signature": {
+//               |       "type_parameters": {
+//               |         "symlinks": [],
+//               |         "hardlinks": []
+//               |       },
+//               |       "parents": [],
+//               |       "declarations": {
+//               |         "symlinks": [
+//               |           "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/chatID0:",
+//               |           "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/indexedSignature0:(a)",
+//               |           "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/indexedSignature1:(_)"
+//               |         ],
+//               |         "hardlinks": []
+//               |       }
+//               |     }
+//               |   }
+//               | }
+  chatID: User
+//^^^^^^ definition syntax 1.0.0 src/`signatures.ts`/chatID0:
+// info {
+// |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/chatID0:",
+// |   "documentation": [
+// |     "```ts\n(property) chatID: User\n```"
+// |   ],
+// |   "relationships": [],
+// |   "kind": 41,
+// |   "display_name": "chatID",
+// |   "enclosing_symbol": "",
+// |   "signature": {
+// |     "value_signature": {
+// |       "tpe": {
+// |         "type_ref": {
+// |           "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/User#",
+// |           "type_arguments": []
+// |         }
+// |       }
+// |     }
+// |   }
+// | }
+//        ^^^^ reference syntax 1.0.0 src/`signatures.ts`/User#
+  [a: number]: User
+// ^ definition syntax 1.0.0 src/`signatures.ts`/indexedSignature0:(a)
+// info {
+// |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/indexedSignature0:(a)",
+// |   "documentation": [
+// |     "```ts\n(parameter) a: number\n```"
+// |   ],
+// |   "relationships": [],
+// |   "kind": 37,
+// |   "display_name": "a",
+// |   "enclosing_symbol": "",
+// |   "signature": {
+// |     "value_signature": {
+// |       "tpe": {
+// |         "type_ref": {
+// |           "symbol": "scip-typescript npm typescript . number#",
+// |           "type_arguments": []
+// |         }
+// |       }
+// |     }
+// |   }
+// | }
+//             ^^^^ reference syntax 1.0.0 src/`signatures.ts`/User#
+  [_: string]: User
+// ^ definition syntax 1.0.0 src/`signatures.ts`/indexedSignature1:(_)
+// info {
+// |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/indexedSignature1:(_)",
+// |   "documentation": [
+// |     "```ts\n(parameter) _: string\n```"
+// |   ],
+// |   "relationships": [],
+// |   "kind": 37,
+// |   "display_name": "_",
+// |   "enclosing_symbol": "",
+// |   "signature": {
+// |     "value_signature": {
+// |       "tpe": {
+// |         "type_ref": {
+// |           "symbol": "scip-typescript npm typescript . string#",
+// |           "type_arguments": []
+// |         }
+// |       }
+// |     }
+// |   }
+// | }
+//             ^^^^ reference syntax 1.0.0 src/`signatures.ts`/User#
+}
+
+export class ModelProvider {
+//           ^^^^^^^^^^^^^ definition syntax 1.0.0 src/`signatures.ts`/ModelProvider#
+//           info {
+//           |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ModelProvider#",
+//           |   "documentation": [
+//           |     "```ts\nclass ModelProvider\n```"
+//           |   ],
+//           |   "relationships": [],
+//           |   "kind": 7,
+//           |   "display_name": "ModelProvider",
+//           |   "enclosing_symbol": "",
+//           |   "signature": {
+//           |     "class_signature": {
+//           |       "type_parameters": {
+//           |         "symlinks": [],
+//           |         "hardlinks": []
+//           |       },
+//           |       "parents": [],
+//           |       "declarations": {
+//           |         "symlinks": [
+//           |           "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ModelProvider#default."
+//           |         ],
+//           |         "hardlinks": []
+//           |       }
+//           |     }
+//           |   }
+//           | }
+  default = true
+//^^^^^^^ definition syntax 1.0.0 src/`signatures.ts`/ModelProvider#default.
+// info {
+// |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/ModelProvider#default.",
+// |   "documentation": [
+// |     "```ts\n(property) default: boolean\n```"
+// |   ],
+// |   "relationships": [],
+// |   "kind": 41,
+// |   "display_name": "default",
+// |   "enclosing_symbol": "",
+// |   "signature": {
+// |     "value_signature": {
+// |       "tpe": {
+// |         "type_ref": {
+// |           "symbol": "scip-typescript npm typescript . true#",
+// |           "type_arguments": []
+// |         }
+// |       }
+// |     }
+// |   }
+// | }
+}
+
+export enum NumericLiteralEnum {
+//          ^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`signatures.ts`/NumericLiteralEnum#
+//          info {
+//          |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/NumericLiteralEnum#",
+//          |   "documentation": [
+//          |     "```ts\nenum NumericLiteralEnum\n```"
+//          |   ],
+//          |   "relationships": [],
+//          |   "kind": 11,
+//          |   "display_name": "NumericLiteralEnum",
+//          |   "enclosing_symbol": "",
+//          |   "signature": {
+//          |     "class_signature": {
+//          |       "parents": [],
+//          |       "declarations": {
+//          |         "symlinks": [
+//          |           "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/NumericLiteralEnum#MinusOne.",
+//          |           "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/NumericLiteralEnum#Expression.",
+//          |           "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/NumericLiteralEnum#One.",
+//          |           "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/NumericLiteralEnum#TwoThousand."
+//          |         ],
+//          |         "hardlinks": []
+//          |       }
+//          |     }
+//          |   }
+//          | }
+  MinusOne = -1,
+//^^^^^^^^ definition syntax 1.0.0 src/`signatures.ts`/NumericLiteralEnum#MinusOne.
+// info {
+// |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/NumericLiteralEnum#MinusOne.",
+// |   "documentation": [
+// |     "```ts\n(enum member) MinusOne = -1\n```"
+// |   ],
+// |   "relationships": [],
+// |   "kind": 12,
+// |   "display_name": "MinusOne",
+// |   "enclosing_symbol": "",
+// |   "signature": {
+// |     "value_signature": {
+// |       "tpe": {
+// |         "constant_type": {
+// |           "constant": {
+// |             "int_constant": {
+// |               "value": -1
+// |             }
+// |           }
+// |         }
+// |       }
+// |     }
+// |   }
+// | }
+  Expression = 1 + 23 - 2,
+//^^^^^^^^^^ definition syntax 1.0.0 src/`signatures.ts`/NumericLiteralEnum#Expression.
+// info {
+// |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/NumericLiteralEnum#Expression.",
+// |   "documentation": [
+// |     "```ts\n(enum member) Expression = 22\n```"
+// |   ],
+// |   "relationships": [],
+// |   "kind": 12,
+// |   "display_name": "Expression",
+// |   "enclosing_symbol": "",
+// |   "signature": {
+// |     "value_signature": {
+// |       "tpe": {
+// |         "type_ref": {
+// |           "symbol": "scip-typescript npm typescript . number#",
+// |           "type_arguments": []
+// |         }
+// |       }
+// |     }
+// |   }
+// | }
+  One = 1,
+//^^^ definition syntax 1.0.0 src/`signatures.ts`/NumericLiteralEnum#One.
+// info {
+// |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/NumericLiteralEnum#One.",
+// |   "documentation": [
+// |     "```ts\n(enum member) One = 1\n```"
+// |   ],
+// |   "relationships": [],
+// |   "kind": 12,
+// |   "display_name": "One",
+// |   "enclosing_symbol": "",
+// |   "signature": {
+// |     "value_signature": {
+// |       "tpe": {
+// |         "constant_type": {
+// |           "constant": {
+// |             "int_constant": {
+// |               "value": 1
+// |             }
+// |           }
+// |         }
+// |       }
+// |     }
+// |   }
+// | }
+  TwoThousand = 2_000,
+//^^^^^^^^^^^ definition syntax 1.0.0 src/`signatures.ts`/NumericLiteralEnum#TwoThousand.
+// info {
+// |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/NumericLiteralEnum#TwoThousand.",
+// |   "documentation": [
+// |     "```ts\n(enum member) TwoThousand = 2000\n```"
+// |   ],
+// |   "relationships": [],
+// |   "kind": 12,
+// |   "display_name": "TwoThousand",
+// |   "enclosing_symbol": "",
+// |   "signature": {
+// |     "value_signature": {
+// |       "tpe": {
+// |         "constant_type": {
+// |           "constant": {
+// |             "int_constant": {
+// |               "value": 2000
+// |             }
+// |           }
+// |         }
+// |       }
+// |     }
+// |   }
+// | }
+}
+
+export const doubleConstant = 3.14
+//           ^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`signatures.ts`/doubleConstant.
+//           info {
+//           |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/doubleConstant.",
+//           |   "documentation": [
+//           |     "```ts\nvar doubleConstant: 3.14\n```"
+//           |   ],
+//           |   "relationships": [],
+//           |   "kind": 61,
+//           |   "display_name": "doubleConstant",
+//           |   "enclosing_symbol": "",
+//           |   "signature": {
+//           |     "value_signature": {
+//           |       "tpe": {
+//           |         "constant_type": {
+//           |           "constant": {
+//           |             "double_constant": {
+//           |               "value": 3.14
+//           |             }
+//           |           }
+//           |         }
+//           |       }
+//           |     }
+//           |   }
+//           | }
+
+export enum StringLiteralEnum {
+//          ^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`signatures.ts`/StringLiteralEnum#
+//          info {
+//          |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/StringLiteralEnum#",
+//          |   "documentation": [
+//          |     "```ts\nenum StringLiteralEnum\n```"
+//          |   ],
+//          |   "relationships": [],
+//          |   "kind": 11,
+//          |   "display_name": "StringLiteralEnum",
+//          |   "enclosing_symbol": "",
+//          |   "signature": {
+//          |     "class_signature": {
+//          |       "parents": [],
+//          |       "declarations": {
+//          |         "symlinks": [
+//          |           "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/StringLiteralEnum#Saturday.",
+//          |           "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/StringLiteralEnum#Sunday."
+//          |         ],
+//          |         "hardlinks": []
+//          |       }
+//          |     }
+//          |   }
+//          | }
+  Saturday = 'saturday',
+//^^^^^^^^ definition syntax 1.0.0 src/`signatures.ts`/StringLiteralEnum#Saturday.
+// info {
+// |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/StringLiteralEnum#Saturday.",
+// |   "documentation": [
+// |     "```ts\n(enum member) Saturday = saturday\n```"
+// |   ],
+// |   "relationships": [],
+// |   "kind": 12,
+// |   "display_name": "Saturday",
+// |   "enclosing_symbol": "",
+// |   "signature": {
+// |     "value_signature": {
+// |       "tpe": {
+// |         "constant_type": {
+// |           "constant": {
+// |             "string_constant": {
+// |               "value": "saturday"
+// |             }
+// |           }
+// |         }
+// |       }
+// |     }
+// |   }
+// | }
+  Sunday = 'sunday',
+//^^^^^^ definition syntax 1.0.0 src/`signatures.ts`/StringLiteralEnum#Sunday.
+// info {
+// |   "symbol": "scip-typescript npm syntax 1.0.0 src/`signatures.ts`/StringLiteralEnum#Sunday.",
+// |   "documentation": [
+// |     "```ts\n(enum member) Sunday = sunday\n```"
+// |   ],
+// |   "relationships": [],
+// |   "kind": 12,
+// |   "display_name": "Sunday",
+// |   "enclosing_symbol": "",
+// |   "signature": {
+// |     "value_signature": {
+// |       "tpe": {
+// |         "constant_type": {
+// |           "constant": {
+// |             "string_constant": {
+// |               "value": "sunday"
+// |             }
+// |           }
+// |         }
+// |       }
+// |     }
+// |   }
+// | }
+}
+

--- a/snapshots/output/syntax/src/string-literals.ts
+++ b/snapshots/output/syntax/src/string-literals.ts
@@ -3,11 +3,11 @@
 interface SomeInterface {
 //        ^^^^^^^^^^^^^ definition syntax 1.0.0 src/`string-literals.ts`/SomeInterface#
   a: number
-//^ definition syntax 1.0.0 src/`string-literals.ts`/SomeInterface#a.
+//^ definition syntax 1.0.0 src/`string-literals.ts`/a0:
   b: number
-//^ definition syntax 1.0.0 src/`string-literals.ts`/SomeInterface#b.
+//^ definition syntax 1.0.0 src/`string-literals.ts`/b0:
   c: number
-//^ definition syntax 1.0.0 src/`string-literals.ts`/SomeInterface#c.
+//^ definition syntax 1.0.0 src/`string-literals.ts`/c0:
 }
 // "Go to definition" does not work for the 'a', 'b' and 'c' string literals
 // below when using tsserver so it's fine that scip-typescript does not emit

--- a/snapshots/output/syntax/src/structural-type.ts
+++ b/snapshots/output/syntax/src/structural-type.ts
@@ -7,7 +7,7 @@ export function foo(): Promise<{ member: number }> {
 //                     ^^^^^^^ reference typescript 5.3.3 lib/`lib.es2015.promise.d.ts`/Promise.
 //                     ^^^^^^^ reference typescript 5.3.3 lib/`lib.es2015.symbol.wellknown.d.ts`/Promise#
 //                     ^^^^^^^ reference typescript 5.3.3 lib/`lib.es2018.promise.d.ts`/Promise#
-//                               ^^^^^^ definition syntax 1.0.0 src/`structural-type.ts`/foo().Promise:typeLiteral0:member.
+//                               ^^^^^^ definition syntax 1.0.0 src/`structural-type.ts`/member0:
   return Promise.resolve({ member: 42 })
 //       ^^^^^^^ reference typescript 5.3.3 lib/`lib.es5.d.ts`/Promise#
 //       ^^^^^^^ reference typescript 5.3.3 lib/`lib.es2015.iterable.d.ts`/Promise#
@@ -15,7 +15,7 @@ export function foo(): Promise<{ member: number }> {
 //       ^^^^^^^ reference typescript 5.3.3 lib/`lib.es2015.symbol.wellknown.d.ts`/Promise#
 //       ^^^^^^^ reference typescript 5.3.3 lib/`lib.es2018.promise.d.ts`/Promise#
 //               ^^^^^^^ reference typescript 5.3.3 lib/`lib.es2015.promise.d.ts`/PromiseConstructor#resolve().
-//                         ^^^^^^ definition syntax 1.0.0 src/`structural-type.ts`/member0:
+//                         ^^^^^^ definition syntax 1.0.0 src/`structural-type.ts`/member1:
 }
 export function bar(): Promise<number> {
 //              ^^^ definition syntax 1.0.0 src/`structural-type.ts`/bar().
@@ -29,7 +29,7 @@ export function bar(): Promise<number> {
 //             ^^^^ reference typescript 5.3.3 lib/`lib.es5.d.ts`/Promise#then().
 //                  ^ definition local 4
 //                       ^ reference local 4
-//                         ^^^^^^ reference syntax 1.0.0 src/`structural-type.ts`/foo().Promise:typeLiteral0:member.
+//                         ^^^^^^ reference syntax 1.0.0 src/`structural-type.ts`/member0:
 }
 export function bar2(): Promise<number> {
 //              ^^^^ definition syntax 1.0.0 src/`structural-type.ts`/bar2().
@@ -42,7 +42,7 @@ export function bar2(): Promise<number> {
 //       ^^^ reference syntax 1.0.0 src/`structural-type.ts`/foo().
 //             ^^^^ reference typescript 5.3.3 lib/`lib.es5.d.ts`/Promise#then().
 //                     ^^^^^^ definition local 10
-//                     ^^^^^^ reference syntax 1.0.0 src/`structural-type.ts`/foo().Promise:typeLiteral0:member.
+//                     ^^^^^^ reference syntax 1.0.0 src/`structural-type.ts`/member0:
 //                                  ^^^^^^ reference local 10
 }
 
@@ -53,7 +53,14 @@ type OptionsFlags<Type> = { [Property in keyof Type]: boolean }
 //                                             ^^^^ reference syntax 1.0.0 src/`structural-type.ts`/OptionsFlags#[Type]
 type FeatureFlags = { darkMode: () => void }
 //   ^^^^^^^^^^^^ definition syntax 1.0.0 src/`structural-type.ts`/FeatureFlags#
-//                    ^^^^^^^^ definition syntax 1.0.0 src/`structural-type.ts`/FeatureFlags#typeLiteral13:darkMode.
+//                    ^^^^^^^^ definition syntax 1.0.0 src/`structural-type.ts`/darkMode0:
+export type PropertySignature = {
+//          ^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`structural-type.ts`/PropertySignature#
+  'chat/submit': [{ text: { value: string } }]
+//^^^^^^^^^^^^^ definition syntax 1.0.0 src/`structural-type.ts`/`chat/submit0`:
+//                  ^^^^ definition syntax 1.0.0 src/`structural-type.ts`/text0:
+//                          ^^^^^ definition syntax 1.0.0 src/`structural-type.ts`/value0:
+}
 export type FeatureOptions = OptionsFlags<FeatureFlags> // implicitly // type FeatureOptions = { // darkMode: boolean; // } const fo: FeatureOptions = { darkMode: true }; // ^ go to def
 //          ^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`structural-type.ts`/FeatureOptions#
 //                           ^^^^^^^^^^^^ reference syntax 1.0.0 src/`structural-type.ts`/OptionsFlags#
@@ -61,5 +68,5 @@ export type FeatureOptions = OptionsFlags<FeatureFlags> // implicitly // type Fe
 export const fo: FeatureOptions = { darkMode: true }
 //           ^^ definition syntax 1.0.0 src/`structural-type.ts`/fo.
 //               ^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`structural-type.ts`/FeatureOptions#
-//                                  ^^^^^^^^ definition syntax 1.0.0 src/`structural-type.ts`/darkMode0:
+//                                  ^^^^^^^^ definition syntax 1.0.0 src/`structural-type.ts`/darkMode1:
 

--- a/snapshots/output/syntax/src/typings.ts
+++ b/snapshots/output/syntax/src/typings.ts
@@ -5,6 +5,6 @@ export function process() {
   return window.process
 //       ^^^^^^ reference typescript 5.3.3 lib/`lib.dom.d.ts`/window.
 //              ^^^^^^^ reference @types/node 20.10.5 `globals.d.ts`/global/process.
-//              ^^^^^^^ reference @types/node 20.10.5 `process.d.ts`/`"process"`/global/process.
+//              ^^^^^^^ reference @types/node 20.10.5 `process.d.ts`/process/global/process.
 }
 

--- a/snapshots/yarn.lock
+++ b/snapshots/yarn.lock
@@ -26,6 +26,11 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
+"@types/vscode@1.86.0":
+  version "1.86.0"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.86.0.tgz#5d5f233137b27e51d7ad1462600005741296357a"
+  integrity sha512-DnIXf2ftWv+9LWOB5OJeIeaLigLHF7fdXF6atfc7X5g2w/wVZBgk0amP7b+ub5xAuW1q7qP5YcFvOcit/DtyCQ==
+
 csstype@^3.0.2:
   version "3.0.11"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.11.tgz#d66700c5eacfac1940deb4e3ee5642792d85cd33"

--- a/src/CommandLineOptions.ts
+++ b/src/CommandLineOptions.ts
@@ -14,6 +14,9 @@ export interface MultiProjectOptions {
   yarnBerryWorkspaces: boolean
   pnpmWorkspaces: boolean
   globalCaches: boolean
+  emitSignatures: boolean
+  followSourceMapping: boolean
+  emitExternalSymbols: boolean
   maxFileByteSize?: string
   maxFileByteSizeNumber?: number
   cwd: string
@@ -35,6 +38,7 @@ export interface GlobalCache {
     [ts.SourceFile | undefined, ts.ScriptTarget | ts.CreateSourceFileOptions]
   >
   parsedCommandLines: Map<string, ts.ParsedCommandLine>
+  externalSymbols: Map<string, scip.scip.SymbolInformation>
 }
 
 export function mainCommand(
@@ -68,6 +72,23 @@ export function mainCommand(
     .option(
       '--no-global-caches',
       'whether to disable global caches between TypeScript projects'
+    )
+    .option(
+      '--emit-signatures',
+      'whether to emit experimental `SymbolInformation.signatures`',
+      false
+    )
+    .option(
+      '--emit-external-symbols',
+      'whether to emit `SymbolInformation` for external symbols (defined outside this project)',
+      false
+    )
+    .option(
+      '--follow-source-mapping',
+      'if true, follow `sourceMappingURL` in declaration files. ' +
+        'In multi-project workspaces, this option allows more accurate ' +
+        'cross-project navigation.',
+      true
     )
     .option(
       '--max-file-byte-size <value>',

--- a/src/FileIndexer.ts
+++ b/src/FileIndexer.ts
@@ -1056,7 +1056,8 @@ export class FileIndexer {
   public isExternalSymbol(node: ts.Node): boolean {
     // Simple approximation to filter out symbols that are defined by external projects.
     return (
-      node.pos >= 0 && node.getSourceFile().fileName.includes('node_modules')
+      node.pos >= 0 &&
+      node.getSourceFile?.()?.fileName?.includes?.('node_modules')
     )
   }
 

--- a/src/FileIndexer.ts
+++ b/src/FileIndexer.ts
@@ -461,7 +461,7 @@ export class FileIndexer {
         (ts.isPropertyDeclaration(declaration) && declaration.questionToken) ||
         (ts.isPropertySignature(declaration) && declaration.questionToken)
       )
-      if (isOptional) {
+      if (isOptional && signature.value_signature.tpe !== undefined) {
         signature.value_signature.tpe = this.makeOptional(
           signature.value_signature.tpe
         )

--- a/src/FileIndexer.ts
+++ b/src/FileIndexer.ts
@@ -1,8 +1,9 @@
 import path from 'path'
+import fs from 'fs'
 
 import * as ts from 'typescript'
 
-import { ProjectOptions } from './CommandLineOptions'
+import { GlobalCache, ProjectOptions } from './CommandLineOptions'
 import { Counter } from './Counter'
 import {
   metaDescriptor,
@@ -32,6 +33,7 @@ export class FileIndexer {
     public readonly input: Input,
     public readonly document: scip.scip.Document,
     public readonly globalSymbolTable: Map<ts.Node, ScipSymbol>,
+    private readonly cache: GlobalCache,
     public readonly globalConstructorTable: Map<ts.ClassDeclaration, boolean>,
     public readonly packages: Packages,
     public readonly sourceFile: ts.SourceFile
@@ -40,9 +42,12 @@ export class FileIndexer {
   }
   public index(): void {
     // Uncomment below if you want to skip certain files for local development.
-    // if (!this.sourceFile.fileName.includes('constructor')) {
-    //   return
-    // }
+    if (
+      process.env.SCIP_ONLY &&
+      !this.sourceFile.fileName.includes(process.env.SCIP_ONLY)
+    ) {
+      return
+    }
 
     const byteSize = Buffer.from(this.sourceFile.getText()).length
     if (
@@ -244,7 +249,7 @@ export class FileIndexer {
       return
     }
     const tpe = this.checker.getTypeAtLocation(node.parent.parent)
-    const property = tpe.getProperty(node.getText())
+    const property = tpe.getProperty(this.safeGetText(node))
     for (const declaration of property?.declarations || []) {
       const scipSymbol = this.scipSymbol(declaration)
       if (scipSymbol.isEmpty()) {
@@ -305,6 +310,17 @@ export class FileIndexer {
     declaration: ts.Node,
     symbol: ScipSymbol
   ): void {
+    this.document.symbols.push(
+      this.symbolInformation(node, sym, declaration, symbol)
+    )
+  }
+
+  private symbolInformation(
+    node: ts.Node,
+    sym: ts.Symbol,
+    declaration: ts.Node,
+    symbol: ScipSymbol
+  ): scip.scip.SymbolInformation {
     const documentation = [
       '```ts\n' +
         this.hideWorkingDirectory(this.signatureForDocumentation(node, sym)) +
@@ -315,13 +331,402 @@ export class FileIndexer {
       documentation.push(ts.displayPartsToString(docstring))
     }
 
-    this.document.symbols.push(
-      new scip.scip.SymbolInformation({
-        symbol: symbol.value,
-        documentation,
-        relationships: this.relationships(declaration, symbol),
+    if (
+      symbol.value ===
+      'scip-typescript npm @types/vscode 1.86.0 `index.d.ts`/vscode/ViewColumn#Active.'
+    ) {
+      console.log({
+        kind: ts.SyntaxKind[node.kind],
+        kind2: ts.SyntaxKind[declaration.kind],
       })
+    }
+    return new scip.scip.SymbolInformation({
+      symbol: symbol.value,
+      display_name: this.displayName(declaration),
+      kind: this.symbolKind(declaration),
+      documentation,
+      relationships: this.relationships(declaration, symbol),
+      signature: this.signature(declaration),
+    })
+  }
+
+  private displayName(declaration: ts.Node): string | undefined {
+    const downcast = declaration as any
+    if (downcast?.name?.kind === ts.SyntaxKind.StringLiteral) {
+      return downcast?.name?.text ?? ''
+    }
+    if (typeof downcast?.name?.getText === 'function') {
+      return downcast.name.getText()
+    }
+    if (typeof downcast?.typeName?.getText === 'function') {
+      return downcast.typeName.getText()
+    }
+    return undefined
+  }
+
+  private symbolKind(
+    declaration: ts.Node
+  ): scip.scip.SymbolInformation.Kind | undefined {
+    switch (declaration.kind) {
+      case ts.SyntaxKind.EnumDeclaration:
+        return scip.scip.SymbolInformation.Kind.Enum
+      case ts.SyntaxKind.EnumMember:
+        return scip.scip.SymbolInformation.Kind.EnumMember
+      case ts.SyntaxKind.Constructor:
+        return scip.scip.SymbolInformation.Kind.Constructor
+      case ts.SyntaxKind.VariableDeclaration:
+        return scip.scip.SymbolInformation.Kind.Variable
+      case ts.SyntaxKind.PropertyDeclaration:
+      case ts.SyntaxKind.PropertySignature:
+        return scip.scip.SymbolInformation.Kind.Property
+      case ts.SyntaxKind.InterfaceDeclaration:
+        return scip.scip.SymbolInformation.Kind.Interface
+      case ts.SyntaxKind.ClassDeclaration:
+        return scip.scip.SymbolInformation.Kind.Class
+      case ts.SyntaxKind.FunctionDeclaration:
+      case ts.SyntaxKind.FunctionType:
+        return scip.scip.SymbolInformation.Kind.Function
+      case ts.SyntaxKind.MethodDeclaration:
+      case ts.SyntaxKind.GetAccessor:
+      case ts.SyntaxKind.SetAccessor:
+        return scip.scip.SymbolInformation.Kind.Method
+      case ts.SyntaxKind.TypeAliasDeclaration:
+        return scip.scip.SymbolInformation.Kind.TypeAlias
+      case ts.SyntaxKind.Parameter:
+        return scip.scip.SymbolInformation.Kind.Parameter
+      case ts.SyntaxKind.TypeParameter:
+        return scip.scip.SymbolInformation.Kind.TypeParameter
+      default:
+        // console.log({
+        //   kind: ts.SyntaxKind[declaration.kind],
+        //   text: declaration.getText(),
+        // })
+        return undefined
+    }
+  }
+
+  private signature(declaration: ts.Node): scip.scip.Signature | undefined {
+    if (!this.options.emitSignatures) {
+      return undefined
+    }
+
+    const signature = new scip.scip.Signature({})
+
+    if (
+      ts.isParameter(declaration) ||
+      ts.isPropertyDeclaration(declaration) ||
+      ts.isPropertySignature(declaration) ||
+      ts.isVariableDeclaration(declaration)
+    ) {
+      signature.value_signature = new scip.scip.ValueSignature({
+        tpe: declaration.type
+          ? this.type(declaration.type)
+          : (ts.isPropertyDeclaration(declaration) ||
+                ts.isVariableDeclaration(declaration)) &&
+              declaration.initializer
+            ? this.expressionType(declaration.initializer)
+            : undefined,
+      })
+    } else if (ts.isPropertyAssignment(declaration)) {
+      signature.value_signature = new scip.scip.ValueSignature({
+        tpe: this.expressionType(declaration.initializer),
+      })
+    } else if (ts.isShorthandPropertyAssignment(declaration)) {
+      signature.value_signature = new scip.scip.ValueSignature({
+        tpe: this.expressionType(declaration.name),
+      })
+    } else if (ts.isBindingName(declaration)) {
+      signature.value_signature = new scip.scip.ValueSignature({
+        tpe: this.expressionType(declaration),
+      })
+    } else if (ts.isPropertyAssignment(declaration)) {
+      signature.value_signature = new scip.scip.ValueSignature({
+        tpe: this.expressionType(declaration.initializer),
+      })
+    } else if (
+      ts.isSetAccessorDeclaration(declaration) ||
+      ts.isGetAccessorDeclaration(declaration) ||
+      ts.isConstructorDeclaration(declaration) ||
+      ts.isFunctionDeclaration(declaration) ||
+      ts.isMethodDeclaration(declaration)
+    ) {
+      signature.method_signature = new scip.scip.MethodSignature({
+        return_type: declaration.type ? this.type(declaration.type) : undefined,
+        type_parameters: this.symlinks(declaration.typeParameters),
+        parameter_lists: [this.symlinks(declaration.parameters)],
+      })
+    } else if (ts.isTypeAliasDeclaration(declaration)) {
+      signature.type_signature = new scip.scip.TypeSignature({
+        type_parameters: this.symlinks(declaration.typeParameters),
+        lower_bound: this.type(declaration.type),
+      })
+    } else if (
+      ts.isClassLike(declaration) ||
+      ts.isInterfaceDeclaration(declaration)
+    ) {
+      const members: ts.Node[] = []
+      for (const member of declaration.members) {
+        if (ts.isIndexSignatureDeclaration(member)) {
+          for (const parameter of member.parameters) {
+            members.push(parameter)
+          }
+        } else members.push(member)
+      }
+      signature.class_signature = new scip.scip.ClassSignature({
+        declarations: this.symlinks(ts.factory.createNodeArray(members)),
+        type_parameters: this.symlinks(declaration.typeParameters),
+        parents: declaration.heritageClauses?.flatMap(heritageClause =>
+          heritageClause.types.map(tpe => this.type(tpe))
+        ),
+      })
+    } else if (ts.isEnumDeclaration(declaration)) {
+      signature.class_signature = new scip.scip.ClassSignature({
+        declarations: this.symlinks(declaration.members),
+      })
+    } else if (ts.isEnumMember(declaration)) {
+      signature.value_signature = new scip.scip.ValueSignature({
+        tpe: declaration.initializer
+          ? this.expressionType(declaration.initializer)
+          : new scip.scip.Type({ type_ref: this.builtinType('number') }),
+      })
+    } else if (ts.isTypeParameterDeclaration(declaration)) {
+      // intentionally ignore
+    } else {
+      // console.log({
+      //   kind: ts.SyntaxKind[declaration.kind],
+      //   text: declaration.getText(),
+      // })
+    }
+
+    return signature
+  }
+
+  private symlinks(nodes?: ts.NodeArray<ts.Node>): scip.scip.Scope {
+    if (nodes === undefined) {
+      return new scip.scip.Scope()
+    }
+    return new scip.scip.Scope({
+      symlinks: nodes.map(node => this.scipSymbol(node).value),
+    })
+  }
+
+  private expressionType(node: ts.Node): scip.scip.Type {
+    if (
+      ts.isPrefixUnaryExpression(node) &&
+      node.operator === ts.SyntaxKind.MinusToken &&
+      ts.isNumericLiteral(node.operand)
+    ) {
+      // TODO: support arbitrary expressions. This solution is a hack that
+      // doesn't scale well.
+      const tpe = this.expressionType(node.operand)
+      if (tpe.constant_type.constant.has_int_constant) {
+        tpe.constant_type.constant.int_constant.value =
+          -tpe.constant_type.constant.int_constant.value
+      } else if (tpe.constant_type.constant.has_double_constant) {
+        tpe.constant_type.constant.double_constant.value =
+          -tpe.constant_type.constant.double_constant.value
+      }
+      return tpe
+    }
+    if (ts.isNumericLiteral(node)) {
+      const constant = new scip.scip.Constant()
+      const isFloat = node.text.includes('.')
+      try {
+        if (isFloat) {
+          constant.double_constant = new scip.scip.DoubleConstant({
+            value: Number.parseFloat(node.text),
+          })
+        } else {
+          constant.int_constant = new scip.scip.IntConstant({
+            value: Number.parseInt(node.text, 10),
+          })
+        }
+      } catch {
+        console.log(`unsupported numeric literal: ${node.text}`)
+      }
+      return new scip.scip.Type({
+        constant_type: new scip.scip.ConstantType({ constant }),
+      })
+    }
+    if (ts.isStringLiteral(node)) {
+      return new scip.scip.Type({
+        constant_type: new scip.scip.ConstantType({
+          constant: new scip.scip.Constant({
+            string_constant: new scip.scip.StringConstant({ value: node.text }),
+          }),
+        }),
+      })
+    }
+    const type = this.checker.typeToTypeNode(
+      this.checker.getTypeAtLocation(node),
+      node.parent,
+      undefined
     )
+    return type ? this.type(type) : new scip.scip.Type({})
+  }
+
+  private type(node: ts.Node): scip.scip.Type {
+    const type = new scip.scip.Type({})
+    if (ts.isTypeLiteralNode(node)) {
+      type.structural_type = new scip.scip.StructuralType({
+        declarations: this.symlinks(node.members),
+      })
+    } else if (ts.isParenthesizedTypeNode(node)) {
+      return this.type(node.type)
+    } else if (ts.isUnionTypeNode(node)) {
+      type.union_type = new scip.scip.UnionType({
+        types: node.types.map(type => this.type(type)),
+      })
+    } else if (ts.isIntersectionTypeNode(node)) {
+      type.intersection_type = new scip.scip.IntersectionType({
+        types: node.types.map(type => this.type(type)),
+      })
+    } else if (ts.isTupleTypeNode(node)) {
+      type.type_ref = new scip.scip.TypeRef({
+        symbol: this.builtinType('tuple').symbol,
+        type_arguments: node.elements.map(element => this.type(element)),
+      })
+    } else if (ts.isTypeReferenceNode(node)) {
+      const declaration = this.expressionDeclaration(node.typeName)
+      type.type_ref = new scip.scip.TypeRef({
+        symbol: declaration ? this.scipSymbol(declaration).value : undefined,
+        type_arguments: node.typeArguments?.map(argument =>
+          this.type(argument)
+        ),
+      })
+    } else if (ts.isExpressionWithTypeArguments(node)) {
+      let symbol: string | undefined
+      // Try to emit normal type reference if the expression is a basic reference
+      if (ts.isIdentifier(node.expression)) {
+        const declaration = this.expressionDeclaration(node.expression)
+        if (declaration) {
+          symbol = this.scipSymbol(declaration).value
+        }
+      }
+      const prefix = symbol ? undefined : this.type(node.expression)
+      type.type_ref = new scip.scip.TypeRef({
+        prefix,
+        symbol,
+        // intentionally no symbol
+        type_arguments: node.typeArguments?.map(argument =>
+          this.type(argument)
+        ),
+      })
+    } else if (ts.isArrayTypeNode(node)) {
+      type.type_ref = new scip.scip.TypeRef({
+        symbol: this.builtinType('array').symbol,
+        type_arguments: [this.type(node.elementType)],
+      })
+    } else if (ts.isFunctionTypeNode(node)) {
+      type.lambda_type = new scip.scip.LambdaType({
+        type_parameters: this.symlinks(node.typeParameters),
+        parameters: this.symlinks(node.parameters),
+        return_type: this.type(node.type),
+      })
+    } else if (ts.isStringLiteral(node)) {
+      type.constant_type = new scip.scip.ConstantType({
+        constant: new scip.scip.Constant({
+          string_constant: new scip.scip.StringConstant({
+            value: node.text,
+          }),
+        }),
+      })
+    } else if (ts.isTypeOperatorNode(node)) {
+      return this.type(node.type)
+    } else if (ts.isLiteralTypeNode(node)) {
+      return this.type(node.literal)
+    } else if (ts.isNumericLiteral(node)) {
+      const intConstant = this.checker.getTypeAtLocation(node)
+      if (intConstant.isNumberLiteral()) {
+        type.constant_type = new scip.scip.ConstantType({
+          constant: new scip.scip.Constant({
+            int_constant: new scip.scip.IntConstant({
+              value: intConstant.value,
+            }),
+          }),
+        })
+      }
+    } else {
+      const keywordType = this.syntaxKindToKeywordTypeRef(node.kind)
+      if (keywordType) {
+        type.type_ref = keywordType
+      } else {
+        switch (node.kind) {
+          case ts.SyntaxKind.TypeQuery:
+          case ts.SyntaxKind.PropertyAccessExpression:
+          case ts.SyntaxKind.InferType:
+          case ts.SyntaxKind.ConditionalType:
+          case ts.SyntaxKind.MappedType:
+          case ts.SyntaxKind.PrefixUnaryExpression:
+          case ts.SyntaxKind.RestType:
+          case ts.SyntaxKind.FirstTypeNode:
+          case ts.SyntaxKind.TemplateLiteralType:
+          case ts.SyntaxKind.LastTypeNode:
+          case ts.SyntaxKind.ThisType:
+          case ts.SyntaxKind.NamedTupleMember:
+          case ts.SyntaxKind.ExportDeclaration:
+          case ts.SyntaxKind.ConstructorType:
+            // ignore
+            break
+          case ts.SyntaxKind.IndexedAccessType:
+          case ts.SyntaxKind.Identifier:
+            return this.expressionType(node)
+          default:
+            const tpe = this.checker.getTypeAtLocation(node)
+            console.log({
+              kind: ts.SyntaxKind[node.kind],
+              // text: this.safeGetText(node),
+              tpe: this.checker.typeToString(tpe),
+            })
+        }
+      }
+    }
+    return type
+  }
+
+  private expressionDeclaration(node: ts.Node): ts.Declaration | undefined {
+    const symbol = this.getTSSymbolAtLocation(node)
+    if (!symbol) {
+      return undefined
+    }
+    return symbol.declarations?.[0]
+  }
+
+  private declarations(tpe: ts.Type): ts.Declaration[] {
+    return tpe?.symbol?.declarations ?? tpe.aliasSymbol?.declarations ?? []
+  }
+
+  private syntaxKindToKeywordTypeRef(
+    kind: ts.SyntaxKind
+  ): scip.scip.TypeRef | undefined {
+    const keyword = ts.SyntaxKind[kind]
+    if (keyword?.endsWith('Keyword')) {
+      return this.builtinType(
+        keyword.slice(0, keyword.length - 'Keyword'.length).toLowerCase()
+      )
+    }
+    return undefined
+  }
+
+  private builtinType(keyword: string): scip.scip.TypeRef {
+    const symbol = ScipSymbol.builtinType(keyword).value
+    if (
+      this.options.emitExternalSymbols &&
+      !this.cache.externalSymbols.has(symbol)
+    ) {
+      this.cache.externalSymbols.set(
+        symbol,
+        new scip.scip.SymbolInformation({
+          display_name: keyword,
+          symbol,
+          kind: scip.scip.SymbolInformation.Kind.Type,
+          signature: new scip.scip.Signature({}),
+        })
+      )
+    }
+    return new scip.scip.TypeRef({
+      symbol,
+    })
   }
 
   private pushOccurrence(occurrence: scip.scip.Occurrence): void {
@@ -375,10 +780,13 @@ export class FileIndexer {
       ts.isPropertyAssignment(declaration) ||
       ts.isPropertyDeclaration(declaration)
     ) {
-      const declarationName = declaration.name.getText()
+      const declarationName = this.propertyName(declaration.name)
       this.forEachAncestor(declaration.parent, ancestor => {
         for (const member of ancestor.members) {
-          if (declarationName === member.name?.getText()) {
+          if (
+            member.name &&
+            declarationName === this.propertyName(member.name)
+          ) {
             pushImplementation(member, true)
           }
         }
@@ -386,27 +794,72 @@ export class FileIndexer {
     }
     return relationships
   }
-  private scipSymbol(node: ts.Node): ScipSymbol {
-    const fromCache: ScipSymbol | undefined =
-      this.globalSymbolTable.get(node) || this.localSymbolTable.get(node)
-    if (fromCache) {
-      return fromCache
-    }
-    if (ts.isBlock(node)) {
-      return ScipSymbol.empty()
-    }
-    if (ts.isSourceFile(node)) {
-      const package_ = this.packages.symbol(node.fileName)
-      if (package_.isEmpty()) {
-        return this.cached(node, ScipSymbol.anonymousPackage())
-      }
-      return this.cached(node, package_)
-    }
+
+  // Equivalent to node.getText() except guards against nodes without "real
+  // positions", which throw an error when calling `.getText()`.
+  private safeGetText(node: ts.Node): string {
+    // TODO: come up with better default
+    return node.pos >= 0 ? node.getText() : `${node}`
+  }
+
+  private propertyName(name: ts.PropertyName): string {
     if (
-      ts.isPropertyAssignment(node) ||
-      ts.isShorthandPropertyAssignment(node)
+      ts.isIdentifier(name) ||
+      ts.isStringLiteral(name) ||
+      ts.isNoSubstitutionTemplateLiteral(name) ||
+      ts.isNumericLiteral(name) ||
+      ts.isPrivateIdentifier(name)
     ) {
-      const name = node.name.getText()
+      return name.text
+    }
+    return this.safeGetText(name)
+  }
+
+  private actualFilename(file: ts.SourceFile): string {
+    if (!this.options.followSourceMapping) {
+      return file.fileName
+    }
+    const sourceMapCommentRegExp = /^\/\/[@#] source[M]appingURL=(.+)\r?\n?$/
+    const whitespaceOrMapCommentRegExp = /^\s*(\/\/[@#] .*)?$/
+    const lineStarts = file.getLineStarts()
+    for (
+      let lineNumber = lineStarts.length - 1;
+      lineNumber >= 0;
+      lineNumber--
+    ) {
+      const start = lineStarts[lineNumber]
+      const end = file.getLineEndOfPosition(start)
+      const line = file.text.slice(start, end)
+      const comment = sourceMapCommentRegExp.exec(line)
+      if (comment) {
+        const sourceMappingURL = comment[1].trimEnd()
+        const dirname = path.dirname(file.fileName)
+        const mapFile = path.join(dirname, sourceMappingURL)
+        try {
+          const mapText = fs.readFileSync(mapFile).toString()
+          const mapping = JSON.parse(mapText)
+          const source = mapping?.sources?.[0]
+          if (typeof source === 'string') {
+            const originalPath = path.resolve(dirname, source)
+            if (fs.statSync(originalPath).isFile()) {
+              return originalPath
+            }
+          }
+        } catch (error) {
+          // ignore
+          // console.log('boom', error)
+        }
+      }
+      // If we see a non-whitespace/map comment-like line, break, to avoid scanning up the entire file
+      if (!line.match(whitespaceOrMapCommentRegExp)) {
+        break
+      }
+    }
+    return file.fileName
+  }
+
+  private metaDescriptorSymbol(node: ts.Node, name: string): ScipSymbol {
+    try {
       let counter = this.propertyCounters.get(name)
       if (!counter) {
         counter = new Counter()
@@ -416,8 +869,47 @@ export class FileIndexer {
         node,
         ScipSymbol.global(
           this.scipSymbol(node.getSourceFile()),
-          metaDescriptor(`${node.name.getText()}${counter.next()}`)
+          metaDescriptor(`${name}${counter.next()}`)
         )
+      )
+    } catch (error) {
+      console.log({ pos: node.pos }, error)
+      return ScipSymbol.empty()
+    }
+  }
+
+  private scipSymbol(node: ts.Node): ScipSymbol {
+    if (node === undefined) {
+      return ScipSymbol.empty()
+    }
+    const fromCache: ScipSymbol | undefined =
+      this.globalSymbolTable.get(node) || this.localSymbolTable.get(node)
+    if (fromCache) {
+      return fromCache
+    }
+
+    if (ts.isBlock(node)) {
+      return ScipSymbol.empty()
+    }
+    if (ts.isSourceFile(node)) {
+      const package_ = this.packages.symbol(this.actualFilename(node))
+      if (package_.isEmpty()) {
+        return this.cached(node, ScipSymbol.anonymousPackage())
+      }
+      return this.cached(node, package_)
+    }
+    if (
+      ts.isPropertyAssignment(node) ||
+      ts.isPropertySignature(node) ||
+      ts.isShorthandPropertyAssignment(node)
+    ) {
+      return this.metaDescriptorSymbol(node, this.propertyName(node.name))
+    }
+
+    if (ts.isIndexSignatureDeclaration(node)) {
+      return this.metaDescriptorSymbol(
+        node,
+        node.name ? this.propertyName(node.name) : 'indexedSignature'
       )
     }
 
@@ -467,7 +959,7 @@ export class FileIndexer {
       ts.isNamespaceImport(node)
     ) {
       const tpe = this.checker.getTypeAtLocation(node)
-      for (const declaration of tpe.symbol?.declarations || []) {
+      for (const declaration of this.declarations(tpe)) {
         return this.scipSymbol(declaration)
       }
     }
@@ -491,18 +983,50 @@ export class FileIndexer {
   }
   private cached(node: ts.Node, symbol: ScipSymbol): ScipSymbol {
     this.globalSymbolTable.set(node, symbol)
+    if (this.isExternalSymbol(node)) {
+      this.emitExternalSymbol(node, symbol)
+    }
     return symbol
   }
+
+  public emitExternalSymbol(declaration: ts.Node, symbol: ScipSymbol): void {
+    if (!this.options.emitExternalSymbols) {
+      return
+    }
+    if (this.cache.externalSymbols.has(symbol.value)) {
+      return
+    }
+    const name = declarationName(declaration)
+    if (!name) {
+      return
+    }
+    const tsSymbol = this.getTSSymbolAtLocation(name)
+    if (!tsSymbol) {
+      return
+    }
+    this.cache.externalSymbols.set(
+      symbol.value,
+      this.symbolInformation(name, tsSymbol, declaration, symbol)
+    )
+  }
+
+  public isExternalSymbol(node: ts.Node): boolean {
+    // Simple approximation to filter out symbols that are defined by external projects.
+    return (
+      node.pos >= 0 && node.getSourceFile().fileName.includes('node_modules')
+    )
+  }
+
   private descriptor(node: ts.Node): scip.scip.Descriptor | undefined {
     if (
       ts.isInterfaceDeclaration(node) ||
       ts.isEnumDeclaration(node) ||
       ts.isTypeAliasDeclaration(node)
     ) {
-      return typeDescriptor(node.name.getText())
+      return typeDescriptor(this.propertyName(node.name))
     }
     if (ts.isClassLike(node)) {
-      const name = node.name?.getText()
+      const name = node.name ? this.propertyName(node.name) : undefined
       if (name) {
         return typeDescriptor(name)
       }
@@ -512,7 +1036,7 @@ export class FileIndexer {
       ts.isMethodSignature(node) ||
       ts.isMethodDeclaration(node)
     ) {
-      const name = node.name?.getText()
+      const name = node.name ? this.propertyName(node.name) : undefined
       if (name) {
         return methodDescriptor(name)
       }
@@ -526,23 +1050,27 @@ export class FileIndexer {
       ts.isEnumMember(node) ||
       ts.isVariableDeclaration(node)
     ) {
-      return termDescriptor(node.name.getText())
+      return termDescriptor(
+        ts.isPropertyName(node.name)
+          ? this.propertyName(node.name)
+          : this.safeGetText(node.name)
+      )
     }
     if (ts.isAccessor(node)) {
       const prefix = ts.isGetAccessor(node) ? '<get>' : '<set>'
-      return methodDescriptor(prefix + node.name.getText())
+      return methodDescriptor(prefix + this.propertyName(node.name))
     }
     if (ts.isModuleDeclaration(node)) {
-      return packageDescriptor(node.name.getText())
+      return packageDescriptor(node.name.text)
     }
     if (ts.isParameter(node)) {
       return parameterDescriptor(node.name.getText())
     }
     if (ts.isTypeParameterDeclaration(node)) {
-      return typeParameterDescriptor(node.name.getText())
+      return typeParameterDescriptor(this.safeGetText(node.name))
     }
     if (ts.isTypeReferenceNode(node)) {
-      return metaDescriptor(node.typeName.getText())
+      return metaDescriptor(this.safeGetText(node.typeName))
     }
     if (ts.isTypeLiteralNode(node)) {
       return metaDescriptor('typeLiteral' + this.localCounter.next().toString())
@@ -552,8 +1080,12 @@ export class FileIndexer {
 
   private signatureForDocumentation(node: ts.Node, sym: ts.Symbol): string {
     const kind = scriptElementKind(node, sym)
-    const type = (): string =>
-      this.checker.typeToString(this.checker.getTypeAtLocation(node))
+    const type = (): string => {
+      if (ts.isSourceFile(node)) {
+        return ''
+      }
+      return this.checker.typeToString(this.checker.getTypeAtLocation(node))
+    }
     const asSignatureDeclaration = (
       node: ts.Node,
       sym: ts.Symbol
@@ -582,35 +1114,35 @@ export class FileIndexer {
     switch (kind) {
       case ts.ScriptElementKind.localVariableElement:
       case ts.ScriptElementKind.variableElement: {
-        return 'var ' + node.getText() + ': ' + type()
+        return 'var ' + this.safeGetText(node) + ': ' + type()
       }
       case ts.ScriptElementKind.memberVariableElement: {
-        return '(property) ' + node.getText() + ': ' + type()
+        return '(property) ' + this.safeGetText(node) + ': ' + type()
       }
       case ts.ScriptElementKind.parameterElement: {
-        return '(parameter) ' + node.getText() + ': ' + type()
+        return '(parameter) ' + this.safeGetText(node) + ': ' + type()
       }
       case ts.ScriptElementKind.constElement: {
-        return 'const ' + node.getText() + ': ' + type()
+        return 'const ' + this.safeGetText(node) + ': ' + type()
       }
       case ts.ScriptElementKind.letElement: {
-        return 'let ' + node.getText() + ': ' + type()
+        return 'let ' + this.safeGetText(node) + ': ' + type()
       }
       case ts.ScriptElementKind.alias: {
-        return 'type ' + node.getText()
+        return 'type ' + this.safeGetText(node)
       }
       case ts.ScriptElementKind.classElement:
       case ts.ScriptElementKind.localClassElement: {
         if (ts.isConstructorDeclaration(node)) {
           return 'constructor' + (signature() || '')
         }
-        return 'class ' + node.getText()
+        return 'class ' + this.safeGetText(node)
       }
       case ts.ScriptElementKind.interfaceElement: {
-        return 'interface ' + node.getText()
+        return 'interface ' + this.safeGetText(node)
       }
       case ts.ScriptElementKind.enumElement: {
-        return 'enum ' + node.getText()
+        return 'enum ' + this.safeGetText(node)
       }
       case ts.ScriptElementKind.enumMemberElement: {
         let suffix = ''
@@ -621,25 +1153,25 @@ export class FileIndexer {
             suffix = ' = ' + constantValue.toString()
           }
         }
-        return '(enum member) ' + node.getText() + suffix
+        return '(enum member) ' + this.safeGetText(node) + suffix
       }
       case ts.ScriptElementKind.functionElement: {
-        return 'function ' + node.getText() + (signature() || type())
+        return 'function ' + this.safeGetText(node) + (signature() || type())
       }
       case ts.ScriptElementKind.memberFunctionElement: {
-        return '(method) ' + node.getText() + (signature() || type())
+        return '(method) ' + this.safeGetText(node) + (signature() || type())
       }
       case ts.ScriptElementKind.memberGetAccessorElement: {
-        return 'get ' + node.getText() + ': ' + type()
+        return 'get ' + this.safeGetText(node) + ': ' + type()
       }
       case ts.ScriptElementKind.memberSetAccessorElement: {
-        return 'set ' + node.getText() + type()
+        return 'set ' + this.safeGetText(node) + type()
       }
       case ts.ScriptElementKind.constructorImplementationElement: {
         return ''
       }
     }
-    return node.getText() + ': ' + type()
+    return this.safeGetText(node) + ': ' + type()
   }
 
   // Invokes the `onAncestor` callback for all "ancestors" of the provided node,

--- a/src/ProjectIndexer.ts
+++ b/src/ProjectIndexer.ts
@@ -77,7 +77,7 @@ export class ProjectIndexer {
   constructor(
     public readonly config: ts.ParsedCommandLine,
     public readonly options: ProjectOptions,
-    cache: GlobalCache
+    private readonly cache: GlobalCache
   ) {
     const host = createCompilerHost(cache, config.options, options)
     this.program = ts.createProgram(config.fileNames, config.options, host)
@@ -141,6 +141,7 @@ export class ProjectIndexer {
         input,
         document,
         this.symbolCache,
+        this.cache,
         this.hasConstructor,
         this.packages,
         sourceFile

--- a/src/ScipSymbol.ts
+++ b/src/ScipSymbol.ts
@@ -1,8 +1,15 @@
-import { descriptorString } from './Descriptor'
+import { descriptorString, typeDescriptor } from './Descriptor'
 import * as scip from './scip'
 
 export class ScipSymbol {
-  private constructor(public readonly value: string) {}
+  private constructor(
+    public readonly value: string,
+    private readonly descriptor?: scip.scip.Descriptor
+  ) {}
+
+  public get display_name(): string | undefined {
+    return this.descriptor?.name
+  }
 
   public isEmpty(): boolean {
     return this.value === ''
@@ -26,6 +33,13 @@ export class ScipSymbol {
 
   public static anonymousPackage(): ScipSymbol {
     return ScipSymbol.package('.', '.')
+  }
+
+  public static builtinType(value: string): ScipSymbol {
+    return ScipSymbol.global(
+      ScipSymbol.package('typescript', '.'),
+      typeDescriptor(value)
+    )
   }
 
   public static global(

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -61,6 +61,9 @@ for (const snapshotDirectory of snapshotDirectories) {
       progressBar: false,
       indexedProjects: new Set(),
       globalCaches: true,
+      emitSignatures: true,
+      emitExternalSymbols: true,
+      followSourceMapping: true,
     })
     if (inferTsconfig) {
       fs.rmSync(tsconfigJsonPath)
@@ -81,7 +84,7 @@ for (const snapshotDirectory of snapshotDirectories) {
         ? fs.readFileSync(outputPath).toString()
         : ''
       const input = Input.fromFile(inputPath)
-      const obtained = formatSnapshot(input, document)
+      const obtained = formatSnapshot(input, document, index.external_symbols)
       if (obtained === expected) {
         // Test passed
         continue

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,6 +54,7 @@ export function indexCommand(
   const cache: GlobalCache = {
     sources: new Map(),
     parsedCommandLines: new Map(),
+    externalSymbols: new Map(),
   }
   try {
     writeIndex(
@@ -82,6 +83,14 @@ export function indexCommand(
           writeIndex,
         },
         cache
+      )
+    }
+
+    if (cache.externalSymbols.size > 0) {
+      writeIndex(
+        new scip.scip.Index({
+          external_symbols: [...cache.externalSymbols.values()],
+        })
       )
     }
   } finally {

--- a/src/scip.ts
+++ b/src/scip.ts
@@ -13,6 +13,12 @@ export namespace scip {
         UTF8 = 1,
         UTF16 = 2
     }
+    export enum PositionEncoding {
+        UnspecifiedPositionEncoding = 0,
+        UTF8CodeUnitOffsetFromLineStart = 1,
+        UTF16CodeUnitOffsetFromLineStart = 2,
+        UTF32CodeUnitOffsetFromLineStart = 3
+    }
     export enum SymbolRole {
         UnspecifiedSymbolRole = 0,
         Definition = 1,
@@ -566,6 +572,7 @@ export namespace scip {
             occurrences?: Occurrence[];
             symbols?: SymbolInformation[];
             text?: string;
+            position_encoding?: PositionEncoding;
         }) {
             super();
             pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [2, 3], this.#one_of_decls);
@@ -584,6 +591,9 @@ export namespace scip {
                 }
                 if ("text" in data && data.text != undefined) {
                     this.text = data.text;
+                }
+                if ("position_encoding" in data && data.position_encoding != undefined) {
+                    this.position_encoding = data.position_encoding;
                 }
             }
         }
@@ -617,12 +627,19 @@ export namespace scip {
         set text(value: string) {
             pb_1.Message.setField(this, 5, value);
         }
+        get position_encoding() {
+            return pb_1.Message.getFieldWithDefault(this, 6, PositionEncoding.UnspecifiedPositionEncoding) as PositionEncoding;
+        }
+        set position_encoding(value: PositionEncoding) {
+            pb_1.Message.setField(this, 6, value);
+        }
         static fromObject(data: {
             language?: string;
             relative_path?: string;
             occurrences?: ReturnType<typeof Occurrence.prototype.toObject>[];
             symbols?: ReturnType<typeof SymbolInformation.prototype.toObject>[];
             text?: string;
+            position_encoding?: PositionEncoding;
         }): Document {
             const message = new Document({});
             if (data.language != null) {
@@ -640,6 +657,9 @@ export namespace scip {
             if (data.text != null) {
                 message.text = data.text;
             }
+            if (data.position_encoding != null) {
+                message.position_encoding = data.position_encoding;
+            }
             return message;
         }
         toObject() {
@@ -649,6 +669,7 @@ export namespace scip {
                 occurrences?: ReturnType<typeof Occurrence.prototype.toObject>[];
                 symbols?: ReturnType<typeof SymbolInformation.prototype.toObject>[];
                 text?: string;
+                position_encoding?: PositionEncoding;
             } = {};
             if (this.language != null) {
                 data.language = this.language;
@@ -664,6 +685,9 @@ export namespace scip {
             }
             if (this.text != null) {
                 data.text = this.text;
+            }
+            if (this.position_encoding != null) {
+                data.position_encoding = this.position_encoding;
             }
             return data;
         }
@@ -681,6 +705,8 @@ export namespace scip {
                 writer.writeRepeatedMessage(3, this.symbols, (item: SymbolInformation) => item.serialize(writer));
             if (this.text.length)
                 writer.writeString(5, this.text);
+            if (this.position_encoding != PositionEncoding.UnspecifiedPositionEncoding)
+                writer.writeEnum(6, this.position_encoding);
             if (!w)
                 return writer.getResultBuffer();
         }
@@ -704,6 +730,9 @@ export namespace scip {
                         break;
                     case 5:
                         message.text = reader.readString();
+                        break;
+                    case 6:
+                        message.position_encoding = reader.readEnum();
                         break;
                     default: reader.skipField();
                 }
@@ -1085,6 +1114,7 @@ export namespace scip {
             display_name?: string;
             signature_documentation?: Document;
             enclosing_symbol?: string;
+            signature?: Signature;
         }) {
             super();
             pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [3, 4], this.#one_of_decls);
@@ -1109,6 +1139,9 @@ export namespace scip {
                 }
                 if ("enclosing_symbol" in data && data.enclosing_symbol != undefined) {
                     this.enclosing_symbol = data.enclosing_symbol;
+                }
+                if ("signature" in data && data.signature != undefined) {
+                    this.signature = data.signature;
                 }
             }
         }
@@ -1157,6 +1190,15 @@ export namespace scip {
         set enclosing_symbol(value: string) {
             pb_1.Message.setField(this, 8, value);
         }
+        get signature() {
+            return pb_1.Message.getWrapperField(this, Signature, 9) as Signature;
+        }
+        set signature(value: Signature) {
+            pb_1.Message.setWrapperField(this, 9, value);
+        }
+        get has_signature() {
+            return pb_1.Message.getField(this, 9) != null;
+        }
         static fromObject(data: {
             symbol?: string;
             documentation?: string[];
@@ -1165,6 +1207,7 @@ export namespace scip {
             display_name?: string;
             signature_documentation?: ReturnType<typeof Document.prototype.toObject>;
             enclosing_symbol?: string;
+            signature?: ReturnType<typeof Signature.prototype.toObject>;
         }): SymbolInformation {
             const message = new SymbolInformation({});
             if (data.symbol != null) {
@@ -1188,6 +1231,9 @@ export namespace scip {
             if (data.enclosing_symbol != null) {
                 message.enclosing_symbol = data.enclosing_symbol;
             }
+            if (data.signature != null) {
+                message.signature = Signature.fromObject(data.signature);
+            }
             return message;
         }
         toObject() {
@@ -1199,6 +1245,7 @@ export namespace scip {
                 display_name?: string;
                 signature_documentation?: ReturnType<typeof Document.prototype.toObject>;
                 enclosing_symbol?: string;
+                signature?: ReturnType<typeof Signature.prototype.toObject>;
             } = {};
             if (this.symbol != null) {
                 data.symbol = this.symbol;
@@ -1221,6 +1268,9 @@ export namespace scip {
             if (this.enclosing_symbol != null) {
                 data.enclosing_symbol = this.enclosing_symbol;
             }
+            if (this.signature != null) {
+                data.signature = this.signature.toObject();
+            }
             return data;
         }
         serialize(): Uint8Array;
@@ -1241,6 +1291,8 @@ export namespace scip {
                 writer.writeMessage(7, this.signature_documentation, () => this.signature_documentation.serialize(writer));
             if (this.enclosing_symbol.length)
                 writer.writeString(8, this.enclosing_symbol);
+            if (this.has_signature)
+                writer.writeMessage(9, this.signature, () => this.signature.serialize(writer));
             if (!w)
                 return writer.getResultBuffer();
         }
@@ -1270,6 +1322,9 @@ export namespace scip {
                         break;
                     case 8:
                         message.enclosing_symbol = reader.readString();
+                        break;
+                    case 9:
+                        reader.readMessage(message.signature, () => message.signature = Signature.deserialize(reader));
                         break;
                     default: reader.skipField();
                 }
@@ -1891,6 +1946,4162 @@ export namespace scip {
         }
         static deserializeBinary(bytes: Uint8Array): Diagnostic {
             return Diagnostic.deserialize(bytes);
+        }
+    }
+    export class Annotation extends pb_1.Message {
+        #one_of_decls: number[][] = [];
+        constructor(data?: any[] | {
+            tpe?: Type;
+        }) {
+            super();
+            pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
+            if (!Array.isArray(data) && typeof data == "object") {
+                if ("tpe" in data && data.tpe != undefined) {
+                    this.tpe = data.tpe;
+                }
+            }
+        }
+        get tpe() {
+            return pb_1.Message.getWrapperField(this, Type, 1) as Type;
+        }
+        set tpe(value: Type) {
+            pb_1.Message.setWrapperField(this, 1, value);
+        }
+        get has_tpe() {
+            return pb_1.Message.getField(this, 1) != null;
+        }
+        static fromObject(data: {
+            tpe?: ReturnType<typeof Type.prototype.toObject>;
+        }): Annotation {
+            const message = new Annotation({});
+            if (data.tpe != null) {
+                message.tpe = Type.fromObject(data.tpe);
+            }
+            return message;
+        }
+        toObject() {
+            const data: {
+                tpe?: ReturnType<typeof Type.prototype.toObject>;
+            } = {};
+            if (this.tpe != null) {
+                data.tpe = this.tpe.toObject();
+            }
+            return data;
+        }
+        serialize(): Uint8Array;
+        serialize(w: pb_1.BinaryWriter): void;
+        serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
+            const writer = w || new pb_1.BinaryWriter();
+            if (this.has_tpe)
+                writer.writeMessage(1, this.tpe, () => this.tpe.serialize(writer));
+            if (!w)
+                return writer.getResultBuffer();
+        }
+        static deserialize(bytes: Uint8Array | pb_1.BinaryReader): Annotation {
+            const reader = bytes instanceof pb_1.BinaryReader ? bytes : new pb_1.BinaryReader(bytes), message = new Annotation();
+            while (reader.nextField()) {
+                if (reader.isEndGroup())
+                    break;
+                switch (reader.getFieldNumber()) {
+                    case 1:
+                        reader.readMessage(message.tpe, () => message.tpe = Type.deserialize(reader));
+                        break;
+                    default: reader.skipField();
+                }
+            }
+            return message;
+        }
+        serializeBinary(): Uint8Array {
+            return this.serialize();
+        }
+        static deserializeBinary(bytes: Uint8Array): Annotation {
+            return Annotation.deserialize(bytes);
+        }
+    }
+    export class Scope extends pb_1.Message {
+        #one_of_decls: number[][] = [];
+        constructor(data?: any[] | {
+            symlinks?: string[];
+            hardlinks?: SymbolInformation[];
+        }) {
+            super();
+            pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [1, 2], this.#one_of_decls);
+            if (!Array.isArray(data) && typeof data == "object") {
+                if ("symlinks" in data && data.symlinks != undefined) {
+                    this.symlinks = data.symlinks;
+                }
+                if ("hardlinks" in data && data.hardlinks != undefined) {
+                    this.hardlinks = data.hardlinks;
+                }
+            }
+        }
+        get symlinks() {
+            return pb_1.Message.getFieldWithDefault(this, 1, []) as string[];
+        }
+        set symlinks(value: string[]) {
+            pb_1.Message.setField(this, 1, value);
+        }
+        get hardlinks() {
+            return pb_1.Message.getRepeatedWrapperField(this, SymbolInformation, 2) as SymbolInformation[];
+        }
+        set hardlinks(value: SymbolInformation[]) {
+            pb_1.Message.setRepeatedWrapperField(this, 2, value);
+        }
+        static fromObject(data: {
+            symlinks?: string[];
+            hardlinks?: ReturnType<typeof SymbolInformation.prototype.toObject>[];
+        }): Scope {
+            const message = new Scope({});
+            if (data.symlinks != null) {
+                message.symlinks = data.symlinks;
+            }
+            if (data.hardlinks != null) {
+                message.hardlinks = data.hardlinks.map(item => SymbolInformation.fromObject(item));
+            }
+            return message;
+        }
+        toObject() {
+            const data: {
+                symlinks?: string[];
+                hardlinks?: ReturnType<typeof SymbolInformation.prototype.toObject>[];
+            } = {};
+            if (this.symlinks != null) {
+                data.symlinks = this.symlinks;
+            }
+            if (this.hardlinks != null) {
+                data.hardlinks = this.hardlinks.map((item: SymbolInformation) => item.toObject());
+            }
+            return data;
+        }
+        serialize(): Uint8Array;
+        serialize(w: pb_1.BinaryWriter): void;
+        serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
+            const writer = w || new pb_1.BinaryWriter();
+            if (this.symlinks.length)
+                writer.writeRepeatedString(1, this.symlinks);
+            if (this.hardlinks.length)
+                writer.writeRepeatedMessage(2, this.hardlinks, (item: SymbolInformation) => item.serialize(writer));
+            if (!w)
+                return writer.getResultBuffer();
+        }
+        static deserialize(bytes: Uint8Array | pb_1.BinaryReader): Scope {
+            const reader = bytes instanceof pb_1.BinaryReader ? bytes : new pb_1.BinaryReader(bytes), message = new Scope();
+            while (reader.nextField()) {
+                if (reader.isEndGroup())
+                    break;
+                switch (reader.getFieldNumber()) {
+                    case 1:
+                        pb_1.Message.addToRepeatedField(message, 1, reader.readString());
+                        break;
+                    case 2:
+                        reader.readMessage(message.hardlinks, () => pb_1.Message.addToRepeatedWrapperField(message, 2, SymbolInformation.deserialize(reader), SymbolInformation));
+                        break;
+                    default: reader.skipField();
+                }
+            }
+            return message;
+        }
+        serializeBinary(): Uint8Array {
+            return this.serialize();
+        }
+        static deserializeBinary(bytes: Uint8Array): Scope {
+            return Scope.deserialize(bytes);
+        }
+    }
+    export class Type extends pb_1.Message {
+        #one_of_decls: number[][] = [[2, 20, 21, 22, 23, 17, 18, 19, 7, 8, 9, 10, 13, 14, 25, 26]];
+        constructor(data?: any[] | ({} & (({
+            type_ref?: TypeRef;
+            single_type?: never;
+            this_type?: never;
+            super_type?: never;
+            constant_type?: never;
+            intersection_type?: never;
+            union_type?: never;
+            with_type?: never;
+            structural_type?: never;
+            annotated_type?: never;
+            existential_type?: never;
+            universal_type?: never;
+            by_name_type?: never;
+            repeated_type?: never;
+            match_type?: never;
+            lambda_type?: never;
+        } | {
+            type_ref?: never;
+            single_type?: SingleType;
+            this_type?: never;
+            super_type?: never;
+            constant_type?: never;
+            intersection_type?: never;
+            union_type?: never;
+            with_type?: never;
+            structural_type?: never;
+            annotated_type?: never;
+            existential_type?: never;
+            universal_type?: never;
+            by_name_type?: never;
+            repeated_type?: never;
+            match_type?: never;
+            lambda_type?: never;
+        } | {
+            type_ref?: never;
+            single_type?: never;
+            this_type?: ThisType;
+            super_type?: never;
+            constant_type?: never;
+            intersection_type?: never;
+            union_type?: never;
+            with_type?: never;
+            structural_type?: never;
+            annotated_type?: never;
+            existential_type?: never;
+            universal_type?: never;
+            by_name_type?: never;
+            repeated_type?: never;
+            match_type?: never;
+            lambda_type?: never;
+        } | {
+            type_ref?: never;
+            single_type?: never;
+            this_type?: never;
+            super_type?: SuperType;
+            constant_type?: never;
+            intersection_type?: never;
+            union_type?: never;
+            with_type?: never;
+            structural_type?: never;
+            annotated_type?: never;
+            existential_type?: never;
+            universal_type?: never;
+            by_name_type?: never;
+            repeated_type?: never;
+            match_type?: never;
+            lambda_type?: never;
+        } | {
+            type_ref?: never;
+            single_type?: never;
+            this_type?: never;
+            super_type?: never;
+            constant_type?: ConstantType;
+            intersection_type?: never;
+            union_type?: never;
+            with_type?: never;
+            structural_type?: never;
+            annotated_type?: never;
+            existential_type?: never;
+            universal_type?: never;
+            by_name_type?: never;
+            repeated_type?: never;
+            match_type?: never;
+            lambda_type?: never;
+        } | {
+            type_ref?: never;
+            single_type?: never;
+            this_type?: never;
+            super_type?: never;
+            constant_type?: never;
+            intersection_type?: IntersectionType;
+            union_type?: never;
+            with_type?: never;
+            structural_type?: never;
+            annotated_type?: never;
+            existential_type?: never;
+            universal_type?: never;
+            by_name_type?: never;
+            repeated_type?: never;
+            match_type?: never;
+            lambda_type?: never;
+        } | {
+            type_ref?: never;
+            single_type?: never;
+            this_type?: never;
+            super_type?: never;
+            constant_type?: never;
+            intersection_type?: never;
+            union_type?: UnionType;
+            with_type?: never;
+            structural_type?: never;
+            annotated_type?: never;
+            existential_type?: never;
+            universal_type?: never;
+            by_name_type?: never;
+            repeated_type?: never;
+            match_type?: never;
+            lambda_type?: never;
+        } | {
+            type_ref?: never;
+            single_type?: never;
+            this_type?: never;
+            super_type?: never;
+            constant_type?: never;
+            intersection_type?: never;
+            union_type?: never;
+            with_type?: WithType;
+            structural_type?: never;
+            annotated_type?: never;
+            existential_type?: never;
+            universal_type?: never;
+            by_name_type?: never;
+            repeated_type?: never;
+            match_type?: never;
+            lambda_type?: never;
+        } | {
+            type_ref?: never;
+            single_type?: never;
+            this_type?: never;
+            super_type?: never;
+            constant_type?: never;
+            intersection_type?: never;
+            union_type?: never;
+            with_type?: never;
+            structural_type?: StructuralType;
+            annotated_type?: never;
+            existential_type?: never;
+            universal_type?: never;
+            by_name_type?: never;
+            repeated_type?: never;
+            match_type?: never;
+            lambda_type?: never;
+        } | {
+            type_ref?: never;
+            single_type?: never;
+            this_type?: never;
+            super_type?: never;
+            constant_type?: never;
+            intersection_type?: never;
+            union_type?: never;
+            with_type?: never;
+            structural_type?: never;
+            annotated_type?: AnnotatedType;
+            existential_type?: never;
+            universal_type?: never;
+            by_name_type?: never;
+            repeated_type?: never;
+            match_type?: never;
+            lambda_type?: never;
+        } | {
+            type_ref?: never;
+            single_type?: never;
+            this_type?: never;
+            super_type?: never;
+            constant_type?: never;
+            intersection_type?: never;
+            union_type?: never;
+            with_type?: never;
+            structural_type?: never;
+            annotated_type?: never;
+            existential_type?: ExistentialType;
+            universal_type?: never;
+            by_name_type?: never;
+            repeated_type?: never;
+            match_type?: never;
+            lambda_type?: never;
+        } | {
+            type_ref?: never;
+            single_type?: never;
+            this_type?: never;
+            super_type?: never;
+            constant_type?: never;
+            intersection_type?: never;
+            union_type?: never;
+            with_type?: never;
+            structural_type?: never;
+            annotated_type?: never;
+            existential_type?: never;
+            universal_type?: UniversalType;
+            by_name_type?: never;
+            repeated_type?: never;
+            match_type?: never;
+            lambda_type?: never;
+        } | {
+            type_ref?: never;
+            single_type?: never;
+            this_type?: never;
+            super_type?: never;
+            constant_type?: never;
+            intersection_type?: never;
+            union_type?: never;
+            with_type?: never;
+            structural_type?: never;
+            annotated_type?: never;
+            existential_type?: never;
+            universal_type?: never;
+            by_name_type?: ByNameType;
+            repeated_type?: never;
+            match_type?: never;
+            lambda_type?: never;
+        } | {
+            type_ref?: never;
+            single_type?: never;
+            this_type?: never;
+            super_type?: never;
+            constant_type?: never;
+            intersection_type?: never;
+            union_type?: never;
+            with_type?: never;
+            structural_type?: never;
+            annotated_type?: never;
+            existential_type?: never;
+            universal_type?: never;
+            by_name_type?: never;
+            repeated_type?: RepeatedType;
+            match_type?: never;
+            lambda_type?: never;
+        } | {
+            type_ref?: never;
+            single_type?: never;
+            this_type?: never;
+            super_type?: never;
+            constant_type?: never;
+            intersection_type?: never;
+            union_type?: never;
+            with_type?: never;
+            structural_type?: never;
+            annotated_type?: never;
+            existential_type?: never;
+            universal_type?: never;
+            by_name_type?: never;
+            repeated_type?: never;
+            match_type?: MatchType;
+            lambda_type?: never;
+        } | {
+            type_ref?: never;
+            single_type?: never;
+            this_type?: never;
+            super_type?: never;
+            constant_type?: never;
+            intersection_type?: never;
+            union_type?: never;
+            with_type?: never;
+            structural_type?: never;
+            annotated_type?: never;
+            existential_type?: never;
+            universal_type?: never;
+            by_name_type?: never;
+            repeated_type?: never;
+            match_type?: never;
+            lambda_type?: LambdaType;
+        })))) {
+            super();
+            pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
+            if (!Array.isArray(data) && typeof data == "object") {
+                if ("type_ref" in data && data.type_ref != undefined) {
+                    this.type_ref = data.type_ref;
+                }
+                if ("single_type" in data && data.single_type != undefined) {
+                    this.single_type = data.single_type;
+                }
+                if ("this_type" in data && data.this_type != undefined) {
+                    this.this_type = data.this_type;
+                }
+                if ("super_type" in data && data.super_type != undefined) {
+                    this.super_type = data.super_type;
+                }
+                if ("constant_type" in data && data.constant_type != undefined) {
+                    this.constant_type = data.constant_type;
+                }
+                if ("intersection_type" in data && data.intersection_type != undefined) {
+                    this.intersection_type = data.intersection_type;
+                }
+                if ("union_type" in data && data.union_type != undefined) {
+                    this.union_type = data.union_type;
+                }
+                if ("with_type" in data && data.with_type != undefined) {
+                    this.with_type = data.with_type;
+                }
+                if ("structural_type" in data && data.structural_type != undefined) {
+                    this.structural_type = data.structural_type;
+                }
+                if ("annotated_type" in data && data.annotated_type != undefined) {
+                    this.annotated_type = data.annotated_type;
+                }
+                if ("existential_type" in data && data.existential_type != undefined) {
+                    this.existential_type = data.existential_type;
+                }
+                if ("universal_type" in data && data.universal_type != undefined) {
+                    this.universal_type = data.universal_type;
+                }
+                if ("by_name_type" in data && data.by_name_type != undefined) {
+                    this.by_name_type = data.by_name_type;
+                }
+                if ("repeated_type" in data && data.repeated_type != undefined) {
+                    this.repeated_type = data.repeated_type;
+                }
+                if ("match_type" in data && data.match_type != undefined) {
+                    this.match_type = data.match_type;
+                }
+                if ("lambda_type" in data && data.lambda_type != undefined) {
+                    this.lambda_type = data.lambda_type;
+                }
+            }
+        }
+        get type_ref() {
+            return pb_1.Message.getWrapperField(this, TypeRef, 2) as TypeRef;
+        }
+        set type_ref(value: TypeRef) {
+            pb_1.Message.setOneofWrapperField(this, 2, this.#one_of_decls[0], value);
+        }
+        get has_type_ref() {
+            return pb_1.Message.getField(this, 2) != null;
+        }
+        get single_type() {
+            return pb_1.Message.getWrapperField(this, SingleType, 20) as SingleType;
+        }
+        set single_type(value: SingleType) {
+            pb_1.Message.setOneofWrapperField(this, 20, this.#one_of_decls[0], value);
+        }
+        get has_single_type() {
+            return pb_1.Message.getField(this, 20) != null;
+        }
+        get this_type() {
+            return pb_1.Message.getWrapperField(this, ThisType, 21) as ThisType;
+        }
+        set this_type(value: ThisType) {
+            pb_1.Message.setOneofWrapperField(this, 21, this.#one_of_decls[0], value);
+        }
+        get has_this_type() {
+            return pb_1.Message.getField(this, 21) != null;
+        }
+        get super_type() {
+            return pb_1.Message.getWrapperField(this, SuperType, 22) as SuperType;
+        }
+        set super_type(value: SuperType) {
+            pb_1.Message.setOneofWrapperField(this, 22, this.#one_of_decls[0], value);
+        }
+        get has_super_type() {
+            return pb_1.Message.getField(this, 22) != null;
+        }
+        get constant_type() {
+            return pb_1.Message.getWrapperField(this, ConstantType, 23) as ConstantType;
+        }
+        set constant_type(value: ConstantType) {
+            pb_1.Message.setOneofWrapperField(this, 23, this.#one_of_decls[0], value);
+        }
+        get has_constant_type() {
+            return pb_1.Message.getField(this, 23) != null;
+        }
+        get intersection_type() {
+            return pb_1.Message.getWrapperField(this, IntersectionType, 17) as IntersectionType;
+        }
+        set intersection_type(value: IntersectionType) {
+            pb_1.Message.setOneofWrapperField(this, 17, this.#one_of_decls[0], value);
+        }
+        get has_intersection_type() {
+            return pb_1.Message.getField(this, 17) != null;
+        }
+        get union_type() {
+            return pb_1.Message.getWrapperField(this, UnionType, 18) as UnionType;
+        }
+        set union_type(value: UnionType) {
+            pb_1.Message.setOneofWrapperField(this, 18, this.#one_of_decls[0], value);
+        }
+        get has_union_type() {
+            return pb_1.Message.getField(this, 18) != null;
+        }
+        get with_type() {
+            return pb_1.Message.getWrapperField(this, WithType, 19) as WithType;
+        }
+        set with_type(value: WithType) {
+            pb_1.Message.setOneofWrapperField(this, 19, this.#one_of_decls[0], value);
+        }
+        get has_with_type() {
+            return pb_1.Message.getField(this, 19) != null;
+        }
+        get structural_type() {
+            return pb_1.Message.getWrapperField(this, StructuralType, 7) as StructuralType;
+        }
+        set structural_type(value: StructuralType) {
+            pb_1.Message.setOneofWrapperField(this, 7, this.#one_of_decls[0], value);
+        }
+        get has_structural_type() {
+            return pb_1.Message.getField(this, 7) != null;
+        }
+        get annotated_type() {
+            return pb_1.Message.getWrapperField(this, AnnotatedType, 8) as AnnotatedType;
+        }
+        set annotated_type(value: AnnotatedType) {
+            pb_1.Message.setOneofWrapperField(this, 8, this.#one_of_decls[0], value);
+        }
+        get has_annotated_type() {
+            return pb_1.Message.getField(this, 8) != null;
+        }
+        get existential_type() {
+            return pb_1.Message.getWrapperField(this, ExistentialType, 9) as ExistentialType;
+        }
+        set existential_type(value: ExistentialType) {
+            pb_1.Message.setOneofWrapperField(this, 9, this.#one_of_decls[0], value);
+        }
+        get has_existential_type() {
+            return pb_1.Message.getField(this, 9) != null;
+        }
+        get universal_type() {
+            return pb_1.Message.getWrapperField(this, UniversalType, 10) as UniversalType;
+        }
+        set universal_type(value: UniversalType) {
+            pb_1.Message.setOneofWrapperField(this, 10, this.#one_of_decls[0], value);
+        }
+        get has_universal_type() {
+            return pb_1.Message.getField(this, 10) != null;
+        }
+        get by_name_type() {
+            return pb_1.Message.getWrapperField(this, ByNameType, 13) as ByNameType;
+        }
+        set by_name_type(value: ByNameType) {
+            pb_1.Message.setOneofWrapperField(this, 13, this.#one_of_decls[0], value);
+        }
+        get has_by_name_type() {
+            return pb_1.Message.getField(this, 13) != null;
+        }
+        get repeated_type() {
+            return pb_1.Message.getWrapperField(this, RepeatedType, 14) as RepeatedType;
+        }
+        set repeated_type(value: RepeatedType) {
+            pb_1.Message.setOneofWrapperField(this, 14, this.#one_of_decls[0], value);
+        }
+        get has_repeated_type() {
+            return pb_1.Message.getField(this, 14) != null;
+        }
+        get match_type() {
+            return pb_1.Message.getWrapperField(this, MatchType, 25) as MatchType;
+        }
+        set match_type(value: MatchType) {
+            pb_1.Message.setOneofWrapperField(this, 25, this.#one_of_decls[0], value);
+        }
+        get has_match_type() {
+            return pb_1.Message.getField(this, 25) != null;
+        }
+        get lambda_type() {
+            return pb_1.Message.getWrapperField(this, LambdaType, 26) as LambdaType;
+        }
+        set lambda_type(value: LambdaType) {
+            pb_1.Message.setOneofWrapperField(this, 26, this.#one_of_decls[0], value);
+        }
+        get has_lambda_type() {
+            return pb_1.Message.getField(this, 26) != null;
+        }
+        get sealed_value() {
+            const cases: {
+                [index: number]: "none" | "type_ref" | "single_type" | "this_type" | "super_type" | "constant_type" | "intersection_type" | "union_type" | "with_type" | "structural_type" | "annotated_type" | "existential_type" | "universal_type" | "by_name_type" | "repeated_type" | "match_type" | "lambda_type";
+            } = {
+                0: "none",
+                2: "type_ref",
+                20: "single_type",
+                21: "this_type",
+                22: "super_type",
+                23: "constant_type",
+                17: "intersection_type",
+                18: "union_type",
+                19: "with_type",
+                7: "structural_type",
+                8: "annotated_type",
+                9: "existential_type",
+                10: "universal_type",
+                13: "by_name_type",
+                14: "repeated_type",
+                25: "match_type",
+                26: "lambda_type"
+            };
+            return cases[pb_1.Message.computeOneofCase(this, [2, 20, 21, 22, 23, 17, 18, 19, 7, 8, 9, 10, 13, 14, 25, 26])];
+        }
+        static fromObject(data: {
+            type_ref?: ReturnType<typeof TypeRef.prototype.toObject>;
+            single_type?: ReturnType<typeof SingleType.prototype.toObject>;
+            this_type?: ReturnType<typeof ThisType.prototype.toObject>;
+            super_type?: ReturnType<typeof SuperType.prototype.toObject>;
+            constant_type?: ReturnType<typeof ConstantType.prototype.toObject>;
+            intersection_type?: ReturnType<typeof IntersectionType.prototype.toObject>;
+            union_type?: ReturnType<typeof UnionType.prototype.toObject>;
+            with_type?: ReturnType<typeof WithType.prototype.toObject>;
+            structural_type?: ReturnType<typeof StructuralType.prototype.toObject>;
+            annotated_type?: ReturnType<typeof AnnotatedType.prototype.toObject>;
+            existential_type?: ReturnType<typeof ExistentialType.prototype.toObject>;
+            universal_type?: ReturnType<typeof UniversalType.prototype.toObject>;
+            by_name_type?: ReturnType<typeof ByNameType.prototype.toObject>;
+            repeated_type?: ReturnType<typeof RepeatedType.prototype.toObject>;
+            match_type?: ReturnType<typeof MatchType.prototype.toObject>;
+            lambda_type?: ReturnType<typeof LambdaType.prototype.toObject>;
+        }): Type {
+            const message = new Type({});
+            if (data.type_ref != null) {
+                message.type_ref = TypeRef.fromObject(data.type_ref);
+            }
+            if (data.single_type != null) {
+                message.single_type = SingleType.fromObject(data.single_type);
+            }
+            if (data.this_type != null) {
+                message.this_type = ThisType.fromObject(data.this_type);
+            }
+            if (data.super_type != null) {
+                message.super_type = SuperType.fromObject(data.super_type);
+            }
+            if (data.constant_type != null) {
+                message.constant_type = ConstantType.fromObject(data.constant_type);
+            }
+            if (data.intersection_type != null) {
+                message.intersection_type = IntersectionType.fromObject(data.intersection_type);
+            }
+            if (data.union_type != null) {
+                message.union_type = UnionType.fromObject(data.union_type);
+            }
+            if (data.with_type != null) {
+                message.with_type = WithType.fromObject(data.with_type);
+            }
+            if (data.structural_type != null) {
+                message.structural_type = StructuralType.fromObject(data.structural_type);
+            }
+            if (data.annotated_type != null) {
+                message.annotated_type = AnnotatedType.fromObject(data.annotated_type);
+            }
+            if (data.existential_type != null) {
+                message.existential_type = ExistentialType.fromObject(data.existential_type);
+            }
+            if (data.universal_type != null) {
+                message.universal_type = UniversalType.fromObject(data.universal_type);
+            }
+            if (data.by_name_type != null) {
+                message.by_name_type = ByNameType.fromObject(data.by_name_type);
+            }
+            if (data.repeated_type != null) {
+                message.repeated_type = RepeatedType.fromObject(data.repeated_type);
+            }
+            if (data.match_type != null) {
+                message.match_type = MatchType.fromObject(data.match_type);
+            }
+            if (data.lambda_type != null) {
+                message.lambda_type = LambdaType.fromObject(data.lambda_type);
+            }
+            return message;
+        }
+        toObject() {
+            const data: {
+                type_ref?: ReturnType<typeof TypeRef.prototype.toObject>;
+                single_type?: ReturnType<typeof SingleType.prototype.toObject>;
+                this_type?: ReturnType<typeof ThisType.prototype.toObject>;
+                super_type?: ReturnType<typeof SuperType.prototype.toObject>;
+                constant_type?: ReturnType<typeof ConstantType.prototype.toObject>;
+                intersection_type?: ReturnType<typeof IntersectionType.prototype.toObject>;
+                union_type?: ReturnType<typeof UnionType.prototype.toObject>;
+                with_type?: ReturnType<typeof WithType.prototype.toObject>;
+                structural_type?: ReturnType<typeof StructuralType.prototype.toObject>;
+                annotated_type?: ReturnType<typeof AnnotatedType.prototype.toObject>;
+                existential_type?: ReturnType<typeof ExistentialType.prototype.toObject>;
+                universal_type?: ReturnType<typeof UniversalType.prototype.toObject>;
+                by_name_type?: ReturnType<typeof ByNameType.prototype.toObject>;
+                repeated_type?: ReturnType<typeof RepeatedType.prototype.toObject>;
+                match_type?: ReturnType<typeof MatchType.prototype.toObject>;
+                lambda_type?: ReturnType<typeof LambdaType.prototype.toObject>;
+            } = {};
+            if (this.type_ref != null) {
+                data.type_ref = this.type_ref.toObject();
+            }
+            if (this.single_type != null) {
+                data.single_type = this.single_type.toObject();
+            }
+            if (this.this_type != null) {
+                data.this_type = this.this_type.toObject();
+            }
+            if (this.super_type != null) {
+                data.super_type = this.super_type.toObject();
+            }
+            if (this.constant_type != null) {
+                data.constant_type = this.constant_type.toObject();
+            }
+            if (this.intersection_type != null) {
+                data.intersection_type = this.intersection_type.toObject();
+            }
+            if (this.union_type != null) {
+                data.union_type = this.union_type.toObject();
+            }
+            if (this.with_type != null) {
+                data.with_type = this.with_type.toObject();
+            }
+            if (this.structural_type != null) {
+                data.structural_type = this.structural_type.toObject();
+            }
+            if (this.annotated_type != null) {
+                data.annotated_type = this.annotated_type.toObject();
+            }
+            if (this.existential_type != null) {
+                data.existential_type = this.existential_type.toObject();
+            }
+            if (this.universal_type != null) {
+                data.universal_type = this.universal_type.toObject();
+            }
+            if (this.by_name_type != null) {
+                data.by_name_type = this.by_name_type.toObject();
+            }
+            if (this.repeated_type != null) {
+                data.repeated_type = this.repeated_type.toObject();
+            }
+            if (this.match_type != null) {
+                data.match_type = this.match_type.toObject();
+            }
+            if (this.lambda_type != null) {
+                data.lambda_type = this.lambda_type.toObject();
+            }
+            return data;
+        }
+        serialize(): Uint8Array;
+        serialize(w: pb_1.BinaryWriter): void;
+        serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
+            const writer = w || new pb_1.BinaryWriter();
+            if (this.has_type_ref)
+                writer.writeMessage(2, this.type_ref, () => this.type_ref.serialize(writer));
+            if (this.has_single_type)
+                writer.writeMessage(20, this.single_type, () => this.single_type.serialize(writer));
+            if (this.has_this_type)
+                writer.writeMessage(21, this.this_type, () => this.this_type.serialize(writer));
+            if (this.has_super_type)
+                writer.writeMessage(22, this.super_type, () => this.super_type.serialize(writer));
+            if (this.has_constant_type)
+                writer.writeMessage(23, this.constant_type, () => this.constant_type.serialize(writer));
+            if (this.has_intersection_type)
+                writer.writeMessage(17, this.intersection_type, () => this.intersection_type.serialize(writer));
+            if (this.has_union_type)
+                writer.writeMessage(18, this.union_type, () => this.union_type.serialize(writer));
+            if (this.has_with_type)
+                writer.writeMessage(19, this.with_type, () => this.with_type.serialize(writer));
+            if (this.has_structural_type)
+                writer.writeMessage(7, this.structural_type, () => this.structural_type.serialize(writer));
+            if (this.has_annotated_type)
+                writer.writeMessage(8, this.annotated_type, () => this.annotated_type.serialize(writer));
+            if (this.has_existential_type)
+                writer.writeMessage(9, this.existential_type, () => this.existential_type.serialize(writer));
+            if (this.has_universal_type)
+                writer.writeMessage(10, this.universal_type, () => this.universal_type.serialize(writer));
+            if (this.has_by_name_type)
+                writer.writeMessage(13, this.by_name_type, () => this.by_name_type.serialize(writer));
+            if (this.has_repeated_type)
+                writer.writeMessage(14, this.repeated_type, () => this.repeated_type.serialize(writer));
+            if (this.has_match_type)
+                writer.writeMessage(25, this.match_type, () => this.match_type.serialize(writer));
+            if (this.has_lambda_type)
+                writer.writeMessage(26, this.lambda_type, () => this.lambda_type.serialize(writer));
+            if (!w)
+                return writer.getResultBuffer();
+        }
+        static deserialize(bytes: Uint8Array | pb_1.BinaryReader): Type {
+            const reader = bytes instanceof pb_1.BinaryReader ? bytes : new pb_1.BinaryReader(bytes), message = new Type();
+            while (reader.nextField()) {
+                if (reader.isEndGroup())
+                    break;
+                switch (reader.getFieldNumber()) {
+                    case 2:
+                        reader.readMessage(message.type_ref, () => message.type_ref = TypeRef.deserialize(reader));
+                        break;
+                    case 20:
+                        reader.readMessage(message.single_type, () => message.single_type = SingleType.deserialize(reader));
+                        break;
+                    case 21:
+                        reader.readMessage(message.this_type, () => message.this_type = ThisType.deserialize(reader));
+                        break;
+                    case 22:
+                        reader.readMessage(message.super_type, () => message.super_type = SuperType.deserialize(reader));
+                        break;
+                    case 23:
+                        reader.readMessage(message.constant_type, () => message.constant_type = ConstantType.deserialize(reader));
+                        break;
+                    case 17:
+                        reader.readMessage(message.intersection_type, () => message.intersection_type = IntersectionType.deserialize(reader));
+                        break;
+                    case 18:
+                        reader.readMessage(message.union_type, () => message.union_type = UnionType.deserialize(reader));
+                        break;
+                    case 19:
+                        reader.readMessage(message.with_type, () => message.with_type = WithType.deserialize(reader));
+                        break;
+                    case 7:
+                        reader.readMessage(message.structural_type, () => message.structural_type = StructuralType.deserialize(reader));
+                        break;
+                    case 8:
+                        reader.readMessage(message.annotated_type, () => message.annotated_type = AnnotatedType.deserialize(reader));
+                        break;
+                    case 9:
+                        reader.readMessage(message.existential_type, () => message.existential_type = ExistentialType.deserialize(reader));
+                        break;
+                    case 10:
+                        reader.readMessage(message.universal_type, () => message.universal_type = UniversalType.deserialize(reader));
+                        break;
+                    case 13:
+                        reader.readMessage(message.by_name_type, () => message.by_name_type = ByNameType.deserialize(reader));
+                        break;
+                    case 14:
+                        reader.readMessage(message.repeated_type, () => message.repeated_type = RepeatedType.deserialize(reader));
+                        break;
+                    case 25:
+                        reader.readMessage(message.match_type, () => message.match_type = MatchType.deserialize(reader));
+                        break;
+                    case 26:
+                        reader.readMessage(message.lambda_type, () => message.lambda_type = LambdaType.deserialize(reader));
+                        break;
+                    default: reader.skipField();
+                }
+            }
+            return message;
+        }
+        serializeBinary(): Uint8Array {
+            return this.serialize();
+        }
+        static deserializeBinary(bytes: Uint8Array): Type {
+            return Type.deserialize(bytes);
+        }
+    }
+    export class TypeRef extends pb_1.Message {
+        #one_of_decls: number[][] = [];
+        constructor(data?: any[] | {
+            prefix?: Type;
+            symbol?: string;
+            type_arguments?: Type[];
+        }) {
+            super();
+            pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [3], this.#one_of_decls);
+            if (!Array.isArray(data) && typeof data == "object") {
+                if ("prefix" in data && data.prefix != undefined) {
+                    this.prefix = data.prefix;
+                }
+                if ("symbol" in data && data.symbol != undefined) {
+                    this.symbol = data.symbol;
+                }
+                if ("type_arguments" in data && data.type_arguments != undefined) {
+                    this.type_arguments = data.type_arguments;
+                }
+            }
+        }
+        get prefix() {
+            return pb_1.Message.getWrapperField(this, Type, 1) as Type;
+        }
+        set prefix(value: Type) {
+            pb_1.Message.setWrapperField(this, 1, value);
+        }
+        get has_prefix() {
+            return pb_1.Message.getField(this, 1) != null;
+        }
+        get symbol() {
+            return pb_1.Message.getFieldWithDefault(this, 2, "") as string;
+        }
+        set symbol(value: string) {
+            pb_1.Message.setField(this, 2, value);
+        }
+        get type_arguments() {
+            return pb_1.Message.getRepeatedWrapperField(this, Type, 3) as Type[];
+        }
+        set type_arguments(value: Type[]) {
+            pb_1.Message.setRepeatedWrapperField(this, 3, value);
+        }
+        static fromObject(data: {
+            prefix?: ReturnType<typeof Type.prototype.toObject>;
+            symbol?: string;
+            type_arguments?: ReturnType<typeof Type.prototype.toObject>[];
+        }): TypeRef {
+            const message = new TypeRef({});
+            if (data.prefix != null) {
+                message.prefix = Type.fromObject(data.prefix);
+            }
+            if (data.symbol != null) {
+                message.symbol = data.symbol;
+            }
+            if (data.type_arguments != null) {
+                message.type_arguments = data.type_arguments.map(item => Type.fromObject(item));
+            }
+            return message;
+        }
+        toObject() {
+            const data: {
+                prefix?: ReturnType<typeof Type.prototype.toObject>;
+                symbol?: string;
+                type_arguments?: ReturnType<typeof Type.prototype.toObject>[];
+            } = {};
+            if (this.prefix != null) {
+                data.prefix = this.prefix.toObject();
+            }
+            if (this.symbol != null) {
+                data.symbol = this.symbol;
+            }
+            if (this.type_arguments != null) {
+                data.type_arguments = this.type_arguments.map((item: Type) => item.toObject());
+            }
+            return data;
+        }
+        serialize(): Uint8Array;
+        serialize(w: pb_1.BinaryWriter): void;
+        serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
+            const writer = w || new pb_1.BinaryWriter();
+            if (this.has_prefix)
+                writer.writeMessage(1, this.prefix, () => this.prefix.serialize(writer));
+            if (this.symbol.length)
+                writer.writeString(2, this.symbol);
+            if (this.type_arguments.length)
+                writer.writeRepeatedMessage(3, this.type_arguments, (item: Type) => item.serialize(writer));
+            if (!w)
+                return writer.getResultBuffer();
+        }
+        static deserialize(bytes: Uint8Array | pb_1.BinaryReader): TypeRef {
+            const reader = bytes instanceof pb_1.BinaryReader ? bytes : new pb_1.BinaryReader(bytes), message = new TypeRef();
+            while (reader.nextField()) {
+                if (reader.isEndGroup())
+                    break;
+                switch (reader.getFieldNumber()) {
+                    case 1:
+                        reader.readMessage(message.prefix, () => message.prefix = Type.deserialize(reader));
+                        break;
+                    case 2:
+                        message.symbol = reader.readString();
+                        break;
+                    case 3:
+                        reader.readMessage(message.type_arguments, () => pb_1.Message.addToRepeatedWrapperField(message, 3, Type.deserialize(reader), Type));
+                        break;
+                    default: reader.skipField();
+                }
+            }
+            return message;
+        }
+        serializeBinary(): Uint8Array {
+            return this.serialize();
+        }
+        static deserializeBinary(bytes: Uint8Array): TypeRef {
+            return TypeRef.deserialize(bytes);
+        }
+    }
+    export class SingleType extends pb_1.Message {
+        #one_of_decls: number[][] = [];
+        constructor(data?: any[] | {
+            prefix?: Type;
+            symbol?: string;
+        }) {
+            super();
+            pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
+            if (!Array.isArray(data) && typeof data == "object") {
+                if ("prefix" in data && data.prefix != undefined) {
+                    this.prefix = data.prefix;
+                }
+                if ("symbol" in data && data.symbol != undefined) {
+                    this.symbol = data.symbol;
+                }
+            }
+        }
+        get prefix() {
+            return pb_1.Message.getWrapperField(this, Type, 1) as Type;
+        }
+        set prefix(value: Type) {
+            pb_1.Message.setWrapperField(this, 1, value);
+        }
+        get has_prefix() {
+            return pb_1.Message.getField(this, 1) != null;
+        }
+        get symbol() {
+            return pb_1.Message.getFieldWithDefault(this, 2, "") as string;
+        }
+        set symbol(value: string) {
+            pb_1.Message.setField(this, 2, value);
+        }
+        static fromObject(data: {
+            prefix?: ReturnType<typeof Type.prototype.toObject>;
+            symbol?: string;
+        }): SingleType {
+            const message = new SingleType({});
+            if (data.prefix != null) {
+                message.prefix = Type.fromObject(data.prefix);
+            }
+            if (data.symbol != null) {
+                message.symbol = data.symbol;
+            }
+            return message;
+        }
+        toObject() {
+            const data: {
+                prefix?: ReturnType<typeof Type.prototype.toObject>;
+                symbol?: string;
+            } = {};
+            if (this.prefix != null) {
+                data.prefix = this.prefix.toObject();
+            }
+            if (this.symbol != null) {
+                data.symbol = this.symbol;
+            }
+            return data;
+        }
+        serialize(): Uint8Array;
+        serialize(w: pb_1.BinaryWriter): void;
+        serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
+            const writer = w || new pb_1.BinaryWriter();
+            if (this.has_prefix)
+                writer.writeMessage(1, this.prefix, () => this.prefix.serialize(writer));
+            if (this.symbol.length)
+                writer.writeString(2, this.symbol);
+            if (!w)
+                return writer.getResultBuffer();
+        }
+        static deserialize(bytes: Uint8Array | pb_1.BinaryReader): SingleType {
+            const reader = bytes instanceof pb_1.BinaryReader ? bytes : new pb_1.BinaryReader(bytes), message = new SingleType();
+            while (reader.nextField()) {
+                if (reader.isEndGroup())
+                    break;
+                switch (reader.getFieldNumber()) {
+                    case 1:
+                        reader.readMessage(message.prefix, () => message.prefix = Type.deserialize(reader));
+                        break;
+                    case 2:
+                        message.symbol = reader.readString();
+                        break;
+                    default: reader.skipField();
+                }
+            }
+            return message;
+        }
+        serializeBinary(): Uint8Array {
+            return this.serialize();
+        }
+        static deserializeBinary(bytes: Uint8Array): SingleType {
+            return SingleType.deserialize(bytes);
+        }
+    }
+    export class ThisType extends pb_1.Message {
+        #one_of_decls: number[][] = [];
+        constructor(data?: any[] | {
+            symbol?: string;
+        }) {
+            super();
+            pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
+            if (!Array.isArray(data) && typeof data == "object") {
+                if ("symbol" in data && data.symbol != undefined) {
+                    this.symbol = data.symbol;
+                }
+            }
+        }
+        get symbol() {
+            return pb_1.Message.getFieldWithDefault(this, 1, "") as string;
+        }
+        set symbol(value: string) {
+            pb_1.Message.setField(this, 1, value);
+        }
+        static fromObject(data: {
+            symbol?: string;
+        }): ThisType {
+            const message = new ThisType({});
+            if (data.symbol != null) {
+                message.symbol = data.symbol;
+            }
+            return message;
+        }
+        toObject() {
+            const data: {
+                symbol?: string;
+            } = {};
+            if (this.symbol != null) {
+                data.symbol = this.symbol;
+            }
+            return data;
+        }
+        serialize(): Uint8Array;
+        serialize(w: pb_1.BinaryWriter): void;
+        serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
+            const writer = w || new pb_1.BinaryWriter();
+            if (this.symbol.length)
+                writer.writeString(1, this.symbol);
+            if (!w)
+                return writer.getResultBuffer();
+        }
+        static deserialize(bytes: Uint8Array | pb_1.BinaryReader): ThisType {
+            const reader = bytes instanceof pb_1.BinaryReader ? bytes : new pb_1.BinaryReader(bytes), message = new ThisType();
+            while (reader.nextField()) {
+                if (reader.isEndGroup())
+                    break;
+                switch (reader.getFieldNumber()) {
+                    case 1:
+                        message.symbol = reader.readString();
+                        break;
+                    default: reader.skipField();
+                }
+            }
+            return message;
+        }
+        serializeBinary(): Uint8Array {
+            return this.serialize();
+        }
+        static deserializeBinary(bytes: Uint8Array): ThisType {
+            return ThisType.deserialize(bytes);
+        }
+    }
+    export class SuperType extends pb_1.Message {
+        #one_of_decls: number[][] = [];
+        constructor(data?: any[] | {
+            prefix?: Type;
+            symbol?: string;
+        }) {
+            super();
+            pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
+            if (!Array.isArray(data) && typeof data == "object") {
+                if ("prefix" in data && data.prefix != undefined) {
+                    this.prefix = data.prefix;
+                }
+                if ("symbol" in data && data.symbol != undefined) {
+                    this.symbol = data.symbol;
+                }
+            }
+        }
+        get prefix() {
+            return pb_1.Message.getWrapperField(this, Type, 1) as Type;
+        }
+        set prefix(value: Type) {
+            pb_1.Message.setWrapperField(this, 1, value);
+        }
+        get has_prefix() {
+            return pb_1.Message.getField(this, 1) != null;
+        }
+        get symbol() {
+            return pb_1.Message.getFieldWithDefault(this, 2, "") as string;
+        }
+        set symbol(value: string) {
+            pb_1.Message.setField(this, 2, value);
+        }
+        static fromObject(data: {
+            prefix?: ReturnType<typeof Type.prototype.toObject>;
+            symbol?: string;
+        }): SuperType {
+            const message = new SuperType({});
+            if (data.prefix != null) {
+                message.prefix = Type.fromObject(data.prefix);
+            }
+            if (data.symbol != null) {
+                message.symbol = data.symbol;
+            }
+            return message;
+        }
+        toObject() {
+            const data: {
+                prefix?: ReturnType<typeof Type.prototype.toObject>;
+                symbol?: string;
+            } = {};
+            if (this.prefix != null) {
+                data.prefix = this.prefix.toObject();
+            }
+            if (this.symbol != null) {
+                data.symbol = this.symbol;
+            }
+            return data;
+        }
+        serialize(): Uint8Array;
+        serialize(w: pb_1.BinaryWriter): void;
+        serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
+            const writer = w || new pb_1.BinaryWriter();
+            if (this.has_prefix)
+                writer.writeMessage(1, this.prefix, () => this.prefix.serialize(writer));
+            if (this.symbol.length)
+                writer.writeString(2, this.symbol);
+            if (!w)
+                return writer.getResultBuffer();
+        }
+        static deserialize(bytes: Uint8Array | pb_1.BinaryReader): SuperType {
+            const reader = bytes instanceof pb_1.BinaryReader ? bytes : new pb_1.BinaryReader(bytes), message = new SuperType();
+            while (reader.nextField()) {
+                if (reader.isEndGroup())
+                    break;
+                switch (reader.getFieldNumber()) {
+                    case 1:
+                        reader.readMessage(message.prefix, () => message.prefix = Type.deserialize(reader));
+                        break;
+                    case 2:
+                        message.symbol = reader.readString();
+                        break;
+                    default: reader.skipField();
+                }
+            }
+            return message;
+        }
+        serializeBinary(): Uint8Array {
+            return this.serialize();
+        }
+        static deserializeBinary(bytes: Uint8Array): SuperType {
+            return SuperType.deserialize(bytes);
+        }
+    }
+    export class ConstantType extends pb_1.Message {
+        #one_of_decls: number[][] = [];
+        constructor(data?: any[] | {
+            constant?: Constant;
+        }) {
+            super();
+            pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
+            if (!Array.isArray(data) && typeof data == "object") {
+                if ("constant" in data && data.constant != undefined) {
+                    this.constant = data.constant;
+                }
+            }
+        }
+        get constant() {
+            return pb_1.Message.getWrapperField(this, Constant, 1) as Constant;
+        }
+        set constant(value: Constant) {
+            pb_1.Message.setWrapperField(this, 1, value);
+        }
+        get has_constant() {
+            return pb_1.Message.getField(this, 1) != null;
+        }
+        static fromObject(data: {
+            constant?: ReturnType<typeof Constant.prototype.toObject>;
+        }): ConstantType {
+            const message = new ConstantType({});
+            if (data.constant != null) {
+                message.constant = Constant.fromObject(data.constant);
+            }
+            return message;
+        }
+        toObject() {
+            const data: {
+                constant?: ReturnType<typeof Constant.prototype.toObject>;
+            } = {};
+            if (this.constant != null) {
+                data.constant = this.constant.toObject();
+            }
+            return data;
+        }
+        serialize(): Uint8Array;
+        serialize(w: pb_1.BinaryWriter): void;
+        serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
+            const writer = w || new pb_1.BinaryWriter();
+            if (this.has_constant)
+                writer.writeMessage(1, this.constant, () => this.constant.serialize(writer));
+            if (!w)
+                return writer.getResultBuffer();
+        }
+        static deserialize(bytes: Uint8Array | pb_1.BinaryReader): ConstantType {
+            const reader = bytes instanceof pb_1.BinaryReader ? bytes : new pb_1.BinaryReader(bytes), message = new ConstantType();
+            while (reader.nextField()) {
+                if (reader.isEndGroup())
+                    break;
+                switch (reader.getFieldNumber()) {
+                    case 1:
+                        reader.readMessage(message.constant, () => message.constant = Constant.deserialize(reader));
+                        break;
+                    default: reader.skipField();
+                }
+            }
+            return message;
+        }
+        serializeBinary(): Uint8Array {
+            return this.serialize();
+        }
+        static deserializeBinary(bytes: Uint8Array): ConstantType {
+            return ConstantType.deserialize(bytes);
+        }
+    }
+    export class IntersectionType extends pb_1.Message {
+        #one_of_decls: number[][] = [];
+        constructor(data?: any[] | {
+            types?: Type[];
+        }) {
+            super();
+            pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [1], this.#one_of_decls);
+            if (!Array.isArray(data) && typeof data == "object") {
+                if ("types" in data && data.types != undefined) {
+                    this.types = data.types;
+                }
+            }
+        }
+        get types() {
+            return pb_1.Message.getRepeatedWrapperField(this, Type, 1) as Type[];
+        }
+        set types(value: Type[]) {
+            pb_1.Message.setRepeatedWrapperField(this, 1, value);
+        }
+        static fromObject(data: {
+            types?: ReturnType<typeof Type.prototype.toObject>[];
+        }): IntersectionType {
+            const message = new IntersectionType({});
+            if (data.types != null) {
+                message.types = data.types.map(item => Type.fromObject(item));
+            }
+            return message;
+        }
+        toObject() {
+            const data: {
+                types?: ReturnType<typeof Type.prototype.toObject>[];
+            } = {};
+            if (this.types != null) {
+                data.types = this.types.map((item: Type) => item.toObject());
+            }
+            return data;
+        }
+        serialize(): Uint8Array;
+        serialize(w: pb_1.BinaryWriter): void;
+        serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
+            const writer = w || new pb_1.BinaryWriter();
+            if (this.types.length)
+                writer.writeRepeatedMessage(1, this.types, (item: Type) => item.serialize(writer));
+            if (!w)
+                return writer.getResultBuffer();
+        }
+        static deserialize(bytes: Uint8Array | pb_1.BinaryReader): IntersectionType {
+            const reader = bytes instanceof pb_1.BinaryReader ? bytes : new pb_1.BinaryReader(bytes), message = new IntersectionType();
+            while (reader.nextField()) {
+                if (reader.isEndGroup())
+                    break;
+                switch (reader.getFieldNumber()) {
+                    case 1:
+                        reader.readMessage(message.types, () => pb_1.Message.addToRepeatedWrapperField(message, 1, Type.deserialize(reader), Type));
+                        break;
+                    default: reader.skipField();
+                }
+            }
+            return message;
+        }
+        serializeBinary(): Uint8Array {
+            return this.serialize();
+        }
+        static deserializeBinary(bytes: Uint8Array): IntersectionType {
+            return IntersectionType.deserialize(bytes);
+        }
+    }
+    export class UnionType extends pb_1.Message {
+        #one_of_decls: number[][] = [];
+        constructor(data?: any[] | {
+            types?: Type[];
+        }) {
+            super();
+            pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [1], this.#one_of_decls);
+            if (!Array.isArray(data) && typeof data == "object") {
+                if ("types" in data && data.types != undefined) {
+                    this.types = data.types;
+                }
+            }
+        }
+        get types() {
+            return pb_1.Message.getRepeatedWrapperField(this, Type, 1) as Type[];
+        }
+        set types(value: Type[]) {
+            pb_1.Message.setRepeatedWrapperField(this, 1, value);
+        }
+        static fromObject(data: {
+            types?: ReturnType<typeof Type.prototype.toObject>[];
+        }): UnionType {
+            const message = new UnionType({});
+            if (data.types != null) {
+                message.types = data.types.map(item => Type.fromObject(item));
+            }
+            return message;
+        }
+        toObject() {
+            const data: {
+                types?: ReturnType<typeof Type.prototype.toObject>[];
+            } = {};
+            if (this.types != null) {
+                data.types = this.types.map((item: Type) => item.toObject());
+            }
+            return data;
+        }
+        serialize(): Uint8Array;
+        serialize(w: pb_1.BinaryWriter): void;
+        serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
+            const writer = w || new pb_1.BinaryWriter();
+            if (this.types.length)
+                writer.writeRepeatedMessage(1, this.types, (item: Type) => item.serialize(writer));
+            if (!w)
+                return writer.getResultBuffer();
+        }
+        static deserialize(bytes: Uint8Array | pb_1.BinaryReader): UnionType {
+            const reader = bytes instanceof pb_1.BinaryReader ? bytes : new pb_1.BinaryReader(bytes), message = new UnionType();
+            while (reader.nextField()) {
+                if (reader.isEndGroup())
+                    break;
+                switch (reader.getFieldNumber()) {
+                    case 1:
+                        reader.readMessage(message.types, () => pb_1.Message.addToRepeatedWrapperField(message, 1, Type.deserialize(reader), Type));
+                        break;
+                    default: reader.skipField();
+                }
+            }
+            return message;
+        }
+        serializeBinary(): Uint8Array {
+            return this.serialize();
+        }
+        static deserializeBinary(bytes: Uint8Array): UnionType {
+            return UnionType.deserialize(bytes);
+        }
+    }
+    export class WithType extends pb_1.Message {
+        #one_of_decls: number[][] = [];
+        constructor(data?: any[] | {
+            types?: Type[];
+        }) {
+            super();
+            pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [1], this.#one_of_decls);
+            if (!Array.isArray(data) && typeof data == "object") {
+                if ("types" in data && data.types != undefined) {
+                    this.types = data.types;
+                }
+            }
+        }
+        get types() {
+            return pb_1.Message.getRepeatedWrapperField(this, Type, 1) as Type[];
+        }
+        set types(value: Type[]) {
+            pb_1.Message.setRepeatedWrapperField(this, 1, value);
+        }
+        static fromObject(data: {
+            types?: ReturnType<typeof Type.prototype.toObject>[];
+        }): WithType {
+            const message = new WithType({});
+            if (data.types != null) {
+                message.types = data.types.map(item => Type.fromObject(item));
+            }
+            return message;
+        }
+        toObject() {
+            const data: {
+                types?: ReturnType<typeof Type.prototype.toObject>[];
+            } = {};
+            if (this.types != null) {
+                data.types = this.types.map((item: Type) => item.toObject());
+            }
+            return data;
+        }
+        serialize(): Uint8Array;
+        serialize(w: pb_1.BinaryWriter): void;
+        serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
+            const writer = w || new pb_1.BinaryWriter();
+            if (this.types.length)
+                writer.writeRepeatedMessage(1, this.types, (item: Type) => item.serialize(writer));
+            if (!w)
+                return writer.getResultBuffer();
+        }
+        static deserialize(bytes: Uint8Array | pb_1.BinaryReader): WithType {
+            const reader = bytes instanceof pb_1.BinaryReader ? bytes : new pb_1.BinaryReader(bytes), message = new WithType();
+            while (reader.nextField()) {
+                if (reader.isEndGroup())
+                    break;
+                switch (reader.getFieldNumber()) {
+                    case 1:
+                        reader.readMessage(message.types, () => pb_1.Message.addToRepeatedWrapperField(message, 1, Type.deserialize(reader), Type));
+                        break;
+                    default: reader.skipField();
+                }
+            }
+            return message;
+        }
+        serializeBinary(): Uint8Array {
+            return this.serialize();
+        }
+        static deserializeBinary(bytes: Uint8Array): WithType {
+            return WithType.deserialize(bytes);
+        }
+    }
+    export class StructuralType extends pb_1.Message {
+        #one_of_decls: number[][] = [];
+        constructor(data?: any[] | {
+            tpe?: Type;
+            declarations?: Scope;
+        }) {
+            super();
+            pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
+            if (!Array.isArray(data) && typeof data == "object") {
+                if ("tpe" in data && data.tpe != undefined) {
+                    this.tpe = data.tpe;
+                }
+                if ("declarations" in data && data.declarations != undefined) {
+                    this.declarations = data.declarations;
+                }
+            }
+        }
+        get tpe() {
+            return pb_1.Message.getWrapperField(this, Type, 4) as Type;
+        }
+        set tpe(value: Type) {
+            pb_1.Message.setWrapperField(this, 4, value);
+        }
+        get has_tpe() {
+            return pb_1.Message.getField(this, 4) != null;
+        }
+        get declarations() {
+            return pb_1.Message.getWrapperField(this, Scope, 5) as Scope;
+        }
+        set declarations(value: Scope) {
+            pb_1.Message.setWrapperField(this, 5, value);
+        }
+        get has_declarations() {
+            return pb_1.Message.getField(this, 5) != null;
+        }
+        static fromObject(data: {
+            tpe?: ReturnType<typeof Type.prototype.toObject>;
+            declarations?: ReturnType<typeof Scope.prototype.toObject>;
+        }): StructuralType {
+            const message = new StructuralType({});
+            if (data.tpe != null) {
+                message.tpe = Type.fromObject(data.tpe);
+            }
+            if (data.declarations != null) {
+                message.declarations = Scope.fromObject(data.declarations);
+            }
+            return message;
+        }
+        toObject() {
+            const data: {
+                tpe?: ReturnType<typeof Type.prototype.toObject>;
+                declarations?: ReturnType<typeof Scope.prototype.toObject>;
+            } = {};
+            if (this.tpe != null) {
+                data.tpe = this.tpe.toObject();
+            }
+            if (this.declarations != null) {
+                data.declarations = this.declarations.toObject();
+            }
+            return data;
+        }
+        serialize(): Uint8Array;
+        serialize(w: pb_1.BinaryWriter): void;
+        serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
+            const writer = w || new pb_1.BinaryWriter();
+            if (this.has_tpe)
+                writer.writeMessage(4, this.tpe, () => this.tpe.serialize(writer));
+            if (this.has_declarations)
+                writer.writeMessage(5, this.declarations, () => this.declarations.serialize(writer));
+            if (!w)
+                return writer.getResultBuffer();
+        }
+        static deserialize(bytes: Uint8Array | pb_1.BinaryReader): StructuralType {
+            const reader = bytes instanceof pb_1.BinaryReader ? bytes : new pb_1.BinaryReader(bytes), message = new StructuralType();
+            while (reader.nextField()) {
+                if (reader.isEndGroup())
+                    break;
+                switch (reader.getFieldNumber()) {
+                    case 4:
+                        reader.readMessage(message.tpe, () => message.tpe = Type.deserialize(reader));
+                        break;
+                    case 5:
+                        reader.readMessage(message.declarations, () => message.declarations = Scope.deserialize(reader));
+                        break;
+                    default: reader.skipField();
+                }
+            }
+            return message;
+        }
+        serializeBinary(): Uint8Array {
+            return this.serialize();
+        }
+        static deserializeBinary(bytes: Uint8Array): StructuralType {
+            return StructuralType.deserialize(bytes);
+        }
+    }
+    export class AnnotatedType extends pb_1.Message {
+        #one_of_decls: number[][] = [];
+        constructor(data?: any[] | {
+            annotations?: Annotation[];
+            tpe?: Type;
+        }) {
+            super();
+            pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [3], this.#one_of_decls);
+            if (!Array.isArray(data) && typeof data == "object") {
+                if ("annotations" in data && data.annotations != undefined) {
+                    this.annotations = data.annotations;
+                }
+                if ("tpe" in data && data.tpe != undefined) {
+                    this.tpe = data.tpe;
+                }
+            }
+        }
+        get annotations() {
+            return pb_1.Message.getRepeatedWrapperField(this, Annotation, 3) as Annotation[];
+        }
+        set annotations(value: Annotation[]) {
+            pb_1.Message.setRepeatedWrapperField(this, 3, value);
+        }
+        get tpe() {
+            return pb_1.Message.getWrapperField(this, Type, 1) as Type;
+        }
+        set tpe(value: Type) {
+            pb_1.Message.setWrapperField(this, 1, value);
+        }
+        get has_tpe() {
+            return pb_1.Message.getField(this, 1) != null;
+        }
+        static fromObject(data: {
+            annotations?: ReturnType<typeof Annotation.prototype.toObject>[];
+            tpe?: ReturnType<typeof Type.prototype.toObject>;
+        }): AnnotatedType {
+            const message = new AnnotatedType({});
+            if (data.annotations != null) {
+                message.annotations = data.annotations.map(item => Annotation.fromObject(item));
+            }
+            if (data.tpe != null) {
+                message.tpe = Type.fromObject(data.tpe);
+            }
+            return message;
+        }
+        toObject() {
+            const data: {
+                annotations?: ReturnType<typeof Annotation.prototype.toObject>[];
+                tpe?: ReturnType<typeof Type.prototype.toObject>;
+            } = {};
+            if (this.annotations != null) {
+                data.annotations = this.annotations.map((item: Annotation) => item.toObject());
+            }
+            if (this.tpe != null) {
+                data.tpe = this.tpe.toObject();
+            }
+            return data;
+        }
+        serialize(): Uint8Array;
+        serialize(w: pb_1.BinaryWriter): void;
+        serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
+            const writer = w || new pb_1.BinaryWriter();
+            if (this.annotations.length)
+                writer.writeRepeatedMessage(3, this.annotations, (item: Annotation) => item.serialize(writer));
+            if (this.has_tpe)
+                writer.writeMessage(1, this.tpe, () => this.tpe.serialize(writer));
+            if (!w)
+                return writer.getResultBuffer();
+        }
+        static deserialize(bytes: Uint8Array | pb_1.BinaryReader): AnnotatedType {
+            const reader = bytes instanceof pb_1.BinaryReader ? bytes : new pb_1.BinaryReader(bytes), message = new AnnotatedType();
+            while (reader.nextField()) {
+                if (reader.isEndGroup())
+                    break;
+                switch (reader.getFieldNumber()) {
+                    case 3:
+                        reader.readMessage(message.annotations, () => pb_1.Message.addToRepeatedWrapperField(message, 3, Annotation.deserialize(reader), Annotation));
+                        break;
+                    case 1:
+                        reader.readMessage(message.tpe, () => message.tpe = Type.deserialize(reader));
+                        break;
+                    default: reader.skipField();
+                }
+            }
+            return message;
+        }
+        serializeBinary(): Uint8Array {
+            return this.serialize();
+        }
+        static deserializeBinary(bytes: Uint8Array): AnnotatedType {
+            return AnnotatedType.deserialize(bytes);
+        }
+    }
+    export class ExistentialType extends pb_1.Message {
+        #one_of_decls: number[][] = [];
+        constructor(data?: any[] | {
+            tpe?: Type;
+            declarations?: Scope;
+        }) {
+            super();
+            pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
+            if (!Array.isArray(data) && typeof data == "object") {
+                if ("tpe" in data && data.tpe != undefined) {
+                    this.tpe = data.tpe;
+                }
+                if ("declarations" in data && data.declarations != undefined) {
+                    this.declarations = data.declarations;
+                }
+            }
+        }
+        get tpe() {
+            return pb_1.Message.getWrapperField(this, Type, 1) as Type;
+        }
+        set tpe(value: Type) {
+            pb_1.Message.setWrapperField(this, 1, value);
+        }
+        get has_tpe() {
+            return pb_1.Message.getField(this, 1) != null;
+        }
+        get declarations() {
+            return pb_1.Message.getWrapperField(this, Scope, 3) as Scope;
+        }
+        set declarations(value: Scope) {
+            pb_1.Message.setWrapperField(this, 3, value);
+        }
+        get has_declarations() {
+            return pb_1.Message.getField(this, 3) != null;
+        }
+        static fromObject(data: {
+            tpe?: ReturnType<typeof Type.prototype.toObject>;
+            declarations?: ReturnType<typeof Scope.prototype.toObject>;
+        }): ExistentialType {
+            const message = new ExistentialType({});
+            if (data.tpe != null) {
+                message.tpe = Type.fromObject(data.tpe);
+            }
+            if (data.declarations != null) {
+                message.declarations = Scope.fromObject(data.declarations);
+            }
+            return message;
+        }
+        toObject() {
+            const data: {
+                tpe?: ReturnType<typeof Type.prototype.toObject>;
+                declarations?: ReturnType<typeof Scope.prototype.toObject>;
+            } = {};
+            if (this.tpe != null) {
+                data.tpe = this.tpe.toObject();
+            }
+            if (this.declarations != null) {
+                data.declarations = this.declarations.toObject();
+            }
+            return data;
+        }
+        serialize(): Uint8Array;
+        serialize(w: pb_1.BinaryWriter): void;
+        serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
+            const writer = w || new pb_1.BinaryWriter();
+            if (this.has_tpe)
+                writer.writeMessage(1, this.tpe, () => this.tpe.serialize(writer));
+            if (this.has_declarations)
+                writer.writeMessage(3, this.declarations, () => this.declarations.serialize(writer));
+            if (!w)
+                return writer.getResultBuffer();
+        }
+        static deserialize(bytes: Uint8Array | pb_1.BinaryReader): ExistentialType {
+            const reader = bytes instanceof pb_1.BinaryReader ? bytes : new pb_1.BinaryReader(bytes), message = new ExistentialType();
+            while (reader.nextField()) {
+                if (reader.isEndGroup())
+                    break;
+                switch (reader.getFieldNumber()) {
+                    case 1:
+                        reader.readMessage(message.tpe, () => message.tpe = Type.deserialize(reader));
+                        break;
+                    case 3:
+                        reader.readMessage(message.declarations, () => message.declarations = Scope.deserialize(reader));
+                        break;
+                    default: reader.skipField();
+                }
+            }
+            return message;
+        }
+        serializeBinary(): Uint8Array {
+            return this.serialize();
+        }
+        static deserializeBinary(bytes: Uint8Array): ExistentialType {
+            return ExistentialType.deserialize(bytes);
+        }
+    }
+    export class UniversalType extends pb_1.Message {
+        #one_of_decls: number[][] = [];
+        constructor(data?: any[] | {
+            type_parameters?: Scope;
+            tpe?: Type;
+        }) {
+            super();
+            pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
+            if (!Array.isArray(data) && typeof data == "object") {
+                if ("type_parameters" in data && data.type_parameters != undefined) {
+                    this.type_parameters = data.type_parameters;
+                }
+                if ("tpe" in data && data.tpe != undefined) {
+                    this.tpe = data.tpe;
+                }
+            }
+        }
+        get type_parameters() {
+            return pb_1.Message.getWrapperField(this, Scope, 3) as Scope;
+        }
+        set type_parameters(value: Scope) {
+            pb_1.Message.setWrapperField(this, 3, value);
+        }
+        get has_type_parameters() {
+            return pb_1.Message.getField(this, 3) != null;
+        }
+        get tpe() {
+            return pb_1.Message.getWrapperField(this, Type, 2) as Type;
+        }
+        set tpe(value: Type) {
+            pb_1.Message.setWrapperField(this, 2, value);
+        }
+        get has_tpe() {
+            return pb_1.Message.getField(this, 2) != null;
+        }
+        static fromObject(data: {
+            type_parameters?: ReturnType<typeof Scope.prototype.toObject>;
+            tpe?: ReturnType<typeof Type.prototype.toObject>;
+        }): UniversalType {
+            const message = new UniversalType({});
+            if (data.type_parameters != null) {
+                message.type_parameters = Scope.fromObject(data.type_parameters);
+            }
+            if (data.tpe != null) {
+                message.tpe = Type.fromObject(data.tpe);
+            }
+            return message;
+        }
+        toObject() {
+            const data: {
+                type_parameters?: ReturnType<typeof Scope.prototype.toObject>;
+                tpe?: ReturnType<typeof Type.prototype.toObject>;
+            } = {};
+            if (this.type_parameters != null) {
+                data.type_parameters = this.type_parameters.toObject();
+            }
+            if (this.tpe != null) {
+                data.tpe = this.tpe.toObject();
+            }
+            return data;
+        }
+        serialize(): Uint8Array;
+        serialize(w: pb_1.BinaryWriter): void;
+        serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
+            const writer = w || new pb_1.BinaryWriter();
+            if (this.has_type_parameters)
+                writer.writeMessage(3, this.type_parameters, () => this.type_parameters.serialize(writer));
+            if (this.has_tpe)
+                writer.writeMessage(2, this.tpe, () => this.tpe.serialize(writer));
+            if (!w)
+                return writer.getResultBuffer();
+        }
+        static deserialize(bytes: Uint8Array | pb_1.BinaryReader): UniversalType {
+            const reader = bytes instanceof pb_1.BinaryReader ? bytes : new pb_1.BinaryReader(bytes), message = new UniversalType();
+            while (reader.nextField()) {
+                if (reader.isEndGroup())
+                    break;
+                switch (reader.getFieldNumber()) {
+                    case 3:
+                        reader.readMessage(message.type_parameters, () => message.type_parameters = Scope.deserialize(reader));
+                        break;
+                    case 2:
+                        reader.readMessage(message.tpe, () => message.tpe = Type.deserialize(reader));
+                        break;
+                    default: reader.skipField();
+                }
+            }
+            return message;
+        }
+        serializeBinary(): Uint8Array {
+            return this.serialize();
+        }
+        static deserializeBinary(bytes: Uint8Array): UniversalType {
+            return UniversalType.deserialize(bytes);
+        }
+    }
+    export class ByNameType extends pb_1.Message {
+        #one_of_decls: number[][] = [];
+        constructor(data?: any[] | {
+            tpe?: Type;
+        }) {
+            super();
+            pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
+            if (!Array.isArray(data) && typeof data == "object") {
+                if ("tpe" in data && data.tpe != undefined) {
+                    this.tpe = data.tpe;
+                }
+            }
+        }
+        get tpe() {
+            return pb_1.Message.getWrapperField(this, Type, 1) as Type;
+        }
+        set tpe(value: Type) {
+            pb_1.Message.setWrapperField(this, 1, value);
+        }
+        get has_tpe() {
+            return pb_1.Message.getField(this, 1) != null;
+        }
+        static fromObject(data: {
+            tpe?: ReturnType<typeof Type.prototype.toObject>;
+        }): ByNameType {
+            const message = new ByNameType({});
+            if (data.tpe != null) {
+                message.tpe = Type.fromObject(data.tpe);
+            }
+            return message;
+        }
+        toObject() {
+            const data: {
+                tpe?: ReturnType<typeof Type.prototype.toObject>;
+            } = {};
+            if (this.tpe != null) {
+                data.tpe = this.tpe.toObject();
+            }
+            return data;
+        }
+        serialize(): Uint8Array;
+        serialize(w: pb_1.BinaryWriter): void;
+        serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
+            const writer = w || new pb_1.BinaryWriter();
+            if (this.has_tpe)
+                writer.writeMessage(1, this.tpe, () => this.tpe.serialize(writer));
+            if (!w)
+                return writer.getResultBuffer();
+        }
+        static deserialize(bytes: Uint8Array | pb_1.BinaryReader): ByNameType {
+            const reader = bytes instanceof pb_1.BinaryReader ? bytes : new pb_1.BinaryReader(bytes), message = new ByNameType();
+            while (reader.nextField()) {
+                if (reader.isEndGroup())
+                    break;
+                switch (reader.getFieldNumber()) {
+                    case 1:
+                        reader.readMessage(message.tpe, () => message.tpe = Type.deserialize(reader));
+                        break;
+                    default: reader.skipField();
+                }
+            }
+            return message;
+        }
+        serializeBinary(): Uint8Array {
+            return this.serialize();
+        }
+        static deserializeBinary(bytes: Uint8Array): ByNameType {
+            return ByNameType.deserialize(bytes);
+        }
+    }
+    export class RepeatedType extends pb_1.Message {
+        #one_of_decls: number[][] = [];
+        constructor(data?: any[] | {
+            tpe?: Type;
+        }) {
+            super();
+            pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
+            if (!Array.isArray(data) && typeof data == "object") {
+                if ("tpe" in data && data.tpe != undefined) {
+                    this.tpe = data.tpe;
+                }
+            }
+        }
+        get tpe() {
+            return pb_1.Message.getWrapperField(this, Type, 1) as Type;
+        }
+        set tpe(value: Type) {
+            pb_1.Message.setWrapperField(this, 1, value);
+        }
+        get has_tpe() {
+            return pb_1.Message.getField(this, 1) != null;
+        }
+        static fromObject(data: {
+            tpe?: ReturnType<typeof Type.prototype.toObject>;
+        }): RepeatedType {
+            const message = new RepeatedType({});
+            if (data.tpe != null) {
+                message.tpe = Type.fromObject(data.tpe);
+            }
+            return message;
+        }
+        toObject() {
+            const data: {
+                tpe?: ReturnType<typeof Type.prototype.toObject>;
+            } = {};
+            if (this.tpe != null) {
+                data.tpe = this.tpe.toObject();
+            }
+            return data;
+        }
+        serialize(): Uint8Array;
+        serialize(w: pb_1.BinaryWriter): void;
+        serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
+            const writer = w || new pb_1.BinaryWriter();
+            if (this.has_tpe)
+                writer.writeMessage(1, this.tpe, () => this.tpe.serialize(writer));
+            if (!w)
+                return writer.getResultBuffer();
+        }
+        static deserialize(bytes: Uint8Array | pb_1.BinaryReader): RepeatedType {
+            const reader = bytes instanceof pb_1.BinaryReader ? bytes : new pb_1.BinaryReader(bytes), message = new RepeatedType();
+            while (reader.nextField()) {
+                if (reader.isEndGroup())
+                    break;
+                switch (reader.getFieldNumber()) {
+                    case 1:
+                        reader.readMessage(message.tpe, () => message.tpe = Type.deserialize(reader));
+                        break;
+                    default: reader.skipField();
+                }
+            }
+            return message;
+        }
+        serializeBinary(): Uint8Array {
+            return this.serialize();
+        }
+        static deserializeBinary(bytes: Uint8Array): RepeatedType {
+            return RepeatedType.deserialize(bytes);
+        }
+    }
+    export class MatchType extends pb_1.Message {
+        #one_of_decls: number[][] = [];
+        constructor(data?: any[] | {
+            scrutinee?: Type;
+            cases?: MatchType.CaseType[];
+        }) {
+            super();
+            pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [2], this.#one_of_decls);
+            if (!Array.isArray(data) && typeof data == "object") {
+                if ("scrutinee" in data && data.scrutinee != undefined) {
+                    this.scrutinee = data.scrutinee;
+                }
+                if ("cases" in data && data.cases != undefined) {
+                    this.cases = data.cases;
+                }
+            }
+        }
+        get scrutinee() {
+            return pb_1.Message.getWrapperField(this, Type, 1) as Type;
+        }
+        set scrutinee(value: Type) {
+            pb_1.Message.setWrapperField(this, 1, value);
+        }
+        get has_scrutinee() {
+            return pb_1.Message.getField(this, 1) != null;
+        }
+        get cases() {
+            return pb_1.Message.getRepeatedWrapperField(this, MatchType.CaseType, 2) as MatchType.CaseType[];
+        }
+        set cases(value: MatchType.CaseType[]) {
+            pb_1.Message.setRepeatedWrapperField(this, 2, value);
+        }
+        static fromObject(data: {
+            scrutinee?: ReturnType<typeof Type.prototype.toObject>;
+            cases?: ReturnType<typeof MatchType.CaseType.prototype.toObject>[];
+        }): MatchType {
+            const message = new MatchType({});
+            if (data.scrutinee != null) {
+                message.scrutinee = Type.fromObject(data.scrutinee);
+            }
+            if (data.cases != null) {
+                message.cases = data.cases.map(item => MatchType.CaseType.fromObject(item));
+            }
+            return message;
+        }
+        toObject() {
+            const data: {
+                scrutinee?: ReturnType<typeof Type.prototype.toObject>;
+                cases?: ReturnType<typeof MatchType.CaseType.prototype.toObject>[];
+            } = {};
+            if (this.scrutinee != null) {
+                data.scrutinee = this.scrutinee.toObject();
+            }
+            if (this.cases != null) {
+                data.cases = this.cases.map((item: MatchType.CaseType) => item.toObject());
+            }
+            return data;
+        }
+        serialize(): Uint8Array;
+        serialize(w: pb_1.BinaryWriter): void;
+        serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
+            const writer = w || new pb_1.BinaryWriter();
+            if (this.has_scrutinee)
+                writer.writeMessage(1, this.scrutinee, () => this.scrutinee.serialize(writer));
+            if (this.cases.length)
+                writer.writeRepeatedMessage(2, this.cases, (item: MatchType.CaseType) => item.serialize(writer));
+            if (!w)
+                return writer.getResultBuffer();
+        }
+        static deserialize(bytes: Uint8Array | pb_1.BinaryReader): MatchType {
+            const reader = bytes instanceof pb_1.BinaryReader ? bytes : new pb_1.BinaryReader(bytes), message = new MatchType();
+            while (reader.nextField()) {
+                if (reader.isEndGroup())
+                    break;
+                switch (reader.getFieldNumber()) {
+                    case 1:
+                        reader.readMessage(message.scrutinee, () => message.scrutinee = Type.deserialize(reader));
+                        break;
+                    case 2:
+                        reader.readMessage(message.cases, () => pb_1.Message.addToRepeatedWrapperField(message, 2, MatchType.CaseType.deserialize(reader), MatchType.CaseType));
+                        break;
+                    default: reader.skipField();
+                }
+            }
+            return message;
+        }
+        serializeBinary(): Uint8Array {
+            return this.serialize();
+        }
+        static deserializeBinary(bytes: Uint8Array): MatchType {
+            return MatchType.deserialize(bytes);
+        }
+    }
+    export namespace MatchType {
+        export class CaseType extends pb_1.Message {
+            #one_of_decls: number[][] = [];
+            constructor(data?: any[] | {
+                key?: Type;
+                body?: Type;
+            }) {
+                super();
+                pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
+                if (!Array.isArray(data) && typeof data == "object") {
+                    if ("key" in data && data.key != undefined) {
+                        this.key = data.key;
+                    }
+                    if ("body" in data && data.body != undefined) {
+                        this.body = data.body;
+                    }
+                }
+            }
+            get key() {
+                return pb_1.Message.getWrapperField(this, Type, 1) as Type;
+            }
+            set key(value: Type) {
+                pb_1.Message.setWrapperField(this, 1, value);
+            }
+            get has_key() {
+                return pb_1.Message.getField(this, 1) != null;
+            }
+            get body() {
+                return pb_1.Message.getWrapperField(this, Type, 2) as Type;
+            }
+            set body(value: Type) {
+                pb_1.Message.setWrapperField(this, 2, value);
+            }
+            get has_body() {
+                return pb_1.Message.getField(this, 2) != null;
+            }
+            static fromObject(data: {
+                key?: ReturnType<typeof Type.prototype.toObject>;
+                body?: ReturnType<typeof Type.prototype.toObject>;
+            }): CaseType {
+                const message = new CaseType({});
+                if (data.key != null) {
+                    message.key = Type.fromObject(data.key);
+                }
+                if (data.body != null) {
+                    message.body = Type.fromObject(data.body);
+                }
+                return message;
+            }
+            toObject() {
+                const data: {
+                    key?: ReturnType<typeof Type.prototype.toObject>;
+                    body?: ReturnType<typeof Type.prototype.toObject>;
+                } = {};
+                if (this.key != null) {
+                    data.key = this.key.toObject();
+                }
+                if (this.body != null) {
+                    data.body = this.body.toObject();
+                }
+                return data;
+            }
+            serialize(): Uint8Array;
+            serialize(w: pb_1.BinaryWriter): void;
+            serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
+                const writer = w || new pb_1.BinaryWriter();
+                if (this.has_key)
+                    writer.writeMessage(1, this.key, () => this.key.serialize(writer));
+                if (this.has_body)
+                    writer.writeMessage(2, this.body, () => this.body.serialize(writer));
+                if (!w)
+                    return writer.getResultBuffer();
+            }
+            static deserialize(bytes: Uint8Array | pb_1.BinaryReader): CaseType {
+                const reader = bytes instanceof pb_1.BinaryReader ? bytes : new pb_1.BinaryReader(bytes), message = new CaseType();
+                while (reader.nextField()) {
+                    if (reader.isEndGroup())
+                        break;
+                    switch (reader.getFieldNumber()) {
+                        case 1:
+                            reader.readMessage(message.key, () => message.key = Type.deserialize(reader));
+                            break;
+                        case 2:
+                            reader.readMessage(message.body, () => message.body = Type.deserialize(reader));
+                            break;
+                        default: reader.skipField();
+                    }
+                }
+                return message;
+            }
+            serializeBinary(): Uint8Array {
+                return this.serialize();
+            }
+            static deserializeBinary(bytes: Uint8Array): CaseType {
+                return CaseType.deserialize(bytes);
+            }
+        }
+    }
+    export class LambdaType extends pb_1.Message {
+        #one_of_decls: number[][] = [];
+        constructor(data?: any[] | {
+            type_parameters?: Scope;
+            parameters?: Scope;
+            return_type?: Type;
+        }) {
+            super();
+            pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
+            if (!Array.isArray(data) && typeof data == "object") {
+                if ("type_parameters" in data && data.type_parameters != undefined) {
+                    this.type_parameters = data.type_parameters;
+                }
+                if ("parameters" in data && data.parameters != undefined) {
+                    this.parameters = data.parameters;
+                }
+                if ("return_type" in data && data.return_type != undefined) {
+                    this.return_type = data.return_type;
+                }
+            }
+        }
+        get type_parameters() {
+            return pb_1.Message.getWrapperField(this, Scope, 3) as Scope;
+        }
+        set type_parameters(value: Scope) {
+            pb_1.Message.setWrapperField(this, 3, value);
+        }
+        get has_type_parameters() {
+            return pb_1.Message.getField(this, 3) != null;
+        }
+        get parameters() {
+            return pb_1.Message.getWrapperField(this, Scope, 1) as Scope;
+        }
+        set parameters(value: Scope) {
+            pb_1.Message.setWrapperField(this, 1, value);
+        }
+        get has_parameters() {
+            return pb_1.Message.getField(this, 1) != null;
+        }
+        get return_type() {
+            return pb_1.Message.getWrapperField(this, Type, 2) as Type;
+        }
+        set return_type(value: Type) {
+            pb_1.Message.setWrapperField(this, 2, value);
+        }
+        get has_return_type() {
+            return pb_1.Message.getField(this, 2) != null;
+        }
+        static fromObject(data: {
+            type_parameters?: ReturnType<typeof Scope.prototype.toObject>;
+            parameters?: ReturnType<typeof Scope.prototype.toObject>;
+            return_type?: ReturnType<typeof Type.prototype.toObject>;
+        }): LambdaType {
+            const message = new LambdaType({});
+            if (data.type_parameters != null) {
+                message.type_parameters = Scope.fromObject(data.type_parameters);
+            }
+            if (data.parameters != null) {
+                message.parameters = Scope.fromObject(data.parameters);
+            }
+            if (data.return_type != null) {
+                message.return_type = Type.fromObject(data.return_type);
+            }
+            return message;
+        }
+        toObject() {
+            const data: {
+                type_parameters?: ReturnType<typeof Scope.prototype.toObject>;
+                parameters?: ReturnType<typeof Scope.prototype.toObject>;
+                return_type?: ReturnType<typeof Type.prototype.toObject>;
+            } = {};
+            if (this.type_parameters != null) {
+                data.type_parameters = this.type_parameters.toObject();
+            }
+            if (this.parameters != null) {
+                data.parameters = this.parameters.toObject();
+            }
+            if (this.return_type != null) {
+                data.return_type = this.return_type.toObject();
+            }
+            return data;
+        }
+        serialize(): Uint8Array;
+        serialize(w: pb_1.BinaryWriter): void;
+        serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
+            const writer = w || new pb_1.BinaryWriter();
+            if (this.has_type_parameters)
+                writer.writeMessage(3, this.type_parameters, () => this.type_parameters.serialize(writer));
+            if (this.has_parameters)
+                writer.writeMessage(1, this.parameters, () => this.parameters.serialize(writer));
+            if (this.has_return_type)
+                writer.writeMessage(2, this.return_type, () => this.return_type.serialize(writer));
+            if (!w)
+                return writer.getResultBuffer();
+        }
+        static deserialize(bytes: Uint8Array | pb_1.BinaryReader): LambdaType {
+            const reader = bytes instanceof pb_1.BinaryReader ? bytes : new pb_1.BinaryReader(bytes), message = new LambdaType();
+            while (reader.nextField()) {
+                if (reader.isEndGroup())
+                    break;
+                switch (reader.getFieldNumber()) {
+                    case 3:
+                        reader.readMessage(message.type_parameters, () => message.type_parameters = Scope.deserialize(reader));
+                        break;
+                    case 1:
+                        reader.readMessage(message.parameters, () => message.parameters = Scope.deserialize(reader));
+                        break;
+                    case 2:
+                        reader.readMessage(message.return_type, () => message.return_type = Type.deserialize(reader));
+                        break;
+                    default: reader.skipField();
+                }
+            }
+            return message;
+        }
+        serializeBinary(): Uint8Array {
+            return this.serialize();
+        }
+        static deserializeBinary(bytes: Uint8Array): LambdaType {
+            return LambdaType.deserialize(bytes);
+        }
+    }
+    export class Constant extends pb_1.Message {
+        #one_of_decls: number[][] = [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]];
+        constructor(data?: any[] | ({} & (({
+            unit_constant?: UnitConstant;
+            boolean_constant?: never;
+            byte_constant?: never;
+            short_constant?: never;
+            char_constant?: never;
+            int_constant?: never;
+            long_constant?: never;
+            float_constant?: never;
+            double_constant?: never;
+            string_constant?: never;
+            null_constant?: never;
+        } | {
+            unit_constant?: never;
+            boolean_constant?: BooleanConstant;
+            byte_constant?: never;
+            short_constant?: never;
+            char_constant?: never;
+            int_constant?: never;
+            long_constant?: never;
+            float_constant?: never;
+            double_constant?: never;
+            string_constant?: never;
+            null_constant?: never;
+        } | {
+            unit_constant?: never;
+            boolean_constant?: never;
+            byte_constant?: ByteConstant;
+            short_constant?: never;
+            char_constant?: never;
+            int_constant?: never;
+            long_constant?: never;
+            float_constant?: never;
+            double_constant?: never;
+            string_constant?: never;
+            null_constant?: never;
+        } | {
+            unit_constant?: never;
+            boolean_constant?: never;
+            byte_constant?: never;
+            short_constant?: ShortConstant;
+            char_constant?: never;
+            int_constant?: never;
+            long_constant?: never;
+            float_constant?: never;
+            double_constant?: never;
+            string_constant?: never;
+            null_constant?: never;
+        } | {
+            unit_constant?: never;
+            boolean_constant?: never;
+            byte_constant?: never;
+            short_constant?: never;
+            char_constant?: CharConstant;
+            int_constant?: never;
+            long_constant?: never;
+            float_constant?: never;
+            double_constant?: never;
+            string_constant?: never;
+            null_constant?: never;
+        } | {
+            unit_constant?: never;
+            boolean_constant?: never;
+            byte_constant?: never;
+            short_constant?: never;
+            char_constant?: never;
+            int_constant?: IntConstant;
+            long_constant?: never;
+            float_constant?: never;
+            double_constant?: never;
+            string_constant?: never;
+            null_constant?: never;
+        } | {
+            unit_constant?: never;
+            boolean_constant?: never;
+            byte_constant?: never;
+            short_constant?: never;
+            char_constant?: never;
+            int_constant?: never;
+            long_constant?: LongConstant;
+            float_constant?: never;
+            double_constant?: never;
+            string_constant?: never;
+            null_constant?: never;
+        } | {
+            unit_constant?: never;
+            boolean_constant?: never;
+            byte_constant?: never;
+            short_constant?: never;
+            char_constant?: never;
+            int_constant?: never;
+            long_constant?: never;
+            float_constant?: FloatConstant;
+            double_constant?: never;
+            string_constant?: never;
+            null_constant?: never;
+        } | {
+            unit_constant?: never;
+            boolean_constant?: never;
+            byte_constant?: never;
+            short_constant?: never;
+            char_constant?: never;
+            int_constant?: never;
+            long_constant?: never;
+            float_constant?: never;
+            double_constant?: DoubleConstant;
+            string_constant?: never;
+            null_constant?: never;
+        } | {
+            unit_constant?: never;
+            boolean_constant?: never;
+            byte_constant?: never;
+            short_constant?: never;
+            char_constant?: never;
+            int_constant?: never;
+            long_constant?: never;
+            float_constant?: never;
+            double_constant?: never;
+            string_constant?: StringConstant;
+            null_constant?: never;
+        } | {
+            unit_constant?: never;
+            boolean_constant?: never;
+            byte_constant?: never;
+            short_constant?: never;
+            char_constant?: never;
+            int_constant?: never;
+            long_constant?: never;
+            float_constant?: never;
+            double_constant?: never;
+            string_constant?: never;
+            null_constant?: NullConstant;
+        })))) {
+            super();
+            pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
+            if (!Array.isArray(data) && typeof data == "object") {
+                if ("unit_constant" in data && data.unit_constant != undefined) {
+                    this.unit_constant = data.unit_constant;
+                }
+                if ("boolean_constant" in data && data.boolean_constant != undefined) {
+                    this.boolean_constant = data.boolean_constant;
+                }
+                if ("byte_constant" in data && data.byte_constant != undefined) {
+                    this.byte_constant = data.byte_constant;
+                }
+                if ("short_constant" in data && data.short_constant != undefined) {
+                    this.short_constant = data.short_constant;
+                }
+                if ("char_constant" in data && data.char_constant != undefined) {
+                    this.char_constant = data.char_constant;
+                }
+                if ("int_constant" in data && data.int_constant != undefined) {
+                    this.int_constant = data.int_constant;
+                }
+                if ("long_constant" in data && data.long_constant != undefined) {
+                    this.long_constant = data.long_constant;
+                }
+                if ("float_constant" in data && data.float_constant != undefined) {
+                    this.float_constant = data.float_constant;
+                }
+                if ("double_constant" in data && data.double_constant != undefined) {
+                    this.double_constant = data.double_constant;
+                }
+                if ("string_constant" in data && data.string_constant != undefined) {
+                    this.string_constant = data.string_constant;
+                }
+                if ("null_constant" in data && data.null_constant != undefined) {
+                    this.null_constant = data.null_constant;
+                }
+            }
+        }
+        get unit_constant() {
+            return pb_1.Message.getWrapperField(this, UnitConstant, 1) as UnitConstant;
+        }
+        set unit_constant(value: UnitConstant) {
+            pb_1.Message.setOneofWrapperField(this, 1, this.#one_of_decls[0], value);
+        }
+        get has_unit_constant() {
+            return pb_1.Message.getField(this, 1) != null;
+        }
+        get boolean_constant() {
+            return pb_1.Message.getWrapperField(this, BooleanConstant, 2) as BooleanConstant;
+        }
+        set boolean_constant(value: BooleanConstant) {
+            pb_1.Message.setOneofWrapperField(this, 2, this.#one_of_decls[0], value);
+        }
+        get has_boolean_constant() {
+            return pb_1.Message.getField(this, 2) != null;
+        }
+        get byte_constant() {
+            return pb_1.Message.getWrapperField(this, ByteConstant, 3) as ByteConstant;
+        }
+        set byte_constant(value: ByteConstant) {
+            pb_1.Message.setOneofWrapperField(this, 3, this.#one_of_decls[0], value);
+        }
+        get has_byte_constant() {
+            return pb_1.Message.getField(this, 3) != null;
+        }
+        get short_constant() {
+            return pb_1.Message.getWrapperField(this, ShortConstant, 4) as ShortConstant;
+        }
+        set short_constant(value: ShortConstant) {
+            pb_1.Message.setOneofWrapperField(this, 4, this.#one_of_decls[0], value);
+        }
+        get has_short_constant() {
+            return pb_1.Message.getField(this, 4) != null;
+        }
+        get char_constant() {
+            return pb_1.Message.getWrapperField(this, CharConstant, 5) as CharConstant;
+        }
+        set char_constant(value: CharConstant) {
+            pb_1.Message.setOneofWrapperField(this, 5, this.#one_of_decls[0], value);
+        }
+        get has_char_constant() {
+            return pb_1.Message.getField(this, 5) != null;
+        }
+        get int_constant() {
+            return pb_1.Message.getWrapperField(this, IntConstant, 6) as IntConstant;
+        }
+        set int_constant(value: IntConstant) {
+            pb_1.Message.setOneofWrapperField(this, 6, this.#one_of_decls[0], value);
+        }
+        get has_int_constant() {
+            return pb_1.Message.getField(this, 6) != null;
+        }
+        get long_constant() {
+            return pb_1.Message.getWrapperField(this, LongConstant, 7) as LongConstant;
+        }
+        set long_constant(value: LongConstant) {
+            pb_1.Message.setOneofWrapperField(this, 7, this.#one_of_decls[0], value);
+        }
+        get has_long_constant() {
+            return pb_1.Message.getField(this, 7) != null;
+        }
+        get float_constant() {
+            return pb_1.Message.getWrapperField(this, FloatConstant, 8) as FloatConstant;
+        }
+        set float_constant(value: FloatConstant) {
+            pb_1.Message.setOneofWrapperField(this, 8, this.#one_of_decls[0], value);
+        }
+        get has_float_constant() {
+            return pb_1.Message.getField(this, 8) != null;
+        }
+        get double_constant() {
+            return pb_1.Message.getWrapperField(this, DoubleConstant, 9) as DoubleConstant;
+        }
+        set double_constant(value: DoubleConstant) {
+            pb_1.Message.setOneofWrapperField(this, 9, this.#one_of_decls[0], value);
+        }
+        get has_double_constant() {
+            return pb_1.Message.getField(this, 9) != null;
+        }
+        get string_constant() {
+            return pb_1.Message.getWrapperField(this, StringConstant, 10) as StringConstant;
+        }
+        set string_constant(value: StringConstant) {
+            pb_1.Message.setOneofWrapperField(this, 10, this.#one_of_decls[0], value);
+        }
+        get has_string_constant() {
+            return pb_1.Message.getField(this, 10) != null;
+        }
+        get null_constant() {
+            return pb_1.Message.getWrapperField(this, NullConstant, 11) as NullConstant;
+        }
+        set null_constant(value: NullConstant) {
+            pb_1.Message.setOneofWrapperField(this, 11, this.#one_of_decls[0], value);
+        }
+        get has_null_constant() {
+            return pb_1.Message.getField(this, 11) != null;
+        }
+        get sealed_value() {
+            const cases: {
+                [index: number]: "none" | "unit_constant" | "boolean_constant" | "byte_constant" | "short_constant" | "char_constant" | "int_constant" | "long_constant" | "float_constant" | "double_constant" | "string_constant" | "null_constant";
+            } = {
+                0: "none",
+                1: "unit_constant",
+                2: "boolean_constant",
+                3: "byte_constant",
+                4: "short_constant",
+                5: "char_constant",
+                6: "int_constant",
+                7: "long_constant",
+                8: "float_constant",
+                9: "double_constant",
+                10: "string_constant",
+                11: "null_constant"
+            };
+            return cases[pb_1.Message.computeOneofCase(this, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])];
+        }
+        static fromObject(data: {
+            unit_constant?: ReturnType<typeof UnitConstant.prototype.toObject>;
+            boolean_constant?: ReturnType<typeof BooleanConstant.prototype.toObject>;
+            byte_constant?: ReturnType<typeof ByteConstant.prototype.toObject>;
+            short_constant?: ReturnType<typeof ShortConstant.prototype.toObject>;
+            char_constant?: ReturnType<typeof CharConstant.prototype.toObject>;
+            int_constant?: ReturnType<typeof IntConstant.prototype.toObject>;
+            long_constant?: ReturnType<typeof LongConstant.prototype.toObject>;
+            float_constant?: ReturnType<typeof FloatConstant.prototype.toObject>;
+            double_constant?: ReturnType<typeof DoubleConstant.prototype.toObject>;
+            string_constant?: ReturnType<typeof StringConstant.prototype.toObject>;
+            null_constant?: ReturnType<typeof NullConstant.prototype.toObject>;
+        }): Constant {
+            const message = new Constant({});
+            if (data.unit_constant != null) {
+                message.unit_constant = UnitConstant.fromObject(data.unit_constant);
+            }
+            if (data.boolean_constant != null) {
+                message.boolean_constant = BooleanConstant.fromObject(data.boolean_constant);
+            }
+            if (data.byte_constant != null) {
+                message.byte_constant = ByteConstant.fromObject(data.byte_constant);
+            }
+            if (data.short_constant != null) {
+                message.short_constant = ShortConstant.fromObject(data.short_constant);
+            }
+            if (data.char_constant != null) {
+                message.char_constant = CharConstant.fromObject(data.char_constant);
+            }
+            if (data.int_constant != null) {
+                message.int_constant = IntConstant.fromObject(data.int_constant);
+            }
+            if (data.long_constant != null) {
+                message.long_constant = LongConstant.fromObject(data.long_constant);
+            }
+            if (data.float_constant != null) {
+                message.float_constant = FloatConstant.fromObject(data.float_constant);
+            }
+            if (data.double_constant != null) {
+                message.double_constant = DoubleConstant.fromObject(data.double_constant);
+            }
+            if (data.string_constant != null) {
+                message.string_constant = StringConstant.fromObject(data.string_constant);
+            }
+            if (data.null_constant != null) {
+                message.null_constant = NullConstant.fromObject(data.null_constant);
+            }
+            return message;
+        }
+        toObject() {
+            const data: {
+                unit_constant?: ReturnType<typeof UnitConstant.prototype.toObject>;
+                boolean_constant?: ReturnType<typeof BooleanConstant.prototype.toObject>;
+                byte_constant?: ReturnType<typeof ByteConstant.prototype.toObject>;
+                short_constant?: ReturnType<typeof ShortConstant.prototype.toObject>;
+                char_constant?: ReturnType<typeof CharConstant.prototype.toObject>;
+                int_constant?: ReturnType<typeof IntConstant.prototype.toObject>;
+                long_constant?: ReturnType<typeof LongConstant.prototype.toObject>;
+                float_constant?: ReturnType<typeof FloatConstant.prototype.toObject>;
+                double_constant?: ReturnType<typeof DoubleConstant.prototype.toObject>;
+                string_constant?: ReturnType<typeof StringConstant.prototype.toObject>;
+                null_constant?: ReturnType<typeof NullConstant.prototype.toObject>;
+            } = {};
+            if (this.unit_constant != null) {
+                data.unit_constant = this.unit_constant.toObject();
+            }
+            if (this.boolean_constant != null) {
+                data.boolean_constant = this.boolean_constant.toObject();
+            }
+            if (this.byte_constant != null) {
+                data.byte_constant = this.byte_constant.toObject();
+            }
+            if (this.short_constant != null) {
+                data.short_constant = this.short_constant.toObject();
+            }
+            if (this.char_constant != null) {
+                data.char_constant = this.char_constant.toObject();
+            }
+            if (this.int_constant != null) {
+                data.int_constant = this.int_constant.toObject();
+            }
+            if (this.long_constant != null) {
+                data.long_constant = this.long_constant.toObject();
+            }
+            if (this.float_constant != null) {
+                data.float_constant = this.float_constant.toObject();
+            }
+            if (this.double_constant != null) {
+                data.double_constant = this.double_constant.toObject();
+            }
+            if (this.string_constant != null) {
+                data.string_constant = this.string_constant.toObject();
+            }
+            if (this.null_constant != null) {
+                data.null_constant = this.null_constant.toObject();
+            }
+            return data;
+        }
+        serialize(): Uint8Array;
+        serialize(w: pb_1.BinaryWriter): void;
+        serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
+            const writer = w || new pb_1.BinaryWriter();
+            if (this.has_unit_constant)
+                writer.writeMessage(1, this.unit_constant, () => this.unit_constant.serialize(writer));
+            if (this.has_boolean_constant)
+                writer.writeMessage(2, this.boolean_constant, () => this.boolean_constant.serialize(writer));
+            if (this.has_byte_constant)
+                writer.writeMessage(3, this.byte_constant, () => this.byte_constant.serialize(writer));
+            if (this.has_short_constant)
+                writer.writeMessage(4, this.short_constant, () => this.short_constant.serialize(writer));
+            if (this.has_char_constant)
+                writer.writeMessage(5, this.char_constant, () => this.char_constant.serialize(writer));
+            if (this.has_int_constant)
+                writer.writeMessage(6, this.int_constant, () => this.int_constant.serialize(writer));
+            if (this.has_long_constant)
+                writer.writeMessage(7, this.long_constant, () => this.long_constant.serialize(writer));
+            if (this.has_float_constant)
+                writer.writeMessage(8, this.float_constant, () => this.float_constant.serialize(writer));
+            if (this.has_double_constant)
+                writer.writeMessage(9, this.double_constant, () => this.double_constant.serialize(writer));
+            if (this.has_string_constant)
+                writer.writeMessage(10, this.string_constant, () => this.string_constant.serialize(writer));
+            if (this.has_null_constant)
+                writer.writeMessage(11, this.null_constant, () => this.null_constant.serialize(writer));
+            if (!w)
+                return writer.getResultBuffer();
+        }
+        static deserialize(bytes: Uint8Array | pb_1.BinaryReader): Constant {
+            const reader = bytes instanceof pb_1.BinaryReader ? bytes : new pb_1.BinaryReader(bytes), message = new Constant();
+            while (reader.nextField()) {
+                if (reader.isEndGroup())
+                    break;
+                switch (reader.getFieldNumber()) {
+                    case 1:
+                        reader.readMessage(message.unit_constant, () => message.unit_constant = UnitConstant.deserialize(reader));
+                        break;
+                    case 2:
+                        reader.readMessage(message.boolean_constant, () => message.boolean_constant = BooleanConstant.deserialize(reader));
+                        break;
+                    case 3:
+                        reader.readMessage(message.byte_constant, () => message.byte_constant = ByteConstant.deserialize(reader));
+                        break;
+                    case 4:
+                        reader.readMessage(message.short_constant, () => message.short_constant = ShortConstant.deserialize(reader));
+                        break;
+                    case 5:
+                        reader.readMessage(message.char_constant, () => message.char_constant = CharConstant.deserialize(reader));
+                        break;
+                    case 6:
+                        reader.readMessage(message.int_constant, () => message.int_constant = IntConstant.deserialize(reader));
+                        break;
+                    case 7:
+                        reader.readMessage(message.long_constant, () => message.long_constant = LongConstant.deserialize(reader));
+                        break;
+                    case 8:
+                        reader.readMessage(message.float_constant, () => message.float_constant = FloatConstant.deserialize(reader));
+                        break;
+                    case 9:
+                        reader.readMessage(message.double_constant, () => message.double_constant = DoubleConstant.deserialize(reader));
+                        break;
+                    case 10:
+                        reader.readMessage(message.string_constant, () => message.string_constant = StringConstant.deserialize(reader));
+                        break;
+                    case 11:
+                        reader.readMessage(message.null_constant, () => message.null_constant = NullConstant.deserialize(reader));
+                        break;
+                    default: reader.skipField();
+                }
+            }
+            return message;
+        }
+        serializeBinary(): Uint8Array {
+            return this.serialize();
+        }
+        static deserializeBinary(bytes: Uint8Array): Constant {
+            return Constant.deserialize(bytes);
+        }
+    }
+    export class UnitConstant extends pb_1.Message {
+        #one_of_decls: number[][] = [];
+        constructor(data?: any[] | {}) {
+            super();
+            pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
+            if (!Array.isArray(data) && typeof data == "object") { }
+        }
+        static fromObject(data: {}): UnitConstant {
+            const message = new UnitConstant({});
+            return message;
+        }
+        toObject() {
+            const data: {} = {};
+            return data;
+        }
+        serialize(): Uint8Array;
+        serialize(w: pb_1.BinaryWriter): void;
+        serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
+            const writer = w || new pb_1.BinaryWriter();
+            if (!w)
+                return writer.getResultBuffer();
+        }
+        static deserialize(bytes: Uint8Array | pb_1.BinaryReader): UnitConstant {
+            const reader = bytes instanceof pb_1.BinaryReader ? bytes : new pb_1.BinaryReader(bytes), message = new UnitConstant();
+            while (reader.nextField()) {
+                if (reader.isEndGroup())
+                    break;
+                switch (reader.getFieldNumber()) {
+                    default: reader.skipField();
+                }
+            }
+            return message;
+        }
+        serializeBinary(): Uint8Array {
+            return this.serialize();
+        }
+        static deserializeBinary(bytes: Uint8Array): UnitConstant {
+            return UnitConstant.deserialize(bytes);
+        }
+    }
+    export class BooleanConstant extends pb_1.Message {
+        #one_of_decls: number[][] = [];
+        constructor(data?: any[] | {
+            value?: boolean;
+        }) {
+            super();
+            pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
+            if (!Array.isArray(data) && typeof data == "object") {
+                if ("value" in data && data.value != undefined) {
+                    this.value = data.value;
+                }
+            }
+        }
+        get value() {
+            return pb_1.Message.getFieldWithDefault(this, 1, false) as boolean;
+        }
+        set value(value: boolean) {
+            pb_1.Message.setField(this, 1, value);
+        }
+        static fromObject(data: {
+            value?: boolean;
+        }): BooleanConstant {
+            const message = new BooleanConstant({});
+            if (data.value != null) {
+                message.value = data.value;
+            }
+            return message;
+        }
+        toObject() {
+            const data: {
+                value?: boolean;
+            } = {};
+            if (this.value != null) {
+                data.value = this.value;
+            }
+            return data;
+        }
+        serialize(): Uint8Array;
+        serialize(w: pb_1.BinaryWriter): void;
+        serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
+            const writer = w || new pb_1.BinaryWriter();
+            if (this.value != false)
+                writer.writeBool(1, this.value);
+            if (!w)
+                return writer.getResultBuffer();
+        }
+        static deserialize(bytes: Uint8Array | pb_1.BinaryReader): BooleanConstant {
+            const reader = bytes instanceof pb_1.BinaryReader ? bytes : new pb_1.BinaryReader(bytes), message = new BooleanConstant();
+            while (reader.nextField()) {
+                if (reader.isEndGroup())
+                    break;
+                switch (reader.getFieldNumber()) {
+                    case 1:
+                        message.value = reader.readBool();
+                        break;
+                    default: reader.skipField();
+                }
+            }
+            return message;
+        }
+        serializeBinary(): Uint8Array {
+            return this.serialize();
+        }
+        static deserializeBinary(bytes: Uint8Array): BooleanConstant {
+            return BooleanConstant.deserialize(bytes);
+        }
+    }
+    export class ByteConstant extends pb_1.Message {
+        #one_of_decls: number[][] = [];
+        constructor(data?: any[] | {
+            value?: number;
+        }) {
+            super();
+            pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
+            if (!Array.isArray(data) && typeof data == "object") {
+                if ("value" in data && data.value != undefined) {
+                    this.value = data.value;
+                }
+            }
+        }
+        get value() {
+            return pb_1.Message.getFieldWithDefault(this, 1, 0) as number;
+        }
+        set value(value: number) {
+            pb_1.Message.setField(this, 1, value);
+        }
+        static fromObject(data: {
+            value?: number;
+        }): ByteConstant {
+            const message = new ByteConstant({});
+            if (data.value != null) {
+                message.value = data.value;
+            }
+            return message;
+        }
+        toObject() {
+            const data: {
+                value?: number;
+            } = {};
+            if (this.value != null) {
+                data.value = this.value;
+            }
+            return data;
+        }
+        serialize(): Uint8Array;
+        serialize(w: pb_1.BinaryWriter): void;
+        serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
+            const writer = w || new pb_1.BinaryWriter();
+            if (this.value != 0)
+                writer.writeInt32(1, this.value);
+            if (!w)
+                return writer.getResultBuffer();
+        }
+        static deserialize(bytes: Uint8Array | pb_1.BinaryReader): ByteConstant {
+            const reader = bytes instanceof pb_1.BinaryReader ? bytes : new pb_1.BinaryReader(bytes), message = new ByteConstant();
+            while (reader.nextField()) {
+                if (reader.isEndGroup())
+                    break;
+                switch (reader.getFieldNumber()) {
+                    case 1:
+                        message.value = reader.readInt32();
+                        break;
+                    default: reader.skipField();
+                }
+            }
+            return message;
+        }
+        serializeBinary(): Uint8Array {
+            return this.serialize();
+        }
+        static deserializeBinary(bytes: Uint8Array): ByteConstant {
+            return ByteConstant.deserialize(bytes);
+        }
+    }
+    export class ShortConstant extends pb_1.Message {
+        #one_of_decls: number[][] = [];
+        constructor(data?: any[] | {
+            value?: number;
+        }) {
+            super();
+            pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
+            if (!Array.isArray(data) && typeof data == "object") {
+                if ("value" in data && data.value != undefined) {
+                    this.value = data.value;
+                }
+            }
+        }
+        get value() {
+            return pb_1.Message.getFieldWithDefault(this, 1, 0) as number;
+        }
+        set value(value: number) {
+            pb_1.Message.setField(this, 1, value);
+        }
+        static fromObject(data: {
+            value?: number;
+        }): ShortConstant {
+            const message = new ShortConstant({});
+            if (data.value != null) {
+                message.value = data.value;
+            }
+            return message;
+        }
+        toObject() {
+            const data: {
+                value?: number;
+            } = {};
+            if (this.value != null) {
+                data.value = this.value;
+            }
+            return data;
+        }
+        serialize(): Uint8Array;
+        serialize(w: pb_1.BinaryWriter): void;
+        serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
+            const writer = w || new pb_1.BinaryWriter();
+            if (this.value != 0)
+                writer.writeInt32(1, this.value);
+            if (!w)
+                return writer.getResultBuffer();
+        }
+        static deserialize(bytes: Uint8Array | pb_1.BinaryReader): ShortConstant {
+            const reader = bytes instanceof pb_1.BinaryReader ? bytes : new pb_1.BinaryReader(bytes), message = new ShortConstant();
+            while (reader.nextField()) {
+                if (reader.isEndGroup())
+                    break;
+                switch (reader.getFieldNumber()) {
+                    case 1:
+                        message.value = reader.readInt32();
+                        break;
+                    default: reader.skipField();
+                }
+            }
+            return message;
+        }
+        serializeBinary(): Uint8Array {
+            return this.serialize();
+        }
+        static deserializeBinary(bytes: Uint8Array): ShortConstant {
+            return ShortConstant.deserialize(bytes);
+        }
+    }
+    export class CharConstant extends pb_1.Message {
+        #one_of_decls: number[][] = [];
+        constructor(data?: any[] | {
+            value?: number;
+        }) {
+            super();
+            pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
+            if (!Array.isArray(data) && typeof data == "object") {
+                if ("value" in data && data.value != undefined) {
+                    this.value = data.value;
+                }
+            }
+        }
+        get value() {
+            return pb_1.Message.getFieldWithDefault(this, 1, 0) as number;
+        }
+        set value(value: number) {
+            pb_1.Message.setField(this, 1, value);
+        }
+        static fromObject(data: {
+            value?: number;
+        }): CharConstant {
+            const message = new CharConstant({});
+            if (data.value != null) {
+                message.value = data.value;
+            }
+            return message;
+        }
+        toObject() {
+            const data: {
+                value?: number;
+            } = {};
+            if (this.value != null) {
+                data.value = this.value;
+            }
+            return data;
+        }
+        serialize(): Uint8Array;
+        serialize(w: pb_1.BinaryWriter): void;
+        serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
+            const writer = w || new pb_1.BinaryWriter();
+            if (this.value != 0)
+                writer.writeInt32(1, this.value);
+            if (!w)
+                return writer.getResultBuffer();
+        }
+        static deserialize(bytes: Uint8Array | pb_1.BinaryReader): CharConstant {
+            const reader = bytes instanceof pb_1.BinaryReader ? bytes : new pb_1.BinaryReader(bytes), message = new CharConstant();
+            while (reader.nextField()) {
+                if (reader.isEndGroup())
+                    break;
+                switch (reader.getFieldNumber()) {
+                    case 1:
+                        message.value = reader.readInt32();
+                        break;
+                    default: reader.skipField();
+                }
+            }
+            return message;
+        }
+        serializeBinary(): Uint8Array {
+            return this.serialize();
+        }
+        static deserializeBinary(bytes: Uint8Array): CharConstant {
+            return CharConstant.deserialize(bytes);
+        }
+    }
+    export class IntConstant extends pb_1.Message {
+        #one_of_decls: number[][] = [];
+        constructor(data?: any[] | {
+            value?: number;
+        }) {
+            super();
+            pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
+            if (!Array.isArray(data) && typeof data == "object") {
+                if ("value" in data && data.value != undefined) {
+                    this.value = data.value;
+                }
+            }
+        }
+        get value() {
+            return pb_1.Message.getFieldWithDefault(this, 1, 0) as number;
+        }
+        set value(value: number) {
+            pb_1.Message.setField(this, 1, value);
+        }
+        static fromObject(data: {
+            value?: number;
+        }): IntConstant {
+            const message = new IntConstant({});
+            if (data.value != null) {
+                message.value = data.value;
+            }
+            return message;
+        }
+        toObject() {
+            const data: {
+                value?: number;
+            } = {};
+            if (this.value != null) {
+                data.value = this.value;
+            }
+            return data;
+        }
+        serialize(): Uint8Array;
+        serialize(w: pb_1.BinaryWriter): void;
+        serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
+            const writer = w || new pb_1.BinaryWriter();
+            if (this.value != 0)
+                writer.writeInt32(1, this.value);
+            if (!w)
+                return writer.getResultBuffer();
+        }
+        static deserialize(bytes: Uint8Array | pb_1.BinaryReader): IntConstant {
+            const reader = bytes instanceof pb_1.BinaryReader ? bytes : new pb_1.BinaryReader(bytes), message = new IntConstant();
+            while (reader.nextField()) {
+                if (reader.isEndGroup())
+                    break;
+                switch (reader.getFieldNumber()) {
+                    case 1:
+                        message.value = reader.readInt32();
+                        break;
+                    default: reader.skipField();
+                }
+            }
+            return message;
+        }
+        serializeBinary(): Uint8Array {
+            return this.serialize();
+        }
+        static deserializeBinary(bytes: Uint8Array): IntConstant {
+            return IntConstant.deserialize(bytes);
+        }
+    }
+    export class LongConstant extends pb_1.Message {
+        #one_of_decls: number[][] = [];
+        constructor(data?: any[] | {
+            value?: number;
+        }) {
+            super();
+            pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
+            if (!Array.isArray(data) && typeof data == "object") {
+                if ("value" in data && data.value != undefined) {
+                    this.value = data.value;
+                }
+            }
+        }
+        get value() {
+            return pb_1.Message.getFieldWithDefault(this, 1, 0) as number;
+        }
+        set value(value: number) {
+            pb_1.Message.setField(this, 1, value);
+        }
+        static fromObject(data: {
+            value?: number;
+        }): LongConstant {
+            const message = new LongConstant({});
+            if (data.value != null) {
+                message.value = data.value;
+            }
+            return message;
+        }
+        toObject() {
+            const data: {
+                value?: number;
+            } = {};
+            if (this.value != null) {
+                data.value = this.value;
+            }
+            return data;
+        }
+        serialize(): Uint8Array;
+        serialize(w: pb_1.BinaryWriter): void;
+        serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
+            const writer = w || new pb_1.BinaryWriter();
+            if (this.value != 0)
+                writer.writeInt64(1, this.value);
+            if (!w)
+                return writer.getResultBuffer();
+        }
+        static deserialize(bytes: Uint8Array | pb_1.BinaryReader): LongConstant {
+            const reader = bytes instanceof pb_1.BinaryReader ? bytes : new pb_1.BinaryReader(bytes), message = new LongConstant();
+            while (reader.nextField()) {
+                if (reader.isEndGroup())
+                    break;
+                switch (reader.getFieldNumber()) {
+                    case 1:
+                        message.value = reader.readInt64();
+                        break;
+                    default: reader.skipField();
+                }
+            }
+            return message;
+        }
+        serializeBinary(): Uint8Array {
+            return this.serialize();
+        }
+        static deserializeBinary(bytes: Uint8Array): LongConstant {
+            return LongConstant.deserialize(bytes);
+        }
+    }
+    export class FloatConstant extends pb_1.Message {
+        #one_of_decls: number[][] = [];
+        constructor(data?: any[] | {
+            value?: number;
+        }) {
+            super();
+            pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
+            if (!Array.isArray(data) && typeof data == "object") {
+                if ("value" in data && data.value != undefined) {
+                    this.value = data.value;
+                }
+            }
+        }
+        get value() {
+            return pb_1.Message.getFieldWithDefault(this, 1, 0) as number;
+        }
+        set value(value: number) {
+            pb_1.Message.setField(this, 1, value);
+        }
+        static fromObject(data: {
+            value?: number;
+        }): FloatConstant {
+            const message = new FloatConstant({});
+            if (data.value != null) {
+                message.value = data.value;
+            }
+            return message;
+        }
+        toObject() {
+            const data: {
+                value?: number;
+            } = {};
+            if (this.value != null) {
+                data.value = this.value;
+            }
+            return data;
+        }
+        serialize(): Uint8Array;
+        serialize(w: pb_1.BinaryWriter): void;
+        serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
+            const writer = w || new pb_1.BinaryWriter();
+            if (this.value != 0)
+                writer.writeFloat(1, this.value);
+            if (!w)
+                return writer.getResultBuffer();
+        }
+        static deserialize(bytes: Uint8Array | pb_1.BinaryReader): FloatConstant {
+            const reader = bytes instanceof pb_1.BinaryReader ? bytes : new pb_1.BinaryReader(bytes), message = new FloatConstant();
+            while (reader.nextField()) {
+                if (reader.isEndGroup())
+                    break;
+                switch (reader.getFieldNumber()) {
+                    case 1:
+                        message.value = reader.readFloat();
+                        break;
+                    default: reader.skipField();
+                }
+            }
+            return message;
+        }
+        serializeBinary(): Uint8Array {
+            return this.serialize();
+        }
+        static deserializeBinary(bytes: Uint8Array): FloatConstant {
+            return FloatConstant.deserialize(bytes);
+        }
+    }
+    export class DoubleConstant extends pb_1.Message {
+        #one_of_decls: number[][] = [];
+        constructor(data?: any[] | {
+            value?: number;
+        }) {
+            super();
+            pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
+            if (!Array.isArray(data) && typeof data == "object") {
+                if ("value" in data && data.value != undefined) {
+                    this.value = data.value;
+                }
+            }
+        }
+        get value() {
+            return pb_1.Message.getFieldWithDefault(this, 1, 0) as number;
+        }
+        set value(value: number) {
+            pb_1.Message.setField(this, 1, value);
+        }
+        static fromObject(data: {
+            value?: number;
+        }): DoubleConstant {
+            const message = new DoubleConstant({});
+            if (data.value != null) {
+                message.value = data.value;
+            }
+            return message;
+        }
+        toObject() {
+            const data: {
+                value?: number;
+            } = {};
+            if (this.value != null) {
+                data.value = this.value;
+            }
+            return data;
+        }
+        serialize(): Uint8Array;
+        serialize(w: pb_1.BinaryWriter): void;
+        serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
+            const writer = w || new pb_1.BinaryWriter();
+            if (this.value != 0)
+                writer.writeDouble(1, this.value);
+            if (!w)
+                return writer.getResultBuffer();
+        }
+        static deserialize(bytes: Uint8Array | pb_1.BinaryReader): DoubleConstant {
+            const reader = bytes instanceof pb_1.BinaryReader ? bytes : new pb_1.BinaryReader(bytes), message = new DoubleConstant();
+            while (reader.nextField()) {
+                if (reader.isEndGroup())
+                    break;
+                switch (reader.getFieldNumber()) {
+                    case 1:
+                        message.value = reader.readDouble();
+                        break;
+                    default: reader.skipField();
+                }
+            }
+            return message;
+        }
+        serializeBinary(): Uint8Array {
+            return this.serialize();
+        }
+        static deserializeBinary(bytes: Uint8Array): DoubleConstant {
+            return DoubleConstant.deserialize(bytes);
+        }
+    }
+    export class StringConstant extends pb_1.Message {
+        #one_of_decls: number[][] = [];
+        constructor(data?: any[] | {
+            value?: string;
+        }) {
+            super();
+            pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
+            if (!Array.isArray(data) && typeof data == "object") {
+                if ("value" in data && data.value != undefined) {
+                    this.value = data.value;
+                }
+            }
+        }
+        get value() {
+            return pb_1.Message.getFieldWithDefault(this, 1, "") as string;
+        }
+        set value(value: string) {
+            pb_1.Message.setField(this, 1, value);
+        }
+        static fromObject(data: {
+            value?: string;
+        }): StringConstant {
+            const message = new StringConstant({});
+            if (data.value != null) {
+                message.value = data.value;
+            }
+            return message;
+        }
+        toObject() {
+            const data: {
+                value?: string;
+            } = {};
+            if (this.value != null) {
+                data.value = this.value;
+            }
+            return data;
+        }
+        serialize(): Uint8Array;
+        serialize(w: pb_1.BinaryWriter): void;
+        serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
+            const writer = w || new pb_1.BinaryWriter();
+            if (this.value.length)
+                writer.writeString(1, this.value);
+            if (!w)
+                return writer.getResultBuffer();
+        }
+        static deserialize(bytes: Uint8Array | pb_1.BinaryReader): StringConstant {
+            const reader = bytes instanceof pb_1.BinaryReader ? bytes : new pb_1.BinaryReader(bytes), message = new StringConstant();
+            while (reader.nextField()) {
+                if (reader.isEndGroup())
+                    break;
+                switch (reader.getFieldNumber()) {
+                    case 1:
+                        message.value = reader.readString();
+                        break;
+                    default: reader.skipField();
+                }
+            }
+            return message;
+        }
+        serializeBinary(): Uint8Array {
+            return this.serialize();
+        }
+        static deserializeBinary(bytes: Uint8Array): StringConstant {
+            return StringConstant.deserialize(bytes);
+        }
+    }
+    export class NullConstant extends pb_1.Message {
+        #one_of_decls: number[][] = [];
+        constructor(data?: any[] | {}) {
+            super();
+            pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
+            if (!Array.isArray(data) && typeof data == "object") { }
+        }
+        static fromObject(data: {}): NullConstant {
+            const message = new NullConstant({});
+            return message;
+        }
+        toObject() {
+            const data: {} = {};
+            return data;
+        }
+        serialize(): Uint8Array;
+        serialize(w: pb_1.BinaryWriter): void;
+        serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
+            const writer = w || new pb_1.BinaryWriter();
+            if (!w)
+                return writer.getResultBuffer();
+        }
+        static deserialize(bytes: Uint8Array | pb_1.BinaryReader): NullConstant {
+            const reader = bytes instanceof pb_1.BinaryReader ? bytes : new pb_1.BinaryReader(bytes), message = new NullConstant();
+            while (reader.nextField()) {
+                if (reader.isEndGroup())
+                    break;
+                switch (reader.getFieldNumber()) {
+                    default: reader.skipField();
+                }
+            }
+            return message;
+        }
+        serializeBinary(): Uint8Array {
+            return this.serialize();
+        }
+        static deserializeBinary(bytes: Uint8Array): NullConstant {
+            return NullConstant.deserialize(bytes);
+        }
+    }
+    export class Signature extends pb_1.Message {
+        #one_of_decls: number[][] = [[1, 2, 3, 4]];
+        constructor(data?: any[] | ({} & (({
+            class_signature?: ClassSignature;
+            method_signature?: never;
+            type_signature?: never;
+            value_signature?: never;
+        } | {
+            class_signature?: never;
+            method_signature?: MethodSignature;
+            type_signature?: never;
+            value_signature?: never;
+        } | {
+            class_signature?: never;
+            method_signature?: never;
+            type_signature?: TypeSignature;
+            value_signature?: never;
+        } | {
+            class_signature?: never;
+            method_signature?: never;
+            type_signature?: never;
+            value_signature?: ValueSignature;
+        })))) {
+            super();
+            pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
+            if (!Array.isArray(data) && typeof data == "object") {
+                if ("class_signature" in data && data.class_signature != undefined) {
+                    this.class_signature = data.class_signature;
+                }
+                if ("method_signature" in data && data.method_signature != undefined) {
+                    this.method_signature = data.method_signature;
+                }
+                if ("type_signature" in data && data.type_signature != undefined) {
+                    this.type_signature = data.type_signature;
+                }
+                if ("value_signature" in data && data.value_signature != undefined) {
+                    this.value_signature = data.value_signature;
+                }
+            }
+        }
+        get class_signature() {
+            return pb_1.Message.getWrapperField(this, ClassSignature, 1) as ClassSignature;
+        }
+        set class_signature(value: ClassSignature) {
+            pb_1.Message.setOneofWrapperField(this, 1, this.#one_of_decls[0], value);
+        }
+        get has_class_signature() {
+            return pb_1.Message.getField(this, 1) != null;
+        }
+        get method_signature() {
+            return pb_1.Message.getWrapperField(this, MethodSignature, 2) as MethodSignature;
+        }
+        set method_signature(value: MethodSignature) {
+            pb_1.Message.setOneofWrapperField(this, 2, this.#one_of_decls[0], value);
+        }
+        get has_method_signature() {
+            return pb_1.Message.getField(this, 2) != null;
+        }
+        get type_signature() {
+            return pb_1.Message.getWrapperField(this, TypeSignature, 3) as TypeSignature;
+        }
+        set type_signature(value: TypeSignature) {
+            pb_1.Message.setOneofWrapperField(this, 3, this.#one_of_decls[0], value);
+        }
+        get has_type_signature() {
+            return pb_1.Message.getField(this, 3) != null;
+        }
+        get value_signature() {
+            return pb_1.Message.getWrapperField(this, ValueSignature, 4) as ValueSignature;
+        }
+        set value_signature(value: ValueSignature) {
+            pb_1.Message.setOneofWrapperField(this, 4, this.#one_of_decls[0], value);
+        }
+        get has_value_signature() {
+            return pb_1.Message.getField(this, 4) != null;
+        }
+        get sealed_value() {
+            const cases: {
+                [index: number]: "none" | "class_signature" | "method_signature" | "type_signature" | "value_signature";
+            } = {
+                0: "none",
+                1: "class_signature",
+                2: "method_signature",
+                3: "type_signature",
+                4: "value_signature"
+            };
+            return cases[pb_1.Message.computeOneofCase(this, [1, 2, 3, 4])];
+        }
+        static fromObject(data: {
+            class_signature?: ReturnType<typeof ClassSignature.prototype.toObject>;
+            method_signature?: ReturnType<typeof MethodSignature.prototype.toObject>;
+            type_signature?: ReturnType<typeof TypeSignature.prototype.toObject>;
+            value_signature?: ReturnType<typeof ValueSignature.prototype.toObject>;
+        }): Signature {
+            const message = new Signature({});
+            if (data.class_signature != null) {
+                message.class_signature = ClassSignature.fromObject(data.class_signature);
+            }
+            if (data.method_signature != null) {
+                message.method_signature = MethodSignature.fromObject(data.method_signature);
+            }
+            if (data.type_signature != null) {
+                message.type_signature = TypeSignature.fromObject(data.type_signature);
+            }
+            if (data.value_signature != null) {
+                message.value_signature = ValueSignature.fromObject(data.value_signature);
+            }
+            return message;
+        }
+        toObject() {
+            const data: {
+                class_signature?: ReturnType<typeof ClassSignature.prototype.toObject>;
+                method_signature?: ReturnType<typeof MethodSignature.prototype.toObject>;
+                type_signature?: ReturnType<typeof TypeSignature.prototype.toObject>;
+                value_signature?: ReturnType<typeof ValueSignature.prototype.toObject>;
+            } = {};
+            if (this.class_signature != null) {
+                data.class_signature = this.class_signature.toObject();
+            }
+            if (this.method_signature != null) {
+                data.method_signature = this.method_signature.toObject();
+            }
+            if (this.type_signature != null) {
+                data.type_signature = this.type_signature.toObject();
+            }
+            if (this.value_signature != null) {
+                data.value_signature = this.value_signature.toObject();
+            }
+            return data;
+        }
+        serialize(): Uint8Array;
+        serialize(w: pb_1.BinaryWriter): void;
+        serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
+            const writer = w || new pb_1.BinaryWriter();
+            if (this.has_class_signature)
+                writer.writeMessage(1, this.class_signature, () => this.class_signature.serialize(writer));
+            if (this.has_method_signature)
+                writer.writeMessage(2, this.method_signature, () => this.method_signature.serialize(writer));
+            if (this.has_type_signature)
+                writer.writeMessage(3, this.type_signature, () => this.type_signature.serialize(writer));
+            if (this.has_value_signature)
+                writer.writeMessage(4, this.value_signature, () => this.value_signature.serialize(writer));
+            if (!w)
+                return writer.getResultBuffer();
+        }
+        static deserialize(bytes: Uint8Array | pb_1.BinaryReader): Signature {
+            const reader = bytes instanceof pb_1.BinaryReader ? bytes : new pb_1.BinaryReader(bytes), message = new Signature();
+            while (reader.nextField()) {
+                if (reader.isEndGroup())
+                    break;
+                switch (reader.getFieldNumber()) {
+                    case 1:
+                        reader.readMessage(message.class_signature, () => message.class_signature = ClassSignature.deserialize(reader));
+                        break;
+                    case 2:
+                        reader.readMessage(message.method_signature, () => message.method_signature = MethodSignature.deserialize(reader));
+                        break;
+                    case 3:
+                        reader.readMessage(message.type_signature, () => message.type_signature = TypeSignature.deserialize(reader));
+                        break;
+                    case 4:
+                        reader.readMessage(message.value_signature, () => message.value_signature = ValueSignature.deserialize(reader));
+                        break;
+                    default: reader.skipField();
+                }
+            }
+            return message;
+        }
+        serializeBinary(): Uint8Array {
+            return this.serialize();
+        }
+        static deserializeBinary(bytes: Uint8Array): Signature {
+            return Signature.deserialize(bytes);
+        }
+    }
+    export class ClassSignature extends pb_1.Message {
+        #one_of_decls: number[][] = [];
+        constructor(data?: any[] | {
+            type_parameters?: Scope;
+            parents?: Type[];
+            self?: Type;
+            declarations?: Scope;
+        }) {
+            super();
+            pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [2], this.#one_of_decls);
+            if (!Array.isArray(data) && typeof data == "object") {
+                if ("type_parameters" in data && data.type_parameters != undefined) {
+                    this.type_parameters = data.type_parameters;
+                }
+                if ("parents" in data && data.parents != undefined) {
+                    this.parents = data.parents;
+                }
+                if ("self" in data && data.self != undefined) {
+                    this.self = data.self;
+                }
+                if ("declarations" in data && data.declarations != undefined) {
+                    this.declarations = data.declarations;
+                }
+            }
+        }
+        get type_parameters() {
+            return pb_1.Message.getWrapperField(this, Scope, 1) as Scope;
+        }
+        set type_parameters(value: Scope) {
+            pb_1.Message.setWrapperField(this, 1, value);
+        }
+        get has_type_parameters() {
+            return pb_1.Message.getField(this, 1) != null;
+        }
+        get parents() {
+            return pb_1.Message.getRepeatedWrapperField(this, Type, 2) as Type[];
+        }
+        set parents(value: Type[]) {
+            pb_1.Message.setRepeatedWrapperField(this, 2, value);
+        }
+        get self() {
+            return pb_1.Message.getWrapperField(this, Type, 3) as Type;
+        }
+        set self(value: Type) {
+            pb_1.Message.setWrapperField(this, 3, value);
+        }
+        get has_self() {
+            return pb_1.Message.getField(this, 3) != null;
+        }
+        get declarations() {
+            return pb_1.Message.getWrapperField(this, Scope, 4) as Scope;
+        }
+        set declarations(value: Scope) {
+            pb_1.Message.setWrapperField(this, 4, value);
+        }
+        get has_declarations() {
+            return pb_1.Message.getField(this, 4) != null;
+        }
+        static fromObject(data: {
+            type_parameters?: ReturnType<typeof Scope.prototype.toObject>;
+            parents?: ReturnType<typeof Type.prototype.toObject>[];
+            self?: ReturnType<typeof Type.prototype.toObject>;
+            declarations?: ReturnType<typeof Scope.prototype.toObject>;
+        }): ClassSignature {
+            const message = new ClassSignature({});
+            if (data.type_parameters != null) {
+                message.type_parameters = Scope.fromObject(data.type_parameters);
+            }
+            if (data.parents != null) {
+                message.parents = data.parents.map(item => Type.fromObject(item));
+            }
+            if (data.self != null) {
+                message.self = Type.fromObject(data.self);
+            }
+            if (data.declarations != null) {
+                message.declarations = Scope.fromObject(data.declarations);
+            }
+            return message;
+        }
+        toObject() {
+            const data: {
+                type_parameters?: ReturnType<typeof Scope.prototype.toObject>;
+                parents?: ReturnType<typeof Type.prototype.toObject>[];
+                self?: ReturnType<typeof Type.prototype.toObject>;
+                declarations?: ReturnType<typeof Scope.prototype.toObject>;
+            } = {};
+            if (this.type_parameters != null) {
+                data.type_parameters = this.type_parameters.toObject();
+            }
+            if (this.parents != null) {
+                data.parents = this.parents.map((item: Type) => item.toObject());
+            }
+            if (this.self != null) {
+                data.self = this.self.toObject();
+            }
+            if (this.declarations != null) {
+                data.declarations = this.declarations.toObject();
+            }
+            return data;
+        }
+        serialize(): Uint8Array;
+        serialize(w: pb_1.BinaryWriter): void;
+        serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
+            const writer = w || new pb_1.BinaryWriter();
+            if (this.has_type_parameters)
+                writer.writeMessage(1, this.type_parameters, () => this.type_parameters.serialize(writer));
+            if (this.parents.length)
+                writer.writeRepeatedMessage(2, this.parents, (item: Type) => item.serialize(writer));
+            if (this.has_self)
+                writer.writeMessage(3, this.self, () => this.self.serialize(writer));
+            if (this.has_declarations)
+                writer.writeMessage(4, this.declarations, () => this.declarations.serialize(writer));
+            if (!w)
+                return writer.getResultBuffer();
+        }
+        static deserialize(bytes: Uint8Array | pb_1.BinaryReader): ClassSignature {
+            const reader = bytes instanceof pb_1.BinaryReader ? bytes : new pb_1.BinaryReader(bytes), message = new ClassSignature();
+            while (reader.nextField()) {
+                if (reader.isEndGroup())
+                    break;
+                switch (reader.getFieldNumber()) {
+                    case 1:
+                        reader.readMessage(message.type_parameters, () => message.type_parameters = Scope.deserialize(reader));
+                        break;
+                    case 2:
+                        reader.readMessage(message.parents, () => pb_1.Message.addToRepeatedWrapperField(message, 2, Type.deserialize(reader), Type));
+                        break;
+                    case 3:
+                        reader.readMessage(message.self, () => message.self = Type.deserialize(reader));
+                        break;
+                    case 4:
+                        reader.readMessage(message.declarations, () => message.declarations = Scope.deserialize(reader));
+                        break;
+                    default: reader.skipField();
+                }
+            }
+            return message;
+        }
+        serializeBinary(): Uint8Array {
+            return this.serialize();
+        }
+        static deserializeBinary(bytes: Uint8Array): ClassSignature {
+            return ClassSignature.deserialize(bytes);
+        }
+    }
+    export class MethodSignature extends pb_1.Message {
+        #one_of_decls: number[][] = [];
+        constructor(data?: any[] | {
+            type_parameters?: Scope;
+            parameter_lists?: Scope[];
+            return_type?: Type;
+        }) {
+            super();
+            pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [2], this.#one_of_decls);
+            if (!Array.isArray(data) && typeof data == "object") {
+                if ("type_parameters" in data && data.type_parameters != undefined) {
+                    this.type_parameters = data.type_parameters;
+                }
+                if ("parameter_lists" in data && data.parameter_lists != undefined) {
+                    this.parameter_lists = data.parameter_lists;
+                }
+                if ("return_type" in data && data.return_type != undefined) {
+                    this.return_type = data.return_type;
+                }
+            }
+        }
+        get type_parameters() {
+            return pb_1.Message.getWrapperField(this, Scope, 1) as Scope;
+        }
+        set type_parameters(value: Scope) {
+            pb_1.Message.setWrapperField(this, 1, value);
+        }
+        get has_type_parameters() {
+            return pb_1.Message.getField(this, 1) != null;
+        }
+        get parameter_lists() {
+            return pb_1.Message.getRepeatedWrapperField(this, Scope, 2) as Scope[];
+        }
+        set parameter_lists(value: Scope[]) {
+            pb_1.Message.setRepeatedWrapperField(this, 2, value);
+        }
+        get return_type() {
+            return pb_1.Message.getWrapperField(this, Type, 3) as Type;
+        }
+        set return_type(value: Type) {
+            pb_1.Message.setWrapperField(this, 3, value);
+        }
+        get has_return_type() {
+            return pb_1.Message.getField(this, 3) != null;
+        }
+        static fromObject(data: {
+            type_parameters?: ReturnType<typeof Scope.prototype.toObject>;
+            parameter_lists?: ReturnType<typeof Scope.prototype.toObject>[];
+            return_type?: ReturnType<typeof Type.prototype.toObject>;
+        }): MethodSignature {
+            const message = new MethodSignature({});
+            if (data.type_parameters != null) {
+                message.type_parameters = Scope.fromObject(data.type_parameters);
+            }
+            if (data.parameter_lists != null) {
+                message.parameter_lists = data.parameter_lists.map(item => Scope.fromObject(item));
+            }
+            if (data.return_type != null) {
+                message.return_type = Type.fromObject(data.return_type);
+            }
+            return message;
+        }
+        toObject() {
+            const data: {
+                type_parameters?: ReturnType<typeof Scope.prototype.toObject>;
+                parameter_lists?: ReturnType<typeof Scope.prototype.toObject>[];
+                return_type?: ReturnType<typeof Type.prototype.toObject>;
+            } = {};
+            if (this.type_parameters != null) {
+                data.type_parameters = this.type_parameters.toObject();
+            }
+            if (this.parameter_lists != null) {
+                data.parameter_lists = this.parameter_lists.map((item: Scope) => item.toObject());
+            }
+            if (this.return_type != null) {
+                data.return_type = this.return_type.toObject();
+            }
+            return data;
+        }
+        serialize(): Uint8Array;
+        serialize(w: pb_1.BinaryWriter): void;
+        serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
+            const writer = w || new pb_1.BinaryWriter();
+            if (this.has_type_parameters)
+                writer.writeMessage(1, this.type_parameters, () => this.type_parameters.serialize(writer));
+            if (this.parameter_lists.length)
+                writer.writeRepeatedMessage(2, this.parameter_lists, (item: Scope) => item.serialize(writer));
+            if (this.has_return_type)
+                writer.writeMessage(3, this.return_type, () => this.return_type.serialize(writer));
+            if (!w)
+                return writer.getResultBuffer();
+        }
+        static deserialize(bytes: Uint8Array | pb_1.BinaryReader): MethodSignature {
+            const reader = bytes instanceof pb_1.BinaryReader ? bytes : new pb_1.BinaryReader(bytes), message = new MethodSignature();
+            while (reader.nextField()) {
+                if (reader.isEndGroup())
+                    break;
+                switch (reader.getFieldNumber()) {
+                    case 1:
+                        reader.readMessage(message.type_parameters, () => message.type_parameters = Scope.deserialize(reader));
+                        break;
+                    case 2:
+                        reader.readMessage(message.parameter_lists, () => pb_1.Message.addToRepeatedWrapperField(message, 2, Scope.deserialize(reader), Scope));
+                        break;
+                    case 3:
+                        reader.readMessage(message.return_type, () => message.return_type = Type.deserialize(reader));
+                        break;
+                    default: reader.skipField();
+                }
+            }
+            return message;
+        }
+        serializeBinary(): Uint8Array {
+            return this.serialize();
+        }
+        static deserializeBinary(bytes: Uint8Array): MethodSignature {
+            return MethodSignature.deserialize(bytes);
+        }
+    }
+    export class TypeSignature extends pb_1.Message {
+        #one_of_decls: number[][] = [];
+        constructor(data?: any[] | {
+            type_parameters?: Scope;
+            lower_bound?: Type;
+            upper_bound?: Type;
+        }) {
+            super();
+            pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
+            if (!Array.isArray(data) && typeof data == "object") {
+                if ("type_parameters" in data && data.type_parameters != undefined) {
+                    this.type_parameters = data.type_parameters;
+                }
+                if ("lower_bound" in data && data.lower_bound != undefined) {
+                    this.lower_bound = data.lower_bound;
+                }
+                if ("upper_bound" in data && data.upper_bound != undefined) {
+                    this.upper_bound = data.upper_bound;
+                }
+            }
+        }
+        get type_parameters() {
+            return pb_1.Message.getWrapperField(this, Scope, 1) as Scope;
+        }
+        set type_parameters(value: Scope) {
+            pb_1.Message.setWrapperField(this, 1, value);
+        }
+        get has_type_parameters() {
+            return pb_1.Message.getField(this, 1) != null;
+        }
+        get lower_bound() {
+            return pb_1.Message.getWrapperField(this, Type, 2) as Type;
+        }
+        set lower_bound(value: Type) {
+            pb_1.Message.setWrapperField(this, 2, value);
+        }
+        get has_lower_bound() {
+            return pb_1.Message.getField(this, 2) != null;
+        }
+        get upper_bound() {
+            return pb_1.Message.getWrapperField(this, Type, 3) as Type;
+        }
+        set upper_bound(value: Type) {
+            pb_1.Message.setWrapperField(this, 3, value);
+        }
+        get has_upper_bound() {
+            return pb_1.Message.getField(this, 3) != null;
+        }
+        static fromObject(data: {
+            type_parameters?: ReturnType<typeof Scope.prototype.toObject>;
+            lower_bound?: ReturnType<typeof Type.prototype.toObject>;
+            upper_bound?: ReturnType<typeof Type.prototype.toObject>;
+        }): TypeSignature {
+            const message = new TypeSignature({});
+            if (data.type_parameters != null) {
+                message.type_parameters = Scope.fromObject(data.type_parameters);
+            }
+            if (data.lower_bound != null) {
+                message.lower_bound = Type.fromObject(data.lower_bound);
+            }
+            if (data.upper_bound != null) {
+                message.upper_bound = Type.fromObject(data.upper_bound);
+            }
+            return message;
+        }
+        toObject() {
+            const data: {
+                type_parameters?: ReturnType<typeof Scope.prototype.toObject>;
+                lower_bound?: ReturnType<typeof Type.prototype.toObject>;
+                upper_bound?: ReturnType<typeof Type.prototype.toObject>;
+            } = {};
+            if (this.type_parameters != null) {
+                data.type_parameters = this.type_parameters.toObject();
+            }
+            if (this.lower_bound != null) {
+                data.lower_bound = this.lower_bound.toObject();
+            }
+            if (this.upper_bound != null) {
+                data.upper_bound = this.upper_bound.toObject();
+            }
+            return data;
+        }
+        serialize(): Uint8Array;
+        serialize(w: pb_1.BinaryWriter): void;
+        serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
+            const writer = w || new pb_1.BinaryWriter();
+            if (this.has_type_parameters)
+                writer.writeMessage(1, this.type_parameters, () => this.type_parameters.serialize(writer));
+            if (this.has_lower_bound)
+                writer.writeMessage(2, this.lower_bound, () => this.lower_bound.serialize(writer));
+            if (this.has_upper_bound)
+                writer.writeMessage(3, this.upper_bound, () => this.upper_bound.serialize(writer));
+            if (!w)
+                return writer.getResultBuffer();
+        }
+        static deserialize(bytes: Uint8Array | pb_1.BinaryReader): TypeSignature {
+            const reader = bytes instanceof pb_1.BinaryReader ? bytes : new pb_1.BinaryReader(bytes), message = new TypeSignature();
+            while (reader.nextField()) {
+                if (reader.isEndGroup())
+                    break;
+                switch (reader.getFieldNumber()) {
+                    case 1:
+                        reader.readMessage(message.type_parameters, () => message.type_parameters = Scope.deserialize(reader));
+                        break;
+                    case 2:
+                        reader.readMessage(message.lower_bound, () => message.lower_bound = Type.deserialize(reader));
+                        break;
+                    case 3:
+                        reader.readMessage(message.upper_bound, () => message.upper_bound = Type.deserialize(reader));
+                        break;
+                    default: reader.skipField();
+                }
+            }
+            return message;
+        }
+        serializeBinary(): Uint8Array {
+            return this.serialize();
+        }
+        static deserializeBinary(bytes: Uint8Array): TypeSignature {
+            return TypeSignature.deserialize(bytes);
+        }
+    }
+    export class ValueSignature extends pb_1.Message {
+        #one_of_decls: number[][] = [];
+        constructor(data?: any[] | {
+            tpe?: Type;
+        }) {
+            super();
+            pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
+            if (!Array.isArray(data) && typeof data == "object") {
+                if ("tpe" in data && data.tpe != undefined) {
+                    this.tpe = data.tpe;
+                }
+            }
+        }
+        get tpe() {
+            return pb_1.Message.getWrapperField(this, Type, 1) as Type;
+        }
+        set tpe(value: Type) {
+            pb_1.Message.setWrapperField(this, 1, value);
+        }
+        get has_tpe() {
+            return pb_1.Message.getField(this, 1) != null;
+        }
+        static fromObject(data: {
+            tpe?: ReturnType<typeof Type.prototype.toObject>;
+        }): ValueSignature {
+            const message = new ValueSignature({});
+            if (data.tpe != null) {
+                message.tpe = Type.fromObject(data.tpe);
+            }
+            return message;
+        }
+        toObject() {
+            const data: {
+                tpe?: ReturnType<typeof Type.prototype.toObject>;
+            } = {};
+            if (this.tpe != null) {
+                data.tpe = this.tpe.toObject();
+            }
+            return data;
+        }
+        serialize(): Uint8Array;
+        serialize(w: pb_1.BinaryWriter): void;
+        serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
+            const writer = w || new pb_1.BinaryWriter();
+            if (this.has_tpe)
+                writer.writeMessage(1, this.tpe, () => this.tpe.serialize(writer));
+            if (!w)
+                return writer.getResultBuffer();
+        }
+        static deserialize(bytes: Uint8Array | pb_1.BinaryReader): ValueSignature {
+            const reader = bytes instanceof pb_1.BinaryReader ? bytes : new pb_1.BinaryReader(bytes), message = new ValueSignature();
+            while (reader.nextField()) {
+                if (reader.isEndGroup())
+                    break;
+                switch (reader.getFieldNumber()) {
+                    case 1:
+                        reader.readMessage(message.tpe, () => message.tpe = Type.deserialize(reader));
+                        break;
+                    default: reader.skipField();
+                }
+            }
+            return message;
+        }
+        serializeBinary(): Uint8Array {
+            return this.serialize();
+        }
+        static deserializeBinary(bytes: Uint8Array): ValueSignature {
+            return ValueSignature.deserialize(bytes);
         }
     }
 }


### PR DESCRIPTION
Companion PRs:

* https://github.com/sourcegraph/scip/pull/231
* https://github.com/sourcegraph/cody/pull/3142

Previously, scip-typescript didn't emit any structured information about signatures. This PR solves that problem, which unblocks new exciting use-cases for SCIP.

Keeping this PR open for a while since we are not planning to merge signature support to SCIP just yet. For now, the Cody repo can use this branch instead.

### Test plan

Green CI
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
