### PR TITLE
Remove stage id from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,6 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build and push snapshot
-        id: docker_build
         if: github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v3
         with:
@@ -41,7 +40,6 @@ jobs:
           tags: |
             sourcegraph/scip-typescript:latest-snapshot
       - name: Build and push tag
-        id: docker_build
         if: startsWith(github.ref, 'refs/tags/v')
         uses: docker/build-push-action@v3
         with:


### PR DESCRIPTION
Apparently gh doesn't lint all workflows, only those that run https://github.com/sourcegraph/scip-typescript/actions/runs/12274624077/workflow

### Test plan
- see if publishing succeeds on main

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
