### PR TITLE
Add `kind` and `display_name` to `SymbolInformation`

### DIFF
--- a/src/FileIndexer.ts
+++ b/src/FileIndexer.ts
@@ -82,6 +82,8 @@ export class FileIndexer {
       new scip.scip.SymbolInformation({
         symbol: symbol.value,
         documentation: ['```ts\nmodule "' + moduleName + '"\n```'],
+        kind: scip.scip.SymbolInformation.Kind.Module,
+        display_name: moduleName,
       })
     )
   }
@@ -320,6 +322,8 @@ export class FileIndexer {
         symbol: symbol.value,
         documentation,
         relationships: this.relationships(declaration, symbol),
+        kind: symbolInformationKind(sym),
+        display_name: sym.getName(),
       })
     )
   }
@@ -808,6 +812,67 @@ function scriptElementKind(
     return ts.ScriptElementKind.memberVariableElement
   }
   return ts.ScriptElementKind.unknown
+}
+
+function symbolInformationKind(
+  sym: ts.Symbol
+): scip.scip.SymbolInformation.Kind {
+  const flags = sym.getFlags()
+  if (flags & ts.SymbolFlags.Class) {
+    return scip.scip.SymbolInformation.Kind.Class
+  }
+  if (flags & ts.SymbolFlags.Interface) {
+    return scip.scip.SymbolInformation.Kind.Interface
+  }
+  if (flags & ts.SymbolFlags.Enum) {
+    return scip.scip.SymbolInformation.Kind.Enum
+  }
+  if (flags & ts.SymbolFlags.EnumMember) {
+    return scip.scip.SymbolInformation.Kind.EnumMember
+  }
+  if (flags & ts.SymbolFlags.TypeAlias) {
+    return scip.scip.SymbolInformation.Kind.TypeAlias
+  }
+  if (flags & ts.SymbolFlags.TypeParameter) {
+    return scip.scip.SymbolInformation.Kind.TypeParameter
+  }
+  if (flags & ts.SymbolFlags.Function) {
+    return scip.scip.SymbolInformation.Kind.Function
+  }
+  if (flags & ts.SymbolFlags.Method) {
+    return scip.scip.SymbolInformation.Kind.Method
+  }
+  if (flags & ts.SymbolFlags.Constructor) {
+    return scip.scip.SymbolInformation.Kind.Constructor
+  }
+  if (flags & ts.SymbolFlags.GetAccessor) {
+    return scip.scip.SymbolInformation.Kind.Getter
+  }
+  if (flags & ts.SymbolFlags.SetAccessor) {
+    return scip.scip.SymbolInformation.Kind.Setter
+  }
+  if (flags & ts.SymbolFlags.Property) {
+    return scip.scip.SymbolInformation.Kind.Property
+  }
+  if (flags & ts.SymbolFlags.Variable) {
+    return scip.scip.SymbolInformation.Kind.Variable
+  }
+  if (flags & ts.SymbolFlags.Module) {
+    if (flags & ts.SymbolFlags.NamespaceModule) {
+      return scip.scip.SymbolInformation.Kind.Namespace
+    }
+    return scip.scip.SymbolInformation.Kind.Module
+  }
+  if (flags & ts.SymbolFlags.Signature) {
+    return scip.scip.SymbolInformation.Kind.Signature
+  }
+  if (flags & ts.SymbolFlags.TypeLiteral) {
+    return scip.scip.SymbolInformation.Kind.Type
+  }
+  if (flags & ts.SymbolFlags.ObjectLiteral) {
+    return scip.scip.SymbolInformation.Kind.Object
+  }
+  return scip.scip.SymbolInformation.Kind.UnspecifiedKind
 }
 
 function isEqualOccurrence(


### PR DESCRIPTION
Started adding support for the `kind` and `display_name` field for `SymbolInformation`.

### Test plan
Currently tested on couple of personal typescript repos, may need to update snapshot tests (not totally sure what the process here is like)
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->