### PR TITLE
chore: checks the format of the version number to be released

### DIFF
--- a/dev/bump-version
+++ b/dev/bump-version
@@ -8,6 +8,10 @@ git rev-parse --abbrev-ref HEAD | grep -q main
 git diff-index --quiet HEAD --
 
 NEW_VERSION="$1"
+if ! [[ "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "You need to specify a version number in the format X.Y.Z"
+    exit 1
+fi
 
 echo "Updating package.json."
 yarn version --no-git-tag-version --new-version "$NEW_VERSION"


### PR DESCRIPTION
I accidentally created a `vv0.3.14` release. Add a check to the release script, so that this particular error can't happen again.

### Test plan

Run `./dev/bump-version v0.0.99` and get an error