### PR TITLE
Fix path normalize check for Windows

### DIFF
--- a/src/Packages.ts
+++ b/src/Packages.ts
@@ -8,7 +8,7 @@ export class Packages {
   constructor(public readonly projectRoot: string) {}
   private cache: Map<string, ScipSymbol> = new Map()
   public symbol(filePath: string): ScipSymbol {
-    if (path.normalize(filePath) !== filePath) {
+    if (path.normalize(filePath).replaceAll('\\', '/') !== filePath) {
       throw new Error(
         `unexpected error: path.normalize('${filePath}') !== ${filePath}`
       )


### PR DESCRIPTION
`path.normalize` on Windows returns paths with back-slashes (\\) instead of forward -slashes (/), which causes the check here to fail.

This change fixes the issue by replacing all the back-slashes with forward-slashes.

### Test plan

Ran indexer on Windows and verified the contents of the index file are as expected.
