### PR TITLE
[demo] Use alternate file symbol syntax

### DIFF
--- a/snapshots/output/enclosing-ranges-ts/index.ts
+++ b/snapshots/output/enclosing-ranges-ts/index.ts
@@ -1,9 +1,9 @@
-// < definition enclosing-ranges-ts 1.0.0 `index.ts`/
+// < definition enclosing-ranges-ts 1.0.0 file://index.ts
 
 // format-options: showRanges
 
 // < start enclosing_range enclosing-ranges-ts 1.0.0 `index.ts`/Foo#
-// < start enclosing_range enclosing-ranges-ts 1.0.0 `index.ts`/
+// < start enclosing_range enclosing-ranges-ts 1.0.0 file://index.ts
 interface Foo {
 //        ^^^ definition enclosing-ranges-ts 1.0.0 `index.ts`/Foo#
   bar: string
@@ -48,4 +48,4 @@ type ComplexTypeAlias<T> = Single<Single<T>>
 //                                       ^ reference enclosing-ranges-ts 1.0.0 `index.ts`/ComplexTypeAlias#[T]
 // < end enclosing_range enclosing-ranges-ts 1.0.0 `index.ts`/ComplexTypeAlias#
 
-// < end enclosing_range enclosing-ranges-ts 1.0.0 `index.ts`/
+// < end enclosing_range enclosing-ranges-ts 1.0.0 file://index.ts

--- a/snapshots/output/enclosing-ranges/range.js
+++ b/snapshots/output/enclosing-ranges/range.js
@@ -1,8 +1,8 @@
-// < definition enclosing-ranges 0.0.1 `range.js`/
+// < definition enclosing-ranges 0.0.1 file://range.js
 
 // format-options: showRanges
 
-// < start enclosing_range enclosing-ranges 0.0.1 `range.js`/
+// < start enclosing_range enclosing-ranges 0.0.1 file://range.js
 //           ⌄ start enclosing_range enclosing-ranges 0.0.1 `range.js`/test.
 const test = () => {
 //    ^^^^ definition enclosing-ranges 0.0.1 `range.js`/test.
@@ -76,4 +76,4 @@ class Test {
 }
 // < end enclosing_range enclosing-ranges 0.0.1 `range.js`/Test#
 
-// < end enclosing_range enclosing-ranges 0.0.1 `range.js`/
+// < end enclosing_range enclosing-ranges 0.0.1 file://range.js

--- a/snapshots/output/invalid-package-json/packages/a/src/a.ts
+++ b/snapshots/output/invalid-package-json/packages/a/src/a.ts
@@ -1,4 +1,4 @@
-// < definition @example/a HEAD src/`a.ts`/
+// < definition @example/a HEAD file://src/a.ts
 
 export function a(): string {
 //              ^ definition @example/a HEAD src/`a.ts`/a().

--- a/snapshots/output/multi-project/packages/a/src/index.ts
+++ b/snapshots/output/multi-project/packages/a/src/index.ts
@@ -1,4 +1,4 @@
-// < definition @example/a 1.0.0 src/`index.ts`/
+// < definition @example/a 1.0.0 file://src/index.ts
 //documentation ```ts
 //            > module "index.ts"
 //            > ```

--- a/snapshots/output/multi-project/packages/b/src/b.ts
+++ b/snapshots/output/multi-project/packages/b/src/b.ts
@@ -1,8 +1,8 @@
-// < definition @example/b 1.0.0 src/`b.ts`/
+// < definition @example/b 1.0.0 file://src/b.ts
 
 import { a } from '@example/a/src'
 //       ^ reference @example/a 1.0.0 src/`index.ts`/a().
-//                ^^^^^^^^^^^^^^^^ reference @example/a 1.0.0 src/`index.ts`/
+//                ^^^^^^^^^^^^^^^^ reference @example/a 1.0.0 file://src/index.ts
 
 export function b() {
 //              ^ definition @example/b 1.0.0 src/`b.ts`/b().

--- a/snapshots/output/pnpm-workspaces/packages/a/src/a.ts
+++ b/snapshots/output/pnpm-workspaces/packages/a/src/a.ts
@@ -1,4 +1,4 @@
-// < definition @example/a 1.0.0 src/`a.ts`/
+// < definition @example/a 1.0.0 file://src/a.ts
 
 export function a(): string {
 //              ^ definition @example/a 1.0.0 src/`a.ts`/a().

--- a/snapshots/output/pnpm-workspaces/packages/b/src/b.ts
+++ b/snapshots/output/pnpm-workspaces/packages/b/src/b.ts
@@ -1,8 +1,8 @@
-// < definition @example/b 1.0.0 src/`b.ts`/
+// < definition @example/b 1.0.0 file://src/b.ts
 
 import { a } from '@example/a'
 //       ^ reference @example/a 1.0.0 src/`a.ts`/a().
-//                ^^^^^^^^^^^^ reference @example/a 1.0.0 src/`a.ts`/
+//                ^^^^^^^^^^^^ reference @example/a 1.0.0 file://src/a.ts
 
 export function b() {
 //              ^ definition @example/b 1.0.0 src/`b.ts`/b().

--- a/snapshots/output/pure-js/src/main.js
+++ b/snapshots/output/pure-js/src/main.js
@@ -1,4 +1,4 @@
-// < definition pure-js 1.0.0 src/`main.js`/
+// < definition pure-js 1.0.0 file://src/main.js
 
 function fib(n) {
 //       ^^^ definition pure-js 1.0.0 src/`main.js`/fib().

--- a/snapshots/output/react/src/LoaderInput.tsx
+++ b/snapshots/output/react/src/LoaderInput.tsx
@@ -1,8 +1,8 @@
-// < definition react-example 1.0.0 src/`LoaderInput.tsx`/
+// < definition react-example 1.0.0 file://src/LoaderInput.tsx
 
 import React from 'react'
 //     ^^^^^ reference @types/react 18.2.39 `index.d.ts`/React/
-//                ^^^^^^^ reference @types/react 18.2.39 `index.d.ts`/
+//                ^^^^^^^ reference @types/react 18.2.39 file://index.d.ts
 
 /** Takes loading prop, input component as child */
 interface Props {

--- a/snapshots/output/react/src/MyTSXElement.tsx
+++ b/snapshots/output/react/src/MyTSXElement.tsx
@@ -1,8 +1,8 @@
-// < definition react-example 1.0.0 src/`MyTSXElement.tsx`/
+// < definition react-example 1.0.0 file://src/MyTSXElement.tsx
 
 import React from 'react'
 //     ^^^^^ reference @types/react 18.2.39 `index.d.ts`/React/
-//                ^^^^^^^ reference @types/react 18.2.39 `index.d.ts`/
+//                ^^^^^^^ reference @types/react 18.2.39 file://index.d.ts
 
 export interface MyProps {}
 //               ^^^^^^^ definition react-example 1.0.0 src/`MyTSXElement.tsx`/MyProps#

--- a/snapshots/output/react/src/UseMyTSXElement.tsx
+++ b/snapshots/output/react/src/UseMyTSXElement.tsx
@@ -1,13 +1,13 @@
-// < definition react-example 1.0.0 src/`UseMyTSXElement.tsx`/
+// < definition react-example 1.0.0 file://src/UseMyTSXElement.tsx
 
 import React from "react";
 //     ^^^^^ reference @types/react 18.2.39 `index.d.ts`/React/
-//                ^^^^^^^ reference @types/react 18.2.39 `index.d.ts`/
+//                ^^^^^^^ reference @types/react 18.2.39 file://index.d.ts
 
 import { MyProps, MyTSXElement } from "./MyTSXElement";
 //       ^^^^^^^ reference react-example 1.0.0 src/`MyTSXElement.tsx`/MyProps#
 //                ^^^^^^^^^^^^ reference react-example 1.0.0 src/`MyTSXElement.tsx`/MyTSXElement.
-//                                    ^^^^^^^^^^^^^^^^ reference react-example 1.0.0 src/`MyTSXElement.tsx`/
+//                                    ^^^^^^^^^^^^^^^^ reference react-example 1.0.0 file://src/MyTSXElement.tsx
 
 export const _: React.FunctionComponent<MyProps> =
 //           ^ definition react-example 1.0.0 src/`UseMyTSXElement.tsx`/_.

--- a/snapshots/output/syntax/src/ClassWithPrivate.ts
+++ b/snapshots/output/syntax/src/ClassWithPrivate.ts
@@ -1,4 +1,4 @@
-// < definition syntax 1.0.0 src/`ClassWithPrivate.ts`/
+// < definition syntax 1.0.0 file://src/ClassWithPrivate.ts
 
 export class ClassWithPrivate {
 //           ^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`ClassWithPrivate.ts`/ClassWithPrivate#

--- a/snapshots/output/syntax/src/accessors.ts
+++ b/snapshots/output/syntax/src/accessors.ts
@@ -1,4 +1,4 @@
-// < definition syntax 1.0.0 src/`accessors.ts`/
+// < definition syntax 1.0.0 file://src/accessors.ts
 
 class C {
 //    ^ definition syntax 1.0.0 src/`accessors.ts`/C#

--- a/snapshots/output/syntax/src/class.ts
+++ b/snapshots/output/syntax/src/class.ts
@@ -1,4 +1,4 @@
-// < definition syntax 1.0.0 src/`class.ts`/
+// < definition syntax 1.0.0 file://src/class.ts
 
 export class Class {
 //           ^^^^^ definition syntax 1.0.0 src/`class.ts`/Class#

--- a/snapshots/output/syntax/src/conflicting-const-interface.ts
+++ b/snapshots/output/syntax/src/conflicting-const-interface.ts
@@ -1,4 +1,4 @@
-// < definition syntax 1.0.0 src/`conflicting-const-interface.ts`/
+// < definition syntax 1.0.0 file://src/conflicting-const-interface.ts
 
 export const ConflictingConst = 42
 //           ^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`conflicting-const-interface.ts`/ConflictingConst.

--- a/snapshots/output/syntax/src/constructor.ts
+++ b/snapshots/output/syntax/src/constructor.ts
@@ -1,4 +1,4 @@
-// < definition syntax 1.0.0 src/`constructor.ts`/
+// < definition syntax 1.0.0 file://src/constructor.ts
 
 namespace Yay {
 //        ^^^ definition syntax 1.0.0 src/`constructor.ts`/Yay/

--- a/snapshots/output/syntax/src/destructuring.ts
+++ b/snapshots/output/syntax/src/destructuring.ts
@@ -1,4 +1,4 @@
-// < definition syntax 1.0.0 src/`destructuring.ts`/
+// < definition syntax 1.0.0 file://src/destructuring.ts
 
 interface Props {
 //        ^^^^^ definition syntax 1.0.0 src/`destructuring.ts`/Props#

--- a/snapshots/output/syntax/src/enum.ts
+++ b/snapshots/output/syntax/src/enum.ts
@@ -1,4 +1,4 @@
-// < definition syntax 1.0.0 src/`enum.ts`/
+// < definition syntax 1.0.0 file://src/enum.ts
 
 export enum Enum {
 //          ^^^^ definition syntax 1.0.0 src/`enum.ts`/Enum#

--- a/snapshots/output/syntax/src/function.ts
+++ b/snapshots/output/syntax/src/function.ts
@@ -1,4 +1,4 @@
-// < definition syntax 1.0.0 src/`function.ts`/
+// < definition syntax 1.0.0 file://src/function.ts
 
 export function newFunction(): void {}
 //              ^^^^^^^^^^^ definition syntax 1.0.0 src/`function.ts`/newFunction().

--- a/snapshots/output/syntax/src/import.ts
+++ b/snapshots/output/syntax/src/import.ts
@@ -1,21 +1,21 @@
-// < definition syntax 1.0.0 src/`import.ts`/
+// < definition syntax 1.0.0 file://src/import.ts
 
 import * as namespace from './namespace'
 //          ^^^^^^^^^ reference syntax 1.0.0 src/`namespace.ts`/
-//                         ^^^^^^^^^^^^^ reference syntax 1.0.0 src/`namespace.ts`/
+//                         ^^^^^^^^^^^^^ reference syntax 1.0.0 file://src/namespace.ts
 import { Class } from './class'
 //       ^^^^^ reference syntax 1.0.0 src/`class.ts`/Class#
-//                    ^^^^^^^^^ reference syntax 1.0.0 src/`class.ts`/
+//                    ^^^^^^^^^ reference syntax 1.0.0 file://src/class.ts
 import { Enum } from './enum'
 //       ^^^^ reference syntax 1.0.0 src/`enum.ts`/Enum#
-//                   ^^^^^^^^ reference syntax 1.0.0 src/`enum.ts`/
+//                   ^^^^^^^^ reference syntax 1.0.0 file://src/enum.ts
 import { newFunction } from './function'
 //       ^^^^^^^^^^^ reference syntax 1.0.0 src/`function.ts`/newFunction().
-//                          ^^^^^^^^^^^^ reference syntax 1.0.0 src/`function.ts`/
+//                          ^^^^^^^^^^^^ reference syntax 1.0.0 file://src/function.ts
 import { newInterface as renamedInterface } from './interface'
 //       ^^^^^^^^^^^^ reference syntax 1.0.0 src/`interface.ts`/newInterface().
 //                       ^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`interface.ts`/newInterface().
-//                                               ^^^^^^^^^^^^^ reference syntax 1.0.0 src/`interface.ts`/
+//                                               ^^^^^^^^^^^^^ reference syntax 1.0.0 file://src/interface.ts
 
 export function useEverything(): string {
 //              ^^^^^^^^^^^^^ definition syntax 1.0.0 src/`import.ts`/useEverything().
@@ -47,7 +47,7 @@ export function dynamicImport(): Promise<void> {
 //                               ^^^^^^^ reference typescript 5.3.3 lib/`lib.es2015.symbol.wellknown.d.ts`/Promise#
 //                               ^^^^^^^ reference typescript 5.3.3 lib/`lib.es2018.promise.d.ts`/Promise#
   return import('./function').then(c => c.newFunction())
-//              ^^^^^^^^^^^^ reference syntax 1.0.0 src/`function.ts`/
+//              ^^^^^^^^^^^^ reference syntax 1.0.0 file://src/function.ts
 //                            ^^^^ reference typescript 5.3.3 lib/`lib.es5.d.ts`/Promise#then().
 //                                 ^ definition local 3
 //                                      ^ reference local 3

--- a/snapshots/output/syntax/src/infer-relationship.ts
+++ b/snapshots/output/syntax/src/infer-relationship.ts
@@ -1,4 +1,4 @@
-// < definition syntax 1.0.0 src/`infer-relationship.ts`/
+// < definition syntax 1.0.0 file://src/infer-relationship.ts
 
 interface Configuration {
 //        ^^^^^^^^^^^^^ definition syntax 1.0.0 src/`infer-relationship.ts`/Configuration#

--- a/snapshots/output/syntax/src/inheritance.ts
+++ b/snapshots/output/syntax/src/inheritance.ts
@@ -1,8 +1,8 @@
-// < definition syntax 1.0.0 src/`inheritance.ts`/
+// < definition syntax 1.0.0 file://src/inheritance.ts
 
 import { Overloader } from './overload'
 //       ^^^^^^^^^^ reference syntax 1.0.0 src/`overload.d.ts`/Overloader#
-//                         ^^^^^^^^^^^^ reference syntax 1.0.0 src/`overload.d.ts`/
+//                         ^^^^^^^^^^^^ reference syntax 1.0.0 file://src/overload.d.ts
 
 export interface Superinterface {
 //               ^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/Superinterface#

--- a/snapshots/output/syntax/src/interface.ts
+++ b/snapshots/output/syntax/src/interface.ts
@@ -1,4 +1,4 @@
-// < definition syntax 1.0.0 src/`interface.ts`/
+// < definition syntax 1.0.0 file://src/interface.ts
 
 export interface Interface {
 //               ^^^^^^^^^ definition syntax 1.0.0 src/`interface.ts`/Interface#

--- a/snapshots/output/syntax/src/issue-45.d.ts
+++ b/snapshots/output/syntax/src/issue-45.d.ts
@@ -1,4 +1,4 @@
-// < definition syntax 1.0.0 src/`issue-45.d.ts`/
+// < definition syntax 1.0.0 file://src/issue-45.d.ts
 
 export namespace example {
 //               ^^^^^^^ definition syntax 1.0.0 src/`issue-45.d.ts`/example/

--- a/snapshots/output/syntax/src/local.ts
+++ b/snapshots/output/syntax/src/local.ts
@@ -1,4 +1,4 @@
-// < definition syntax 1.0.0 src/`local.ts`/
+// < definition syntax 1.0.0 file://src/local.ts
 
 export function local(): string {
 //              ^^^^^ definition syntax 1.0.0 src/`local.ts`/local().

--- a/snapshots/output/syntax/src/module.d.ts
+++ b/snapshots/output/syntax/src/module.d.ts
@@ -1,4 +1,4 @@
-// < definition syntax 1.0.0 src/`module.d.ts`/
+// < definition syntax 1.0.0 file://src/module.d.ts
 
 declare module 'a:b' {
 //             ^^^^^ definition syntax 1.0.0 src/`module.d.ts`/`'a:b'`/

--- a/snapshots/output/syntax/src/namespace.ts
+++ b/snapshots/output/syntax/src/namespace.ts
@@ -1,4 +1,4 @@
-// < definition syntax 1.0.0 src/`namespace.ts`/
+// < definition syntax 1.0.0 file://src/namespace.ts
 
 export declare namespace a {
 //                       ^ definition syntax 1.0.0 src/`namespace.ts`/a/

--- a/snapshots/output/syntax/src/overload.d.ts
+++ b/snapshots/output/syntax/src/overload.d.ts
@@ -1,4 +1,4 @@
-// < definition syntax 1.0.0 src/`overload.d.ts`/
+// < definition syntax 1.0.0 file://src/overload.d.ts
 
 export interface Overloader {
 //               ^^^^^^^^^^ definition syntax 1.0.0 src/`overload.d.ts`/Overloader#

--- a/snapshots/output/syntax/src/property-assignment-reference.ts
+++ b/snapshots/output/syntax/src/property-assignment-reference.ts
@@ -1,4 +1,4 @@
-// < definition syntax 1.0.0 src/`property-assignment-reference.ts`/
+// < definition syntax 1.0.0 file://src/property-assignment-reference.ts
 
 import {
   propertyAssignment,
@@ -6,7 +6,7 @@ import {
   shorthandPropertyAssignment,
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`property-assignment.ts`/shorthandPropertyAssignment().
 } from './property-assignment'
-//     ^^^^^^^^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`property-assignment.ts`/
+//     ^^^^^^^^^^^^^^^^^^^^^^^ reference syntax 1.0.0 file://src/property-assignment.ts
 
 export function run(): string {
 //              ^^^ definition syntax 1.0.0 src/`property-assignment-reference.ts`/run().

--- a/snapshots/output/syntax/src/property-assignment.ts
+++ b/snapshots/output/syntax/src/property-assignment.ts
@@ -1,4 +1,4 @@
-// < definition syntax 1.0.0 src/`property-assignment.ts`/
+// < definition syntax 1.0.0 file://src/property-assignment.ts
 
 export function propertyAssignment() {
 //              ^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`property-assignment.ts`/propertyAssignment().

--- a/snapshots/output/syntax/src/string-literals.ts
+++ b/snapshots/output/syntax/src/string-literals.ts
@@ -1,4 +1,4 @@
-// < definition syntax 1.0.0 src/`string-literals.ts`/
+// < definition syntax 1.0.0 file://src/string-literals.ts
 
 interface SomeInterface {
 //        ^^^^^^^^^^^^^ definition syntax 1.0.0 src/`string-literals.ts`/SomeInterface#

--- a/snapshots/output/syntax/src/structural-type.ts
+++ b/snapshots/output/syntax/src/structural-type.ts
@@ -1,4 +1,4 @@
-// < definition syntax 1.0.0 src/`structural-type.ts`/
+// < definition syntax 1.0.0 file://src/structural-type.ts
 
 export function foo(): Promise<{ member: number }> {
 //              ^^^ definition syntax 1.0.0 src/`structural-type.ts`/foo().

--- a/snapshots/output/syntax/src/type-alias.ts
+++ b/snapshots/output/syntax/src/type-alias.ts
@@ -1,4 +1,4 @@
-// < definition syntax 1.0.0 src/`type-alias.ts`/
+// < definition syntax 1.0.0 file://src/type-alias.ts
 
 type S = string
 //   ^ definition syntax 1.0.0 src/`type-alias.ts`/S#

--- a/snapshots/output/syntax/src/type-parameter.ts
+++ b/snapshots/output/syntax/src/type-parameter.ts
@@ -1,4 +1,4 @@
-// < definition syntax 1.0.0 src/`type-parameter.ts`/
+// < definition syntax 1.0.0 file://src/type-parameter.ts
 
 export function typeParameter<A, B>(parameter: A, parameter2: B): [A, B] {
 //              ^^^^^^^^^^^^^ definition syntax 1.0.0 src/`type-parameter.ts`/typeParameter().

--- a/snapshots/output/syntax/src/typings.ts
+++ b/snapshots/output/syntax/src/typings.ts
@@ -1,4 +1,4 @@
-// < definition syntax 1.0.0 src/`typings.ts`/
+// < definition syntax 1.0.0 file://src/typings.ts
 
 export function process() {
 //              ^^^^^^^ definition syntax 1.0.0 src/`typings.ts`/process().

--- a/src/Debug.ts
+++ b/src/Debug.ts
@@ -1,0 +1,20 @@
+import ts from 'typescript';
+
+import { Range } from './Range';
+
+export function printFullAST(sourceFile: ts.SourceFile): void {
+    console.log(`path: ${sourceFile.fileName}`)
+    printPartialAST(sourceFile)
+}
+
+export function printPartialAST(node: ts.Node): void {
+  let indent = 0;
+  const print = (node: ts.Node): void => {
+      const range = Range.fromNode(node)
+      console.log(new Array(indent + 1).join(' ') + ts.SyntaxKind[node.kind] + ` (${range.start.line},${range.start.character}-${range.end.character})`);
+      indent++;
+      ts.forEachChild(node, print);
+      indent--;
+    }
+  print(node)
+}

--- a/src/FileIndexer.ts
+++ b/src/FileIndexer.ts
@@ -43,6 +43,7 @@ export class FileIndexer {
     // if (!this.sourceFile.fileName.includes('constructor')) {
     //   return
     // }
+    // Debug.printFullAST(this.sourceFile)
 
     const byteSize = Buffer.from(this.sourceFile.getText()).length
     if (

--- a/src/FileIndexer.ts
+++ b/src/FileIndexer.ts
@@ -64,7 +64,7 @@ export class FileIndexer {
     this.visit(this.sourceFile)
   }
   private emitSourceFileOccurrence(): void {
-    const symbol = this.scipSymbol(this.sourceFile)
+    const symbol = this.packages.fileSymbol(this.sourceFile.fileName)
     if (symbol.isEmpty()) {
       return
     }
@@ -167,7 +167,10 @@ export class FileIndexer {
           [node.parent]
         : sym?.declarations || []
     for (const declaration of declarations) {
-      let scipSymbol = this.scipSymbol(declaration)
+      let scipSymbol =
+        (ts.isStringLiteralLike(node) && ts.isSourceFile(declaration))
+        ? this.packages.fileSymbol(declaration.fileName)
+        : this.scipSymbol(declaration)
 
       let enclosingRange: number[] | undefined
 

--- a/src/ScipSymbol.ts
+++ b/src/ScipSymbol.ts
@@ -1,5 +1,6 @@
 import { descriptorString } from './Descriptor'
 import * as scip from './scip'
+import * as path from 'path';
 
 export class ScipSymbol {
   private constructor(public readonly value: string) {}
@@ -33,5 +34,15 @@ export class ScipSymbol {
     descriptor: scip.scip.Descriptor
   ): ScipSymbol {
     return new ScipSymbol(owner.value + descriptorString(descriptor))
+  }
+
+  public static path(
+    owner: ScipSymbol,
+    filePath: string,
+  ): ScipSymbol {
+    if (filePath === '') {
+      return new ScipSymbol(owner.value + 'file:/')
+    }
+    return new ScipSymbol(owner.value + '/' + path.basename(filePath))
   }
 }

--- a/src/scip.ts
+++ b/src/scip.ts
@@ -13,6 +13,12 @@ export namespace scip {
         UTF8 = 1,
         UTF16 = 2
     }
+    export enum PositionEncoding {
+        UnspecifiedPositionEncoding = 0,
+        UTF8CodeUnitOffsetFromLineStart = 1,
+        UTF16CodeUnitOffsetFromLineStart = 2,
+        UTF32CodeUnitOffsetFromLineStart = 3
+    }
     export enum SymbolRole {
         UnspecifiedSymbolRole = 0,
         Definition = 1,
@@ -566,6 +572,7 @@ export namespace scip {
             occurrences?: Occurrence[];
             symbols?: SymbolInformation[];
             text?: string;
+            position_encoding?: PositionEncoding;
         }) {
             super();
             pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [2, 3], this.#one_of_decls);
@@ -584,6 +591,9 @@ export namespace scip {
                 }
                 if ("text" in data && data.text != undefined) {
                     this.text = data.text;
+                }
+                if ("position_encoding" in data && data.position_encoding != undefined) {
+                    this.position_encoding = data.position_encoding;
                 }
             }
         }
@@ -617,12 +627,19 @@ export namespace scip {
         set text(value: string) {
             pb_1.Message.setField(this, 5, value);
         }
+        get position_encoding() {
+            return pb_1.Message.getFieldWithDefault(this, 6, PositionEncoding.UnspecifiedPositionEncoding) as PositionEncoding;
+        }
+        set position_encoding(value: PositionEncoding) {
+            pb_1.Message.setField(this, 6, value);
+        }
         static fromObject(data: {
             language?: string;
             relative_path?: string;
             occurrences?: ReturnType<typeof Occurrence.prototype.toObject>[];
             symbols?: ReturnType<typeof SymbolInformation.prototype.toObject>[];
             text?: string;
+            position_encoding?: PositionEncoding;
         }): Document {
             const message = new Document({});
             if (data.language != null) {
@@ -640,6 +657,9 @@ export namespace scip {
             if (data.text != null) {
                 message.text = data.text;
             }
+            if (data.position_encoding != null) {
+                message.position_encoding = data.position_encoding;
+            }
             return message;
         }
         toObject() {
@@ -649,6 +669,7 @@ export namespace scip {
                 occurrences?: ReturnType<typeof Occurrence.prototype.toObject>[];
                 symbols?: ReturnType<typeof SymbolInformation.prototype.toObject>[];
                 text?: string;
+                position_encoding?: PositionEncoding;
             } = {};
             if (this.language != null) {
                 data.language = this.language;
@@ -664,6 +685,9 @@ export namespace scip {
             }
             if (this.text != null) {
                 data.text = this.text;
+            }
+            if (this.position_encoding != null) {
+                data.position_encoding = this.position_encoding;
             }
             return data;
         }
@@ -681,6 +705,8 @@ export namespace scip {
                 writer.writeRepeatedMessage(3, this.symbols, (item: SymbolInformation) => item.serialize(writer));
             if (this.text.length)
                 writer.writeString(5, this.text);
+            if (this.position_encoding != PositionEncoding.UnspecifiedPositionEncoding)
+                writer.writeEnum(6, this.position_encoding);
             if (!w)
                 return writer.getResultBuffer();
         }
@@ -705,6 +731,9 @@ export namespace scip {
                     case 5:
                         message.text = reader.readString();
                         break;
+                    case 6:
+                        message.position_encoding = reader.readEnum();
+                        break;
                     default: reader.skipField();
                 }
             }
@@ -723,6 +752,7 @@ export namespace scip {
             scheme?: string;
             package?: Package;
             descriptors?: Descriptor[];
+            relative_path?: string;
         }) {
             super();
             pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [3], this.#one_of_decls);
@@ -735,6 +765,9 @@ export namespace scip {
                 }
                 if ("descriptors" in data && data.descriptors != undefined) {
                     this.descriptors = data.descriptors;
+                }
+                if ("relative_path" in data && data.relative_path != undefined) {
+                    this.relative_path = data.relative_path;
                 }
             }
         }
@@ -759,10 +792,17 @@ export namespace scip {
         set descriptors(value: Descriptor[]) {
             pb_1.Message.setRepeatedWrapperField(this, 3, value);
         }
+        get relative_path() {
+            return pb_1.Message.getFieldWithDefault(this, 4, "") as string;
+        }
+        set relative_path(value: string) {
+            pb_1.Message.setField(this, 4, value);
+        }
         static fromObject(data: {
             scheme?: string;
             package?: ReturnType<typeof Package.prototype.toObject>;
             descriptors?: ReturnType<typeof Descriptor.prototype.toObject>[];
+            relative_path?: string;
         }): Symbol {
             const message = new Symbol({});
             if (data.scheme != null) {
@@ -774,6 +814,9 @@ export namespace scip {
             if (data.descriptors != null) {
                 message.descriptors = data.descriptors.map(item => Descriptor.fromObject(item));
             }
+            if (data.relative_path != null) {
+                message.relative_path = data.relative_path;
+            }
             return message;
         }
         toObject() {
@@ -781,6 +824,7 @@ export namespace scip {
                 scheme?: string;
                 package?: ReturnType<typeof Package.prototype.toObject>;
                 descriptors?: ReturnType<typeof Descriptor.prototype.toObject>[];
+                relative_path?: string;
             } = {};
             if (this.scheme != null) {
                 data.scheme = this.scheme;
@@ -790,6 +834,9 @@ export namespace scip {
             }
             if (this.descriptors != null) {
                 data.descriptors = this.descriptors.map((item: Descriptor) => item.toObject());
+            }
+            if (this.relative_path != null) {
+                data.relative_path = this.relative_path;
             }
             return data;
         }
@@ -803,6 +850,8 @@ export namespace scip {
                 writer.writeMessage(2, this.package, () => this.package.serialize(writer));
             if (this.descriptors.length)
                 writer.writeRepeatedMessage(3, this.descriptors, (item: Descriptor) => item.serialize(writer));
+            if (this.relative_path.length)
+                writer.writeString(4, this.relative_path);
             if (!w)
                 return writer.getResultBuffer();
         }
@@ -820,6 +869,9 @@ export namespace scip {
                         break;
                     case 3:
                         reader.readMessage(message.descriptors, () => pb_1.Message.addToRepeatedWrapperField(message, 3, Descriptor.deserialize(reader), Descriptor));
+                        break;
+                    case 4:
+                        message.relative_path = reader.readString();
                         break;
                     default: reader.skipField();
                 }


### PR DESCRIPTION
The second commit is the main one. It is currently quite small:

```
commit 16d82c32c211f38973c78d02578df99c21d7c6ef
Author: Varun Gandhi <varun.gandhi@sourcegraph.com>
Date:   Wed Apr 24 12:59:54 2024 +0800

    Use alternate syntax for file symbols

 src/FileIndexer.ts |  7 +++++--
 src/Packages.ts    | 31 +++++++++++++++++++++++++++++++
 src/ScipSymbol.ts  | 11 +++++++++++
 3 files changed, 47 insertions(+), 2 deletions(-)
```

I haven't yet made the update for setting `file_symbol_info`
and `file_occurrence`.

### Test plan

Covered by snapshot tests