### PR TITLE
fix: Normalize relative_path and avoid emitting multiple Documents for same file

### DIFF
--- a/src/ProjectIndexer.ts
+++ b/src/ProjectIndexer.ts
@@ -88,17 +88,18 @@ export class ProjectIndexer {
     const startTimestamp = Date.now()
     const sourceFiles = this.program.getSourceFiles()
 
-    const filesToIndex: ts.SourceFile[] = []
+    const filesToIndexMap: Map<string, ts.SourceFile> = new Map()
     // Visit every sourceFile in the program
     for (const sourceFile of sourceFiles) {
       const includes = this.config.fileNames.includes(sourceFile.fileName)
       if (!includes) {
         continue
       }
-      filesToIndex.push(sourceFile)
+      const projectRelativePath = path.normalize(path.relative(this.options.cwd, sourceFile.fileName))
+      filesToIndexMap.set(projectRelativePath, sourceFile)
     }
 
-    if (filesToIndex.length === 0) {
+    if (filesToIndexMap.size === 0) {
       throw new Error(
         `no indexable files in project '${this.options.projectDisplayName}'`
       )
@@ -108,7 +109,7 @@ export class ProjectIndexer {
       ? new ProgressBar(
           `  ${this.options.projectDisplayName} [:bar] :current/:total :title`,
           {
-            total: filesToIndex.length,
+            total: filesToIndexMap.size,
             renderThrottle: 100,
             incomplete: '_',
             complete: '#',
@@ -119,9 +120,10 @@ export class ProjectIndexer {
         )
       : undefined
     let lastWrite = startTimestamp
-    for (const [index, sourceFile] of filesToIndex.entries()) {
-      const title = path.relative(this.options.cwd, sourceFile.fileName)
-      jobs?.tick({ title })
+    let index = -1
+    for (const [projectRelativePath, sourceFile] of filesToIndexMap.entries()) {
+      index += 1
+      jobs?.tick({ title: projectRelativePath })
       if (!this.options.progressBar) {
         const now = Date.now()
         const elapsed = now - lastWrite
@@ -131,7 +133,7 @@ export class ProjectIndexer {
         }
       }
       const document = new scip.scip.Document({
-        relative_path: path.relative(this.options.cwd, sourceFile.fileName),
+        relative_path: projectRelativePath,
         occurrences: [],
       })
       const input = new Input(sourceFile.fileName, sourceFile.getText())

--- a/src/SnapshotTesting.ts
+++ b/src/SnapshotTesting.ts
@@ -1,3 +1,4 @@
+import * as path from 'path'
 import { Input } from './Input'
 import { Range } from './Range'
 import { scip } from './scip'
@@ -61,6 +62,12 @@ export function formatSnapshot(
 ): string {
   const out: string[] = []
   const symbolTable = getSymbolTable(doc)
+
+  if (path.normalize(doc.relative_path) !== doc.relative_path) {
+    throw new Error(
+      `Document path must be normalized: ${doc.relative_path}`
+    )
+  }
 
   const externalSymbolTable: Map<string, scip.SymbolInformation> = new Map()
   for (const externalSymbol of externalSymbols) {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/scip-typescript/issues/330

### Test plan

TODO:
- [ ] Add test that was failing before but passes afterwards. Not 100% sure at the moment about how to add a minimal test case. We already have a `multi-project` test which uses a relative reference in tsconfig.json

    ```
    snapshots/input/multi-project/packages/b/tsconfig.json
    10:  "references": [{ "path": "../a" }]
    ```

    Maybe we also need to use a relative import.