### PR TITLE
Add Svelte indexing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # scip-typescript
 
-[SCIP](https://github.com/sourcegraph/scip) indexer for TypeScript and JavaScript.
+[SCIP](https://github.com/sourcegraph/scip) indexer for TypeScript, JavaScript,
+and Svelte.
 
 ## Quick start
 
@@ -32,6 +33,18 @@ scip-typescript index --infer-tsconfig
 
 To improve the quality of indexing results for JavaScript,
 consider adding `@types/*` packages as `devDependencies` in `package.json`.
+
+### Indexing a Svelte project
+
+Install the project dependencies and run the indexer from the directory that
+contains the project's `tsconfig.json` or `jsconfig.json`. SvelteKit projects
+should run `svelte-kit sync` first so their generated configuration is current.
+
+```sh
+npm install # or yarn/pnpm install
+npx svelte-kit sync # SvelteKit projects only
+scip-typescript index
+```
 
 ### Index a TypeScript project using Yarn workspaces
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sourcegraph/scip-typescript",
   "version": "0.4.0",
-  "description": "SCIP indexer for TypeScript and JavaScript",
+  "description": "SCIP indexer for TypeScript, JavaScript, and Svelte",
   "publisher": "sourcegraph",
   "bin": "dist/src/main.js",
   "main": "./dist/src/main.js",
@@ -36,9 +36,12 @@
   },
   "homepage": "https://github.com/sourcegraph/scip-typescript#readme",
   "dependencies": {
+    "@jridgewell/trace-mapping": "^0.3.31",
     "commander": "^14.0.3",
     "google-protobuf": "^4.0.2",
     "progress": "^2.0.3",
+    "svelte": "^5.56.10",
+    "svelte2tsx": "^0.7.61",
     "typescript": "^6.0.3"
   },
   "devDependencies": {

--- a/snapshots/input/multi-project/packages/a/src/Component.svelte
+++ b/snapshots/input/multi-project/packages/a/src/Component.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  type Props = { label: string }
+  let { label }: Props = $props()
+</script>
+
+<p>{label}</p>

--- a/snapshots/input/multi-project/packages/b/src/App.svelte
+++ b/snapshots/input/multi-project/packages/b/src/App.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import Component from '../../a/src/Component.svelte'
+</script>
+
+<Component label="cross-project" />

--- a/snapshots/input/svelte/Child.svelte
+++ b/snapshots/input/svelte/Child.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  let { label, count = 0 }: { label: string; count?: number } = $props()
+  const doubled = $derived(count * 2)
+</script>
+
+<button>{label}: {doubled}</button>

--- a/snapshots/input/svelte/Generic.svelte
+++ b/snapshots/input/svelte/Generic.svelte
@@ -1,0 +1,5 @@
+<script lang="ts" generics="Value">
+  let { value }: { value: Value } = $props()
+</script>
+
+<span>{value}</span>

--- a/snapshots/input/svelte/Legacy.svelte
+++ b/snapshots/input/svelte/Legacy.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  export let value: string
+</script>
+
+<span>{value}</span>

--- a/snapshots/input/svelte/Parent.svelte
+++ b/snapshots/input/svelte/Parent.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import { writable } from 'svelte/store'
+  import Child from './Child.svelte'
+  import Generic from './Generic.svelte'
+  import Legacy from './Legacy.svelte'
+  import Plain from './Plain.svelte'
+  import { format, type User } from './helper'
+  import { importedCount } from './stores'
+
+  const user: User = { name: 'Ada' }
+  let clicks = $state(1)
+  const count = writable(2)
+  let generic: Generic<User> | undefined = $state()
+
+  function increment(): void {
+    clicks += 1
+  }
+</script>
+
+{#snippet greeting(name: string)}
+  <strong>Hello {name}</strong>
+{/snippet}
+
+<button onclick={increment}>Increment</button>
+<Child label={format(user.name)} count={clicks} />
+<Generic bind:this={generic} value={user} />
+<Legacy value="legacy" />
+<Plain enabled={true} />
+<p>{$count}</p>
+<p>{$importedCount}</p>
+{@render greeting(user.name)}

--- a/snapshots/input/svelte/Plain.svelte
+++ b/snapshots/input/svelte/Plain.svelte
@@ -1,0 +1,7 @@
+<script>
+  export let enabled = false
+</script>
+
+{#if enabled}
+  <p>enabled</p>
+{/if}

--- a/snapshots/input/svelte/helper.ts
+++ b/snapshots/input/svelte/helper.ts
@@ -1,0 +1,7 @@
+export interface User {
+  name: string
+}
+
+export function format(name: string): string {
+  return name.toUpperCase()
+}

--- a/snapshots/input/svelte/index.ts
+++ b/snapshots/input/svelte/index.ts
@@ -1,0 +1,5 @@
+import Legacy from './Legacy.svelte'
+import Parent from './Parent.svelte'
+
+export const component = Parent
+export const components = { Legacy, Parent }

--- a/snapshots/input/svelte/package.json
+++ b/snapshots/input/svelte/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "svelte-example",
+  "version": "1.0.0",
+  "private": true
+}

--- a/snapshots/input/svelte/stores.ts
+++ b/snapshots/input/svelte/stores.ts
@@ -1,0 +1,3 @@
+import { writable } from 'svelte/store'
+
+export const importedCount = writable(3)

--- a/snapshots/input/svelte/tsconfig.json
+++ b/snapshots/input/svelte/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["*.ts", "*.svelte"]
+}

--- a/snapshots/output/multi-project/packages/a/src/Component.svelte
+++ b/snapshots/output/multi-project/packages/a/src/Component.svelte
@@ -1,0 +1,17 @@
+// < definition @example/a 1.0.0 src/`Component.svelte`/
+
+<script lang="ts">
+  type Props = { label: string }
+//     ^^^^^ definition @example/a 1.0.0 src/`Component.svelte`/Props#
+//               ^^^^^ definition @example/a 1.0.0 src/`Component.svelte`/Props#label.
+  let { label }: Props = $props()
+//      ^^^^^ definition local 4
+//      ^^^^^ reference @example/a 1.0.0 src/`Component.svelte`/Props#label.
+//               ^^^^^ reference @example/a 1.0.0 src/`Component.svelte`/Props#
+//                       ^^^^^^ reference svelte 5.56.10 types/`index.d.ts`/$props().
+//                       ^^^^^^ reference svelte 5.56.10 types/`index.d.ts`/$props/
+</script>
+
+<p>{label}</p>
+//  ^^^^^ reference local 4
+

--- a/snapshots/output/multi-project/packages/a/src/Component.svelte
+++ b/snapshots/output/multi-project/packages/a/src/Component.svelte
@@ -1,3 +1,4 @@
+// language Svelte
 // < definition @example/a 1.0.0 src/`Component.svelte`/
 
 <script lang="ts">

--- a/snapshots/output/multi-project/packages/b/src/App.svelte
+++ b/snapshots/output/multi-project/packages/b/src/App.svelte
@@ -1,0 +1,12 @@
+// < definition @example/b 1.0.0 src/`App.svelte`/
+
+<script lang="ts">
+  import Component from '../../a/src/Component.svelte'
+//       ^^^^^^^^^ reference @example/a 1.0.0 src/`Component.svelte`/
+//                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference @example/a 1.0.0 src/`Component.svelte`/
+</script>
+
+<Component label="cross-project" />
+//^^^^^^^^^ reference @example/a 1.0.0 src/`Component.svelte`/
+//         ^^^^^ reference @example/a 1.0.0 src/`Component.svelte`/Props#label.
+

--- a/snapshots/output/multi-project/packages/b/src/App.svelte
+++ b/snapshots/output/multi-project/packages/b/src/App.svelte
@@ -1,3 +1,4 @@
+// language Svelte
 // < definition @example/b 1.0.0 src/`App.svelte`/
 
 <script lang="ts">

--- a/snapshots/output/svelte/Child.svelte
+++ b/snapshots/output/svelte/Child.svelte
@@ -1,3 +1,4 @@
+// language Svelte
 // < definition svelte-example 1.0.0 `Child.svelte`/
 
 <script lang="ts">

--- a/snapshots/output/svelte/Child.svelte
+++ b/snapshots/output/svelte/Child.svelte
@@ -1,0 +1,23 @@
+// < definition svelte-example 1.0.0 `Child.svelte`/
+
+<script lang="ts">
+  let { label, count = 0 }: { label: string; count?: number } = $props()
+//      ^^^^^ definition local 4
+//      ^^^^^ reference svelte-example 1.0.0 `Child.svelte`/Props#label.
+//             ^^^^^ definition local 5
+//             ^^^^^ reference svelte-example 1.0.0 `Child.svelte`/Props#count.
+//                            ^^^^^ definition svelte-example 1.0.0 `Child.svelte`/Props#label.
+//                                           ^^^^^ definition svelte-example 1.0.0 `Child.svelte`/Props#count.
+//                                                              ^^^^^^ reference svelte 5.56.10 types/`index.d.ts`/$props().
+//                                                              ^^^^^^ reference svelte 5.56.10 types/`index.d.ts`/$props/
+  const doubled = $derived(count * 2)
+//      ^^^^^^^ definition local 8
+//                ^^^^^^^^ reference svelte 5.56.10 types/`index.d.ts`/$derived().
+//                ^^^^^^^^ reference svelte 5.56.10 types/`index.d.ts`/$derived/
+//                         ^^^^^ reference local 5
+</script>
+
+<button>{label}: {doubled}</button>
+//       ^^^^^ reference local 4
+//                ^^^^^^^ reference local 8
+

--- a/snapshots/output/svelte/Generic.svelte
+++ b/snapshots/output/svelte/Generic.svelte
@@ -1,0 +1,16 @@
+// < definition svelte-example 1.0.0 `Generic.svelte`/
+
+<script lang="ts" generics="Value">
+//                          ^^^^^ definition svelte-example 1.0.0 `Generic.svelte`/[Value]
+  let { value }: { value: Value } = $props()
+//      ^^^^^ definition local 4
+//      ^^^^^ reference svelte-example 1.0.0 `Generic.svelte`/Props#value.
+//                 ^^^^^ definition svelte-example 1.0.0 `Generic.svelte`/Props#value.
+//                        ^^^^^ reference svelte-example 1.0.0 `Generic.svelte`/[Value]
+//                                  ^^^^^^ reference svelte 5.56.10 types/`index.d.ts`/$props().
+//                                  ^^^^^^ reference svelte 5.56.10 types/`index.d.ts`/$props/
+</script>
+
+<span>{value}</span>
+//     ^^^^^ reference local 4
+

--- a/snapshots/output/svelte/Generic.svelte
+++ b/snapshots/output/svelte/Generic.svelte
@@ -1,3 +1,4 @@
+// language Svelte
 // < definition svelte-example 1.0.0 `Generic.svelte`/
 
 <script lang="ts" generics="Value">

--- a/snapshots/output/svelte/Legacy.svelte
+++ b/snapshots/output/svelte/Legacy.svelte
@@ -1,0 +1,11 @@
+// < definition svelte-example 1.0.0 `Legacy.svelte`/
+
+<script lang="ts">
+  export let value: string
+//           ^^^^^ definition local 2
+//           ^^^^^ definition svelte-example 1.0.0 `Legacy.svelte`/Props#value.
+</script>
+
+<span>{value}</span>
+//     ^^^^^ reference local 2
+

--- a/snapshots/output/svelte/Legacy.svelte
+++ b/snapshots/output/svelte/Legacy.svelte
@@ -1,3 +1,4 @@
+// language Svelte
 // < definition svelte-example 1.0.0 `Legacy.svelte`/
 
 <script lang="ts">

--- a/snapshots/output/svelte/Parent.svelte
+++ b/snapshots/output/svelte/Parent.svelte
@@ -1,0 +1,89 @@
+// < definition svelte-example 1.0.0 `Parent.svelte`/
+
+<script lang="ts">
+  import { writable } from 'svelte/store'
+//         ^^^^^^^^ reference svelte 5.56.10 types/`index.d.ts`/`'svelte/store'`/writable().
+//                         ^^^^^^^^^^^^^^ reference svelte 5.56.10 types/`index.d.ts`/`'svelte/store'`/
+  import Child from './Child.svelte'
+//       ^^^^^ reference svelte-example 1.0.0 `Child.svelte`/
+//                  ^^^^^^^^^^^^^^^^ reference svelte-example 1.0.0 `Child.svelte`/
+  import Generic from './Generic.svelte'
+//       ^^^^^^^ reference svelte-example 1.0.0 `Generic.svelte`/
+//                    ^^^^^^^^^^^^^^^^^^ reference svelte-example 1.0.0 `Generic.svelte`/
+  import Legacy from './Legacy.svelte'
+//       ^^^^^^ reference svelte-example 1.0.0 `Legacy.svelte`/
+//                   ^^^^^^^^^^^^^^^^^ reference svelte-example 1.0.0 `Legacy.svelte`/
+  import Plain from './Plain.svelte'
+//       ^^^^^ reference svelte-example 1.0.0 `Plain.svelte`/
+//                  ^^^^^^^^^^^^^^^^ reference svelte-example 1.0.0 `Plain.svelte`/
+  import { format, type User } from './helper'
+//         ^^^^^^ reference svelte-example 1.0.0 `helper.ts`/format().
+//                      ^^^^ reference svelte-example 1.0.0 `helper.ts`/User#
+//                                  ^^^^^^^^^^ reference svelte-example 1.0.0 `helper.ts`/
+  import { importedCount } from './stores'
+//         ^^^^^^^^^^^^^ reference svelte-example 1.0.0 `stores.ts`/importedCount.
+//                              ^^^^^^^^^^ reference svelte-example 1.0.0 `stores.ts`/
+
+  const user: User = { name: 'Ada' }
+//      ^^^^ definition local 7
+//            ^^^^ reference svelte-example 1.0.0 `helper.ts`/User#
+//                     ^^^^ reference svelte-example 1.0.0 `helper.ts`/User#name.
+  let clicks = $state(1)
+//    ^^^^^^ definition local 10
+//             ^^^^^^ reference svelte 5.56.10 types/`index.d.ts`/$state().
+//             ^^^^^^ reference svelte 5.56.10 types/`index.d.ts`/$state/
+  const count = writable(2)
+//      ^^^^^ definition local 13
+//              ^^^^^^^^ reference svelte 5.56.10 types/`index.d.ts`/`'svelte/store'`/writable().
+  let generic: Generic<User> | undefined = $state()
+//    ^^^^^^^ definition local 16
+//             ^^^^^^^ reference svelte-example 1.0.0 `Generic.svelte`/
+//                     ^^^^ reference svelte-example 1.0.0 `helper.ts`/User#
+//                                         ^^^^^^ reference svelte 5.56.10 types/`index.d.ts`/$state().
+//                                         ^^^^^^ reference svelte 5.56.10 types/`index.d.ts`/$state/
+
+  function increment(): void {
+//         ^^^^^^^^^ definition local 17
+    clicks += 1
+//  ^^^^^^ reference local 10
+  }
+</script>
+
+{#snippet greeting(name: string)}
+//        ^^^^^^^^ definition local 2
+//                 ^^^^ definition local 4
+  <strong>Hello {name}</strong>
+//               ^^^^ reference local 4
+{/snippet}
+
+<button onclick={increment}>Increment</button>
+//      ^^^^^^^ definition svelte-example 1.0.0 `Parent.svelte`/`"onclick"0`:
+//               ^^^^^^^^^ reference local 17
+<Child label={format(user.name)} count={clicks} />
+//^^^^^ reference svelte-example 1.0.0 `Child.svelte`/
+//     ^^^^^ reference svelte-example 1.0.0 `Child.svelte`/Props#label.
+//            ^^^^^^ reference svelte-example 1.0.0 `helper.ts`/format().
+//                   ^^^^ reference local 7
+//                        ^^^^ reference svelte-example 1.0.0 `helper.ts`/User#name.
+//                               ^^^^^ reference svelte-example 1.0.0 `Child.svelte`/Props#count.
+//                                      ^^^^^^ reference local 10
+<Generic bind:this={generic} value={user} />
+//^^^^^^^ reference svelte-example 1.0.0 `Generic.svelte`/
+//                  ^^^^^^^ reference local 16
+//                           ^^^^^ reference svelte-example 1.0.0 `Generic.svelte`/Props#value.
+//                                  ^^^^ reference local 7
+<Legacy value="legacy" />
+//^^^^^^ reference svelte-example 1.0.0 `Legacy.svelte`/
+//      ^^^^^ reference svelte-example 1.0.0 `Legacy.svelte`/Props#value.
+<Plain enabled={true} />
+//^^^^^ reference svelte-example 1.0.0 `Plain.svelte`/
+//     ^^^^^^^ reference svelte-example 1.0.0 `Plain.svelte`/Props#enabled.
+<p>{$count}</p>
+//  ^^^^^^ reference local 13
+<p>{$importedCount}</p>
+//  ^^^^^^^^^^^^^^ reference svelte-example 1.0.0 `stores.ts`/importedCount.
+{@render greeting(user.name)}
+//       ^^^^^^^^ reference local 2
+//                ^^^^ reference local 7
+//                     ^^^^ reference svelte-example 1.0.0 `helper.ts`/User#name.
+

--- a/snapshots/output/svelte/Parent.svelte
+++ b/snapshots/output/svelte/Parent.svelte
@@ -1,3 +1,4 @@
+// language Svelte
 // < definition svelte-example 1.0.0 `Parent.svelte`/
 
 <script lang="ts">

--- a/snapshots/output/svelte/Plain.svelte
+++ b/snapshots/output/svelte/Plain.svelte
@@ -1,3 +1,4 @@
+// language Svelte
 // < definition svelte-example 1.0.0 `Plain.svelte`/
 
 <script>

--- a/snapshots/output/svelte/Plain.svelte
+++ b/snapshots/output/svelte/Plain.svelte
@@ -1,0 +1,13 @@
+// < definition svelte-example 1.0.0 `Plain.svelte`/
+
+<script>
+  export let enabled = false
+//           ^^^^^^^ definition local 2
+//           ^^^^^^^ definition svelte-example 1.0.0 `Plain.svelte`/Props#enabled.
+</script>
+
+{#if enabled}
+//   ^^^^^^^ reference local 2
+  <p>enabled</p>
+{/if}
+

--- a/snapshots/output/svelte/helper.ts
+++ b/snapshots/output/svelte/helper.ts
@@ -1,3 +1,4 @@
+// language TypeScript
 // < definition svelte-example 1.0.0 `helper.ts`/
 
 export interface User {

--- a/snapshots/output/svelte/helper.ts
+++ b/snapshots/output/svelte/helper.ts
@@ -1,0 +1,16 @@
+// < definition svelte-example 1.0.0 `helper.ts`/
+
+export interface User {
+//               ^^^^ definition svelte-example 1.0.0 `helper.ts`/User#
+  name: string
+//^^^^ definition svelte-example 1.0.0 `helper.ts`/User#name.
+}
+
+export function format(name: string): string {
+//              ^^^^^^ definition svelte-example 1.0.0 `helper.ts`/format().
+//                     ^^^^ definition svelte-example 1.0.0 `helper.ts`/format().(name)
+  return name.toUpperCase()
+//       ^^^^ reference svelte-example 1.0.0 `helper.ts`/format().(name)
+//            ^^^^^^^^^^^ reference typescript 6.0.3 lib/`lib.es5.d.ts`/String#toUpperCase().
+}
+

--- a/snapshots/output/svelte/index.ts
+++ b/snapshots/output/svelte/index.ts
@@ -1,3 +1,4 @@
+// language TypeScript
 // < definition svelte-example 1.0.0 `index.ts`/
 
 import Legacy from './Legacy.svelte'

--- a/snapshots/output/svelte/index.ts
+++ b/snapshots/output/svelte/index.ts
@@ -1,0 +1,19 @@
+// < definition svelte-example 1.0.0 `index.ts`/
+
+import Legacy from './Legacy.svelte'
+//     ^^^^^^ reference svelte-example 1.0.0 `Legacy.svelte`/
+//                 ^^^^^^^^^^^^^^^^^ reference svelte-example 1.0.0 `Legacy.svelte`/
+import Parent from './Parent.svelte'
+//     ^^^^^^ reference svelte-example 1.0.0 `Parent.svelte`/
+//                 ^^^^^^^^^^^^^^^^^ reference svelte-example 1.0.0 `Parent.svelte`/
+
+export const component = Parent
+//           ^^^^^^^^^ definition svelte-example 1.0.0 `index.ts`/component.
+//                       ^^^^^^ reference svelte-example 1.0.0 `Parent.svelte`/
+export const components = { Legacy, Parent }
+//           ^^^^^^^^^^ definition svelte-example 1.0.0 `index.ts`/components.
+//                          ^^^^^^ definition svelte-example 1.0.0 `index.ts`/Legacy0:
+//                          ^^^^^^ reference svelte-example 1.0.0 `Legacy.svelte`/
+//                                  ^^^^^^ definition svelte-example 1.0.0 `index.ts`/Parent0:
+//                                  ^^^^^^ reference svelte-example 1.0.0 `Parent.svelte`/
+

--- a/snapshots/output/svelte/stores.ts
+++ b/snapshots/output/svelte/stores.ts
@@ -1,3 +1,4 @@
+// language TypeScript
 // < definition svelte-example 1.0.0 `stores.ts`/
 
 import { writable } from 'svelte/store'

--- a/snapshots/output/svelte/stores.ts
+++ b/snapshots/output/svelte/stores.ts
@@ -1,0 +1,10 @@
+// < definition svelte-example 1.0.0 `stores.ts`/
+
+import { writable } from 'svelte/store'
+//       ^^^^^^^^ reference svelte 5.56.10 types/`index.d.ts`/`'svelte/store'`/writable().
+//                       ^^^^^^^^^^^^^^ reference svelte 5.56.10 types/`index.d.ts`/`'svelte/store'`/
+
+export const importedCount = writable(3)
+//           ^^^^^^^^^^^^^ definition svelte-example 1.0.0 `stores.ts`/importedCount.
+//                           ^^^^^^^^ reference svelte 5.56.10 types/`index.d.ts`/`'svelte/store'`/writable().
+

--- a/src/CommandLineOptions.ts
+++ b/src/CommandLineOptions.ts
@@ -5,6 +5,7 @@ import packageJson from '../package.json'
 
 import { parseHumanByteSizeIntoNumber } from './parseHumanByteSizeIntoNumber'
 import * as scip from './scip'
+import { SourceInfo } from './SourceInfo'
 
 /** Configuration options to index a multi-project workspace. */
 export interface MultiProjectOptions {
@@ -36,6 +37,7 @@ export interface GlobalCache {
   >
   parsedCommandLines: Map<string, ts.ParsedCommandLine>
   indexedFiles: Set<string>
+  sourceInfos: Map<ts.SourceFile, SourceInfo>
 }
 
 export function mainCommand(
@@ -46,7 +48,7 @@ export function mainCommand(
     .name('scip-typescript')
     .version(packageJson.version)
     .description(
-      'SCIP indexer for TypeScript and JavaScript\nFor usage examples, see https://github.com/sourcegraph/scip-typescript/blob/main/README.md'
+      'SCIP indexer for TypeScript, JavaScript, and Svelte\nFor usage examples, see https://github.com/sourcegraph/scip-typescript/blob/main/README.md'
     )
   command
     .command('index')

--- a/src/FileIndexer.ts
+++ b/src/FileIndexer.ts
@@ -16,9 +16,9 @@ import {
 import { Input } from './Input'
 import { Packages } from './Packages'
 import { formatByteSizeAsHumanReadable } from './parseHumanByteSizeIntoNumber'
-import { Range } from './Range'
 import * as scip from './scip'
 import { ScipSymbol } from './ScipSymbol'
+import { SourceInfo } from './SourceInfo'
 import * as ts_inline from './TypeScriptInternal'
 
 export class FileIndexer {
@@ -37,7 +37,9 @@ export class FileIndexer {
     public readonly globalSymbolTable: Map<ts.Node, ScipSymbol>,
     public readonly globalConstructorTable: Map<ts.ClassDeclaration, boolean>,
     public readonly packages: Packages,
-    public readonly sourceFile: ts.SourceFile
+    public readonly sourceFile: ts.SourceFile,
+    public readonly sourceInfo: SourceInfo,
+    public readonly sourceInfos: Map<ts.SourceFile, SourceInfo>
   ) {
     this.workingDirectoryRegExp = new RegExp(options.cwd, 'g')
   }
@@ -47,7 +49,7 @@ export class FileIndexer {
     //   return
     // }
 
-    const byteSize = Buffer.from(this.sourceFile.getText()).length
+    const byteSize = Buffer.from(this.sourceInfo.text).length
     if (
       this.options.maxFileByteSizeNumber &&
       byteSize > this.options.maxFileByteSizeNumber
@@ -102,17 +104,18 @@ export class FileIndexer {
     this.pushOccurrence(
       new scip.scip.Occurrence({
         range: [0, 0, 0],
-        enclosing_range: Range.fromNode(this.sourceFile).toLsif(),
+        enclosing_range: this.sourceInfo.range(this.sourceFile),
         symbol: symbol.value,
         symbol_roles: scip.scip.SymbolRole.Definition,
       })
     )
     const moduleName =
-      this.sourceFile.moduleName || path.basename(this.sourceFile.fileName)
+      this.sourceFile.moduleName || path.basename(this.sourceInfo.fileName)
+    const language = this.sourceInfo.language ?? 'ts'
     this.pushSymbolInformation(
       new scip.scip.SymbolInformation({
         symbol: symbol.value,
-        documentation: ['```ts\nmodule "' + moduleName + '"\n```'],
+        documentation: [`\`\`\`${language}\nmodule "${moduleName}"\n\`\`\``],
         kind: scip.scip.SymbolInformation.Kind.File,
       })
     )
@@ -190,9 +193,15 @@ export class FileIndexer {
     if (contextualType === undefined) {
       return
     }
+    // svelte2tsx gives the generated props object the contextual type
+    // `Props | undefined`. Property lookup on that union cannot find `label`
+    // in `<Component label={value} />`, so remove the nullish branch first.
+    const propertyOwner = this.sourceInfo.isSvelte
+      ? this.checker.getNonNullableType(contextualType)
+      : contextualType
     const symbol = ts_inline.getPropertySymbolFromContextualType(
       objectElement,
-      contextualType
+      propertyOwner
     )
     const declarations = symbol?.getDeclarations()
     // Inferred object types can contextually resolve a property back to its
@@ -206,9 +215,12 @@ export class FileIndexer {
     // For constructors, this method is passed the declaration node and not the identifier node.
     // In either case, this method needs to get the range of the "name" of the declaration, for constructors we
     // get the firstToken which contains the text "constructor".
-    const range = Range.fromNode(
+    const range = this.sourceInfo.range(
       isConstructor ? (node.getFirstToken() ?? node) : node
-    ).toLsif()
+    )
+    if (!range) {
+      return
+    }
     let role = 0
     let declarations: ts.Node[] =
       this.getDeclarationsForPropertyAssignment(node) ?? []
@@ -242,7 +254,7 @@ export class FileIndexer {
         declaration.initializer &&
         ts.isFunctionLike(declaration.initializer)
       ) {
-        enclosingRange = Range.fromNode(declaration.initializer).toLsif()
+        enclosingRange = this.sourceInfo.range(declaration.initializer)
       } else if (
         ts.isFunctionDeclaration(declaration) ||
         ts.isEnumDeclaration(declaration) ||
@@ -252,7 +264,7 @@ export class FileIndexer {
         ts.isInterfaceDeclaration(declaration) ||
         ts.isConstructorDeclaration(declaration)
       ) {
-        enclosingRange = Range.fromNode(declaration).toLsif()
+        enclosingRange = this.sourceInfo.range(declaration)
       }
 
       if (
@@ -368,8 +380,21 @@ export class FileIndexer {
     }
   }
 
-  private hideWorkingDirectory(value: string): string {
-    return value.replace(this.workingDirectoryRegExp, '')
+  private sanitizeDocumentation(value: string): string {
+    // TypeScript signatures expose implementation names from svelte2tsx.
+    // Keep SCIP hover documentation in terms of the component source instead
+    // of leaking generated helpers that users cannot navigate to or import.
+    return (
+      value
+        // Absolute paths make documentation machine-specific.
+        .replace(this.workingDirectoryRegExp, '')
+        // Legacy-mode components are represented by this generated helper type.
+        .replace(/\b__sveltets_\d+_IsomorphicComponent\b/g, 'Component')
+        // Generic components get a generated `Name__SvelteComponent_` type.
+        .replace(/\b([A-Za-z_$][\w$]*)__SvelteComponent_/g, '$1')
+        // Inline `$props()` annotations are moved into this generated alias.
+        .replace(/\$\$ComponentProps/g, 'Props')
+    )
   }
   private addSymbolInformation(
     node: ts.Node,
@@ -379,7 +404,7 @@ export class FileIndexer {
   ): void {
     const documentation = [
       '```ts\n' +
-        this.hideWorkingDirectory(
+        this.sanitizeDocumentation(
           this.signatureForDocumentation(node, sym, declaration)
         ) +
         '\n```',
@@ -529,6 +554,32 @@ export class FileIndexer {
     if (fromCache) {
       return fromCache
     }
+    // svelte2tsx introduces declarations with no user-authored identity.
+    // Normalize those declarations before the regular SCIP symbol algorithm
+    // assigns local or generated-name symbols to them.
+    const sourceInfo = this.sourceInfos.get(node.getSourceFile())
+    const canonicalDeclaration = sourceInfo?.canonicalDeclaration(node)
+    if (canonicalDeclaration && canonicalDeclaration !== node) {
+      // Store auto-subscriptions resolve to the original store, while generic
+      // parameters owned by the generated $$render resolve to the component.
+      return this.cached(node, this.scipSymbol(canonicalDeclaration))
+    }
+    if (sourceInfo?.isComponentPropsDeclaration(node)) {
+      // Give generated inline component props a stable, cross-file identity so
+      // component attributes navigate to their declaration in the .svelte file.
+      return this.cached(
+        node,
+        ScipSymbol.global(
+          this.scipSymbol(node.getSourceFile()),
+          typeDescriptor('Props')
+        )
+      )
+    }
+    if (sourceInfo?.isComponentDeclaration(node)) {
+      // The generated default export has no source range. Use the file symbol
+      // so imports and component tags navigate to the component document.
+      return this.cached(node, this.scipSymbol(node.getSourceFile()))
+    }
     if (ts.isBlock(node)) {
       return ScipSymbol.empty()
     }
@@ -553,6 +604,20 @@ export class FileIndexer {
       return this.cached(node, symbol)
     }
 
+    if (
+      ts.isPropertyAssignment(node) &&
+      sourceInfo?.isComponentPropsDeclaration(node.parent)
+    ) {
+      // JavaScript-mode legacy components express props as generated object
+      // properties rather than a type. Give them the same stable Props members.
+      return this.cached(
+        node,
+        ScipSymbol.global(
+          this.scipSymbol(node.parent),
+          termDescriptor(node.name.getText())
+        )
+      )
+    }
     if (
       ts.isPropertyAssignment(node) ||
       ts.isShorthandPropertyAssignment(node)
@@ -617,6 +682,18 @@ export class FileIndexer {
       ts.isImportClause(node) ||
       ts.isNamespaceImport(node)
     ) {
+      // Resolve the import binding rather than its inferred type. This matters
+      // for Svelte components and imported stores, whose inferred types point
+      // at framework helpers instead of the user-authored declaration.
+      const alias = node.name
+        ? this.checker.getSymbolAtLocation(node.name)
+        : undefined
+      if (alias && (alias.flags & ts.SymbolFlags.Alias) !== 0) {
+        const imported = this.checker.getAliasedSymbol(alias)
+        for (const declaration of imported.declarations || []) {
+          return this.scipSymbol(declaration)
+        }
+      }
       const tpe = this.checker.getTypeAtLocation(node)
       for (const declaration of tpe.symbol?.declarations || []) {
         return this.scipSymbol(declaration)

--- a/src/FileIndexer.ts
+++ b/src/FileIndexer.ts
@@ -688,7 +688,11 @@ export class FileIndexer {
       const alias = node.name
         ? this.checker.getSymbolAtLocation(node.name)
         : undefined
-      if (alias && (alias.flags & ts.SymbolFlags.Alias) !== 0) {
+      if (
+        (sourceInfo?.isSvelte || isSvelteImport(node)) &&
+        alias &&
+        (alias.flags & ts.SymbolFlags.Alias) !== 0
+      ) {
         const imported = this.checker.getAliasedSymbol(alias)
         for (const declaration of imported.declarations || []) {
           return this.scipSymbol(declaration)
@@ -963,6 +967,20 @@ function isAnonymousContainerOfSymbols(node: ts.Node): boolean {
     ts.isNamedImports(node) ||
     ts.isVariableStatement(node) ||
     ts.isVariableDeclarationList(node)
+  )
+}
+
+function isSvelteImport(
+  node: ts.ImportSpecifier | ts.ImportClause | ts.NamespaceImport
+): boolean {
+  let parent: ts.Node | undefined = node.parent
+  while (parent && !ts.isImportDeclaration(parent)) {
+    parent = parent.parent
+  }
+  return (
+    !!parent &&
+    ts.isStringLiteral(parent.moduleSpecifier) &&
+    parent.moduleSpecifier.text.endsWith('.svelte')
   )
 }
 

--- a/src/ProjectIndexer.test.ts
+++ b/src/ProjectIndexer.test.ts
@@ -8,10 +8,12 @@ import * as assert from 'uvu/assert'
 
 import { GlobalCache, ProjectOptions } from './CommandLineOptions'
 import {
+  deduplicateOccurrences,
   languageForFileName,
   prettyMilliseconds,
   ProjectIndexer,
 } from './ProjectIndexer'
+import * as scip from './scip'
 
 function minute(x: number): number {
   return x * 60 * 1000
@@ -58,6 +60,7 @@ test('only deduplicates documents after successful emission', () => {
       sources: new Map(),
       parsedCommandLines: new Map(),
       indexedFiles: new Set(),
+      sourceInfos: new Map(),
     }
     const options: ProjectOptions = {
       cwd: projectRoot,
@@ -89,6 +92,35 @@ test('only deduplicates documents after successful emission', () => {
   } finally {
     fs.rmSync(projectRoot, { recursive: true })
   }
+})
+
+test('Svelte occurrence deduplication preserves definition metadata', () => {
+  const reference = new scip.scip.Occurrence({
+    range: [1, 2, 3],
+    symbol: 'local 0',
+  })
+  const definition = new scip.scip.Occurrence({
+    range: [1, 2, 3],
+    enclosing_range: [1, 0, 5, 0],
+    symbol: 'local 0',
+    symbol_roles: scip.scip.SymbolRole.Definition,
+    diagnostics: [
+      new scip.scip.Diagnostic({ message: 'definition diagnostic' }),
+    ],
+  })
+  const document = new scip.scip.Document({
+    occurrences: [reference, definition],
+  })
+
+  deduplicateOccurrences(document)
+
+  assert.is(document.occurrences.length, 1)
+  assert.is(document.occurrences[0], definition)
+  assert.equal(document.occurrences[0].enclosing_range, [1, 0, 5, 0])
+  assert.is(
+    document.occurrences[0].diagnostics[0].message,
+    'definition diagnostic'
+  )
 })
 
 test.run()

--- a/src/ProjectIndexer.ts
+++ b/src/ProjectIndexer.ts
@@ -9,33 +9,61 @@ import { Input } from './Input'
 import { Packages } from './Packages'
 import * as scip from './scip'
 import { ScipSymbol } from './ScipSymbol'
+import { SourceInfo, typescriptSourceInfo } from './SourceInfo'
+import { isSvelteFile, SvelteSupport } from './Svelte'
 
 function createCompilerHost(
   cache: GlobalCache,
   compilerOptions: ts.CompilerOptions,
-  projectOptions: ProjectOptions
+  projectOptions: ProjectOptions,
+  hasSvelte: boolean
 ): ts.CompilerHost {
   const host = ts.createCompilerHost(compilerOptions)
-  if (!projectOptions.globalCaches) {
+  if (!hasSvelte && !projectOptions.globalCaches) {
     return host
   }
   const hostCopy = { ...host }
-  host.getParsedCommandLine = (fileName: string) => {
-    if (!hostCopy.getParsedCommandLine) {
-      return undefined
+  const svelte = hasSvelte
+    ? new SvelteSupport(hostCopy, compilerOptions, cache.sourceInfos)
+    : undefined
+  if (svelte) {
+    host.fileExists = fileName => svelte.fileExists(fileName)
+    host.readFile = fileName => svelte.readFile(fileName)
+    host.realpath = fileName => svelte.realpath(fileName)
+    host.resolveModuleNameLiterals = (
+      moduleLiterals,
+      containingFile,
+      redirectedReference,
+      options,
+      containingSourceFile
+    ) =>
+      svelte.resolveModuleNameLiterals(
+        moduleLiterals,
+        containingFile,
+        redirectedReference,
+        options,
+        containingSourceFile
+      )
+  }
+
+  if (projectOptions.globalCaches) {
+    host.getParsedCommandLine = (fileName: string) => {
+      if (!hostCopy.getParsedCommandLine) {
+        return undefined
+      }
+      const fromCache = cache.parsedCommandLines.get(fileName)
+      if (fromCache !== undefined) {
+        return fromCache
+      }
+      const result = hostCopy.getParsedCommandLine(fileName)
+      if (result !== undefined) {
+        // Don't cache undefined results even if they could be cached
+        // theoretically. The big performance gains from this cache come from
+        // caching non-undefined results.
+        cache.parsedCommandLines.set(fileName, result)
+      }
+      return result
     }
-    const fromCache = cache.parsedCommandLines.get(fileName)
-    if (fromCache !== undefined) {
-      return fromCache
-    }
-    const result = hostCopy.getParsedCommandLine(fileName)
-    if (result !== undefined) {
-      // Don't cache undefined results even if they could be cached
-      // theoretically. The big performance gains from this cache come from
-      // caching non-undefined results.
-      cache.parsedCommandLines.set(fileName, result)
-    }
-    return result
   }
   host.getSourceFile = (
     fileName,
@@ -43,20 +71,29 @@ function createCompilerHost(
     onError,
     shouldCreateNewSourceFile
   ) => {
-    const fromCache = cache.sources.get(fileName)
-    if (fromCache !== undefined) {
-      const [sourceFile, cachedLanguageVersion] = fromCache
-      if (isSameLanguageVersion(languageVersion, cachedLanguageVersion)) {
-        return sourceFile
+    if (projectOptions.globalCaches) {
+      const fromCache = cache.sources.get(fileName)
+      if (fromCache !== undefined) {
+        const [sourceFile, cachedLanguageVersion] = fromCache
+        if (isSameLanguageVersion(languageVersion, cachedLanguageVersion)) {
+          return sourceFile
+        }
       }
     }
-    const result = hostCopy.getSourceFile(
-      fileName,
-      languageVersion,
-      onError,
-      shouldCreateNewSourceFile
-    )
-    if (result !== undefined) {
+    const result = svelte
+      ? svelte.getSourceFile(
+          fileName,
+          languageVersion,
+          onError,
+          shouldCreateNewSourceFile
+        )
+      : hostCopy.getSourceFile(
+          fileName,
+          languageVersion,
+          onError,
+          shouldCreateNewSourceFile
+        )
+    if (projectOptions.globalCaches && result !== undefined) {
       // Don't cache undefined results even if they could be cached
       // theoretically. The big performance gains from this cache come from
       // caching non-undefined results.
@@ -74,16 +111,28 @@ export class ProjectIndexer {
   private hasConstructor: Map<ts.ClassDeclaration, boolean> = new Map()
   private packages: Packages
   private indexedFiles: Set<string>
+  private sourceInfos: Map<ts.SourceFile, SourceInfo>
   constructor(
     public readonly config: ts.ParsedCommandLine,
     public readonly options: ProjectOptions,
     cache: GlobalCache
   ) {
-    const host = createCompilerHost(cache, config.options, options)
-    this.program = ts.createProgram(config.fileNames, config.options, host)
+    const hasSvelte = config.fileNames.some(isSvelteFile)
+    const host = createCompilerHost(cache, config.options, options, hasSvelte)
+    const rootNames = hasSvelte
+      ? [
+          ...config.fileNames,
+          // Ambient declarations for the __sveltets helpers emitted by
+          // svelte2tsx. They let TypeScript infer component props and generics,
+          // but are not in config.fileNames and therefore are not indexed.
+          require.resolve('svelte2tsx/svelte-shims-v4.d.ts'),
+        ]
+      : config.fileNames
+    this.program = ts.createProgram(rootNames, config.options, host)
     this.checker = this.program.getTypeChecker()
     this.packages = new Packages(options.projectRoot)
     this.indexedFiles = cache.indexedFiles
+    this.sourceInfos = cache.sourceInfos
   }
   public index(): void {
     const startTimestamp = Date.now()
@@ -141,12 +190,15 @@ export class ProjectIndexer {
           process.stdout.write('.')
         }
       }
+      const sourceInfo =
+        this.sourceInfos.get(sourceFile) ?? typescriptSourceInfo(sourceFile)
       const document = new scip.scip.Document({
-        language: languageForFileName(sourceFile.fileName),
-        relative_path: path.relative(this.options.cwd, sourceFile.fileName),
+        language:
+          sourceInfo.language ?? languageForFileName(sourceInfo.fileName),
+        relative_path: path.relative(this.options.cwd, sourceInfo.fileName),
         occurrences: [],
       })
-      const input = new Input(sourceFile.fileName, sourceFile.getText())
+      const input = new Input(sourceInfo.fileName, sourceInfo.text)
       const visitor = new FileIndexer(
         this.checker,
         this.options,
@@ -155,7 +207,9 @@ export class ProjectIndexer {
         this.symbolCache,
         this.hasConstructor,
         this.packages,
-        sourceFile
+        sourceFile,
+        sourceInfo,
+        this.sourceInfos
       )
       try {
         visitor.index()
@@ -164,6 +218,9 @@ export class ProjectIndexer {
           `unexpected error indexing project root '${this.options.cwd}'`,
           error
         )
+      }
+      if (sourceInfo.isSvelte) {
+        deduplicateOccurrences(visitor.document)
       }
       if (visitor.document.occurrences.length > 0) {
         this.options.writeIndex(
@@ -202,6 +259,20 @@ export function languageForFileName(fileName: string): string | undefined {
   }
   if (extension === '.json') return 'JSON'
   return undefined
+}
+
+function deduplicateOccurrences(document: scip.scip.Document): void {
+  const occurrences = new Map<string, scip.scip.Occurrence>()
+  for (const occurrence of document.occurrences) {
+    const key = `${occurrence.range.join(':')} ${occurrence.symbol}`
+    const existing = occurrences.get(key)
+    if (existing) {
+      existing.symbol_roles |= occurrence.symbol_roles
+    } else {
+      occurrences.set(key, occurrence)
+    }
+  }
+  document.occurrences = [...occurrences.values()]
 }
 
 export function prettyMilliseconds(milliseconds: number): string {

--- a/src/ProjectIndexer.ts
+++ b/src/ProjectIndexer.ts
@@ -16,7 +16,8 @@ function createCompilerHost(
   cache: GlobalCache,
   compilerOptions: ts.CompilerOptions,
   projectOptions: ProjectOptions,
-  hasSvelte: boolean
+  hasSvelte: boolean,
+  sourceInfos: Map<ts.SourceFile, SourceInfo>
 ): ts.CompilerHost {
   const host = ts.createCompilerHost(compilerOptions)
   if (!hasSvelte && !projectOptions.globalCaches) {
@@ -24,7 +25,7 @@ function createCompilerHost(
   }
   const hostCopy = { ...host }
   const svelte = hasSvelte
-    ? new SvelteSupport(hostCopy, compilerOptions, cache.sourceInfos)
+    ? new SvelteSupport(hostCopy, compilerOptions, sourceInfos)
     : undefined
   if (svelte) {
     host.fileExists = fileName => svelte.fileExists(fileName)
@@ -118,7 +119,16 @@ export class ProjectIndexer {
     cache: GlobalCache
   ) {
     const hasSvelte = config.fileNames.some(isSvelteFile)
-    const host = createCompilerHost(cache, config.options, options, hasSvelte)
+    const sourceInfos = options.globalCaches
+      ? cache.sourceInfos
+      : new Map<ts.SourceFile, SourceInfo>()
+    const host = createCompilerHost(
+      cache,
+      config.options,
+      options,
+      hasSvelte,
+      sourceInfos
+    )
     const rootNames = hasSvelte
       ? [
           ...config.fileNames,
@@ -132,7 +142,7 @@ export class ProjectIndexer {
     this.checker = this.program.getTypeChecker()
     this.packages = new Packages(options.projectRoot)
     this.indexedFiles = cache.indexedFiles
-    this.sourceInfos = cache.sourceInfos
+    this.sourceInfos = sourceInfos
   }
   public index(): void {
     const startTimestamp = Date.now()
@@ -261,13 +271,38 @@ export function languageForFileName(fileName: string): string | undefined {
   return undefined
 }
 
-function deduplicateOccurrences(document: scip.scip.Document): void {
+export function deduplicateOccurrences(document: scip.scip.Document): void {
   const occurrences = new Map<string, scip.scip.Occurrence>()
   for (const occurrence of document.occurrences) {
     const key = `${occurrence.range.join(':')} ${occurrence.symbol}`
     const existing = occurrences.get(key)
     if (existing) {
-      existing.symbol_roles |= occurrence.symbol_roles
+      const symbolRoles = existing.symbol_roles | occurrence.symbol_roles
+      const existingIsDefinition =
+        (existing.symbol_roles & scip.scip.SymbolRole.Definition) !== 0
+      const occurrenceIsDefinition =
+        (occurrence.symbol_roles & scip.scip.SymbolRole.Definition) !== 0
+      // svelte2tsx can map a generated reference and definition to the same
+      // source range. Keep the definition as the survivor because it carries
+      // the enclosing range and diagnostics associated with the declaration.
+      if (occurrenceIsDefinition && !existingIsDefinition) {
+        occurrence.symbol_roles = symbolRoles
+        if (occurrence.enclosing_range.length === 0) {
+          occurrence.enclosing_range = existing.enclosing_range
+        }
+        if (occurrence.diagnostics.length === 0) {
+          occurrence.diagnostics = existing.diagnostics
+        }
+        occurrences.set(key, occurrence)
+      } else {
+        existing.symbol_roles = symbolRoles
+        if (existing.enclosing_range.length === 0) {
+          existing.enclosing_range = occurrence.enclosing_range
+        }
+        if (existing.diagnostics.length === 0) {
+          existing.diagnostics = occurrence.diagnostics
+        }
+      }
     } else {
       occurrences.set(key, occurrence)
     }

--- a/src/SourceInfo.ts
+++ b/src/SourceInfo.ts
@@ -1,0 +1,27 @@
+import * as ts from 'typescript'
+
+import { Range } from './Range'
+
+export interface SourceInfo {
+  readonly fileName: string
+  readonly text: string
+  readonly language?: string
+  readonly isSvelte: boolean
+
+  range(node: ts.Node): number[] | undefined
+  isComponentDeclaration(node: ts.Node): boolean
+  isComponentPropsDeclaration(node: ts.Node): boolean
+  canonicalDeclaration(node: ts.Node): ts.Node
+}
+
+export function typescriptSourceInfo(sourceFile: ts.SourceFile): SourceInfo {
+  return {
+    fileName: sourceFile.fileName,
+    text: sourceFile.getText(),
+    isSvelte: false,
+    range: node => Range.fromNode(node).toLsif(),
+    isComponentDeclaration: () => false,
+    isComponentPropsDeclaration: () => false,
+    canonicalDeclaration: node => node,
+  }
+}

--- a/src/Svelte.test.ts
+++ b/src/Svelte.test.ts
@@ -1,0 +1,129 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+import { svelte2tsx } from 'svelte2tsx'
+import * as ts from 'typescript'
+import { test } from 'uvu'
+import * as assert from 'uvu/assert'
+
+import { SourceInfo } from './SourceInfo'
+import { SvelteSupport } from './Svelte'
+
+test('svelte2tsx generated declaration conventions', () => {
+  const transformed = svelte2tsx(
+    `<script lang="ts" generics="Value">
+      let { value }: { value: Value } = $props()
+    </script>
+    <span>{value}</span>`,
+    {
+      filename: 'Generic.svelte',
+      isTsFile: true,
+      emitOnTemplateError: true,
+    }
+  )
+
+  // SvelteSourceInfo canonicalizes these declarations. If an upgrade changes
+  // them, update the normalization and documentation filtering together.
+  assert.ok(transformed.code.includes('function $$render'))
+  assert.ok(transformed.code.includes('type $$ComponentProps'))
+  assert.ok(transformed.code.includes('Generic__SvelteComponent_'))
+
+  const legacy = svelte2tsx(
+    `<script lang="ts">
+      import { count } from './stores'
+      export let value: string
+    </script>
+    <span>{$count}: {value}</span>`,
+    {
+      filename: 'Legacy.svelte',
+      isTsFile: true,
+      emitOnTemplateError: true,
+    }
+  )
+  assert.ok(legacy.code.includes('return { props:'))
+  assert.ok(legacy.code.includes('as {value: string}'))
+  assert.ok(legacy.code.includes('let $count = __sveltets_2_store_get(count)'))
+
+  const javascript = svelte2tsx(`<script>export let enabled = false</script>`, {
+    filename: 'Javascript.svelte',
+    isTsFile: false,
+    emitOnTemplateError: true,
+  })
+  assert.ok(javascript.code.includes('props: {enabled: enabled}'))
+})
+
+test('Svelte host preserves modern module resolution and rune modules', () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'scip-svelte-'))
+  try {
+    const packageDirectory = path.join(directory, 'node_modules', 'dual')
+    fs.mkdirSync(packageDirectory, { recursive: true })
+    fs.writeFileSync(
+      path.join(packageDirectory, 'package.json'),
+      JSON.stringify({
+        name: 'dual',
+        exports: {
+          '.': {
+            import: './import.d.ts',
+            require: './require.d.ts',
+          },
+        },
+      })
+    )
+    fs.writeFileSync(path.join(packageDirectory, 'import.d.ts'), 'export {}')
+    fs.writeFileSync(path.join(packageDirectory, 'require.d.ts'), 'export {}')
+
+    const options: ts.CompilerOptions = {
+      module: ts.ModuleKind.NodeNext,
+      moduleResolution: ts.ModuleResolutionKind.NodeNext,
+    }
+    const host = ts.createCompilerHost(options)
+    const sourceInfos = new Map<ts.SourceFile, SourceInfo>()
+    const svelte = new SvelteSupport(host, options, sourceInfos)
+    const containingFile = path.join(directory, 'index.mts')
+    const sourceFile = ts.createSourceFile(
+      containingFile,
+      "import 'dual'",
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS
+    )
+    sourceFile.impliedNodeFormat = ts.ModuleKind.ESNext
+    const statement = sourceFile.statements[0]
+    assert.ok(ts.isImportDeclaration(statement))
+    assert.ok(ts.isStringLiteral(statement.moduleSpecifier))
+    const [resolution] = svelte.resolveModuleNameLiterals(
+      [statement.moduleSpecifier],
+      containingFile,
+      undefined,
+      options,
+      sourceFile
+    )
+    assert.ok(
+      resolution.resolvedModule?.resolvedFileName.endsWith('import.d.ts')
+    )
+
+    const runeModule = path.join(directory, 'counter.svelte.ts')
+    fs.writeFileSync(runeModule, 'export const count = 1')
+    fs.writeFileSync(path.join(directory, 'counter.svelte'), '<p>component</p>')
+    assert.is(svelte.readFile(runeModule), 'export const count = 1')
+
+    const brokenComponent = path.join(directory, 'Broken.svelte')
+    fs.writeFileSync(brokenComponent, '<script>')
+    let transformError = ''
+    const brokenSource = svelte.getSourceFile(
+      brokenComponent,
+      ts.ScriptTarget.Latest,
+      message => {
+        transformError = message
+      }
+    )
+    assert.ok(brokenSource)
+    assert.ok(transformError.includes('failed to transform'))
+    assert.ok(sourceInfos.get(brokenSource)?.isSvelte)
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+test.run()

--- a/src/Svelte.test.ts
+++ b/src/Svelte.test.ts
@@ -7,6 +7,9 @@ import * as ts from 'typescript'
 import { test } from 'uvu'
 import * as assert from 'uvu/assert'
 
+import { GlobalCache, ProjectOptions } from './CommandLineOptions'
+import { ProjectIndexer } from './ProjectIndexer'
+import * as scip from './scip'
 import { SourceInfo } from './SourceInfo'
 import { SvelteSupport } from './Svelte'
 
@@ -121,6 +124,53 @@ test('Svelte host preserves modern module resolution and rune modules', () => {
     assert.ok(brokenSource)
     assert.ok(transformError.includes('failed to transform'))
     assert.ok(sourceInfos.get(brokenSource)?.isSvelte)
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+test('no-global-caches keeps Svelte source information project-local', () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'scip-svelte-'))
+  try {
+    const fileName = path.join(directory, 'Component.svelte')
+    fs.writeFileSync(fileName, '<h1>Hello</h1>\n')
+    const cache: GlobalCache = {
+      sources: new Map(),
+      parsedCommandLines: new Map(),
+      indexedFiles: new Set(),
+      sourceInfos: new Map(),
+    }
+    const documents: scip.scip.Document[] = []
+    const options: ProjectOptions = {
+      cwd: directory,
+      projectRoot: directory,
+      projectDisplayName: directory,
+      output: path.join(directory, 'index.scip'),
+      inferTsconfig: false,
+      progressBar: false,
+      yarnWorkspaces: false,
+      yarnBerryWorkspaces: false,
+      pnpmWorkspaces: false,
+      globalCaches: false,
+      indexedProjects: new Set(),
+      writeIndex: index => documents.push(...index.documents),
+    }
+    const config: ts.ParsedCommandLine = {
+      options: {
+        allowJs: true,
+        allowNonTsExtensions: true,
+        module: ts.ModuleKind.ESNext,
+        moduleResolution: ts.ModuleResolutionKind.Bundler,
+      },
+      fileNames: [fileName],
+      errors: [],
+    }
+
+    new ProjectIndexer(config, options, cache).index()
+
+    assert.is(documents.length, 1)
+    assert.is(documents[0].language, 'Svelte')
+    assert.is(cache.sourceInfos.size, 0)
   } finally {
     fs.rmSync(directory, { recursive: true, force: true })
   }

--- a/src/Svelte.ts
+++ b/src/Svelte.ts
@@ -232,8 +232,16 @@ class SvelteSourceInfo implements SourceInfo {
       return undefined
     }
     const lastCharacter = this.originalPosition(generatedEnd - 1)
+    const startLine = this.lines[start.line]
+    const lastLine = lastCharacter && this.lines[lastCharacter.line]
     if (
       !lastCharacter ||
+      startLine === undefined ||
+      lastLine === undefined ||
+      start.column < 0 ||
+      start.column > startLine.length ||
+      lastCharacter.column < 0 ||
+      lastCharacter.column >= lastLine.length ||
       start.source !== lastCharacter.source ||
       lastCharacter.line < start.line ||
       (lastCharacter.line === start.line && lastCharacter.column < start.column)
@@ -335,13 +343,15 @@ class SvelteSourceInfo implements SourceInfo {
     line: number,
     column: number
   ): number[] | undefined {
+    const lineText = this.lines[line]
+    if (lineText === undefined || column < 0 || column > lineText.length) {
+      return undefined
+    }
     const candidates = ts.isStringLiteralLike(node)
       ? [node.text, node.getText()]
       : [node.getText()]
     for (const candidate of candidates) {
-      if (
-        this.lines[line].slice(column, column + candidate.length) === candidate
-      ) {
+      if (lineText.slice(column, column + candidate.length) === candidate) {
         return [line, column, column + candidate.length]
       }
     }

--- a/src/Svelte.ts
+++ b/src/Svelte.ts
@@ -1,0 +1,478 @@
+import {
+  originalPositionFor,
+  SourceMapInput,
+  TraceMap,
+} from '@jridgewell/trace-mapping'
+import { svelte2tsx } from 'svelte2tsx'
+import * as ts from 'typescript'
+
+import { SourceInfo } from './SourceInfo'
+
+export const svelteFileExtension: ts.FileExtensionInfo = {
+  extension: '.svelte',
+  isMixedContent: true,
+  scriptKind: ts.ScriptKind.Deferred,
+}
+
+export function isSvelteFile(fileName: string): boolean {
+  return fileName.endsWith('.svelte')
+}
+
+export class SvelteSupport {
+  private readonly moduleResolutionCache: ts.ModuleResolutionCache
+
+  constructor(
+    private readonly host: ts.CompilerHost,
+    private readonly compilerOptions: ts.CompilerOptions,
+    private readonly sourceInfos: Map<ts.SourceFile, SourceInfo>
+  ) {
+    this.moduleResolutionCache = ts.createModuleResolutionCache(
+      host.getCurrentDirectory(),
+      fileName => host.getCanonicalFileName(fileName),
+      compilerOptions
+    )
+  }
+
+  public fileExists(fileName: string): boolean {
+    return this.host.fileExists(this.realFileName(fileName))
+  }
+
+  public readFile(fileName: string): string | undefined {
+    return this.host.readFile(this.realFileName(fileName))
+  }
+
+  public realpath(fileName: string): string {
+    const realFileName = this.realFileName(fileName)
+    return this.host.realpath?.(realFileName) ?? realFileName
+  }
+
+  public getSourceFile(
+    fileName: string,
+    languageVersion: ts.ScriptTarget | ts.CreateSourceFileOptions,
+    onError?: (message: string) => void,
+    shouldCreateNewSourceFile?: boolean
+  ): ts.SourceFile | undefined {
+    if (!isSvelteFile(fileName)) {
+      return this.host.getSourceFile(
+        fileName,
+        languageVersion,
+        onError,
+        shouldCreateNewSourceFile
+      )
+    }
+    const text = this.host.readFile(fileName)
+    if (text === undefined) {
+      return undefined
+    }
+
+    const isTsFile = hasTypeScriptScript(text)
+    let transformed: ReturnType<typeof svelte2tsx>
+    try {
+      transformed = svelte2tsx(text, {
+        filename: fileName,
+        isTsFile,
+        emitOnTemplateError: true,
+      })
+    } catch (error) {
+      const message = `failed to transform ${fileName}: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+      if (onError) {
+        onError(message)
+      } else {
+        console.error(message)
+      }
+      const sourceFile = ts.createSourceFile(
+        fileName,
+        '',
+        languageVersion,
+        true,
+        isTsFile ? ts.ScriptKind.TS : ts.ScriptKind.JS
+      )
+      this.sourceInfos.set(
+        sourceFile,
+        new SvelteSourceInfo(sourceFile, text, undefined)
+      )
+      return sourceFile
+    }
+    const sourceFile = ts.createSourceFile(
+      fileName,
+      transformed.code,
+      languageVersion,
+      true,
+      isTsFile ? ts.ScriptKind.TS : ts.ScriptKind.JS
+    )
+    sourceFile.impliedNodeFormat = ts.getImpliedNodeFormatForFile(
+      fileName,
+      this.moduleResolutionCache,
+      this.host,
+      this.compilerOptions
+    )
+    this.sourceInfos.set(
+      sourceFile,
+      new SvelteSourceInfo(
+        sourceFile,
+        text,
+        new TraceMap(transformed.map as SourceMapInput)
+      )
+    )
+    return sourceFile
+  }
+
+  public resolveModuleNameLiterals(
+    moduleLiterals: readonly ts.StringLiteralLike[],
+    containingFile: string,
+    redirectedReference: ts.ResolvedProjectReference | undefined,
+    options: ts.CompilerOptions,
+    containingSourceFile: ts.SourceFile
+  ): readonly ts.ResolvedModuleWithFailedLookupLocations[] {
+    return moduleLiterals.map(moduleLiteral => {
+      const result = ts.resolveModuleName(
+        moduleLiteral.text,
+        containingFile,
+        options,
+        {
+          fileExists: fileName => this.fileExists(fileName),
+          readFile: fileName => this.readFile(fileName),
+          realpath: fileName => this.realpath(fileName),
+          directoryExists: directoryName =>
+            this.host.directoryExists?.(directoryName) ?? false,
+          getCurrentDirectory: () => this.host.getCurrentDirectory(),
+          getDirectories: directoryName =>
+            this.host.getDirectories?.(directoryName) ?? [],
+          useCaseSensitiveFileNames: () =>
+            this.host.useCaseSensitiveFileNames(),
+        },
+        this.moduleResolutionCache,
+        redirectedReference,
+        ts.getModeForUsageLocation(containingSourceFile, moduleLiteral, options)
+      )
+      const resolved = result.resolvedModule
+      if (!resolved) {
+        return result
+      }
+      const resolvedFileName = this.realFileName(resolved.resolvedFileName)
+      if (!isSvelteFile(resolvedFileName)) {
+        return result
+      }
+      const text = this.host.readFile(resolvedFileName) ?? ''
+      return {
+        ...result,
+        resolvedModule: {
+          ...resolved,
+          resolvedFileName,
+          extension: hasTypeScriptScript(text)
+            ? ts.Extension.Ts
+            : ts.Extension.Js,
+        },
+      }
+    })
+  }
+
+  private realFileName(fileName: string): string {
+    // A real `*.svelte.ts` file is a Svelte 5 rune module, not a virtual probe
+    // for a sibling component with the same basename.
+    if (this.host.fileExists(fileName)) {
+      return fileName
+    }
+    const match = /^(.*?)(?:\.d)?\.svelte\.(?:ts|tsx|js|jsx)$/.exec(fileName)
+    if (!match) {
+      return fileName
+    }
+    const svelteFileName = `${match[1]}.svelte`
+    return this.host.fileExists(svelteFileName) ? svelteFileName : fileName
+  }
+}
+
+class SvelteSourceInfo implements SourceInfo {
+  public readonly fileName: string
+  public readonly language = 'Svelte'
+  public readonly isSvelte = true
+  private readonly lines: string[]
+  private readonly storeDeclarations = new Map<ts.Node, ts.Node>()
+  private readonly legacyPropRanges = new Map<ts.Node, number[]>()
+
+  constructor(
+    private readonly sourceFile: ts.SourceFile,
+    public readonly text: string,
+    private readonly sourceMap: TraceMap | undefined
+  ) {
+    this.fileName = sourceFile.fileName
+    this.lines = text.split('\n')
+    this.collectLegacyPropRanges()
+    this.collectStoreDeclarations()
+  }
+
+  public range(node: ts.Node): number[] | undefined {
+    if (node.getSourceFile() !== this.sourceFile) {
+      return undefined
+    }
+    if (ts.isSourceFile(node)) {
+      const endLine = this.lines.length - 1
+      return toScipRange(0, 0, endLine, this.lines[endLine].length)
+    }
+    const legacyPropRange = this.legacyPropRanges.get(node)
+    if (legacyPropRange) {
+      return legacyPropRange
+    }
+
+    const start = this.originalPosition(node.getStart())
+    if (!start) {
+      return undefined
+    }
+    if (
+      ts.isIdentifier(node) ||
+      ts.isPrivateIdentifier(node) ||
+      ts.isStringLiteralLike(node)
+    ) {
+      return this.rangeForName(node, start.line, start.column)
+    }
+    const generatedEnd = node.getEnd()
+    if (generatedEnd <= node.getStart()) {
+      return undefined
+    }
+    const lastCharacter = this.originalPosition(generatedEnd - 1)
+    if (
+      !lastCharacter ||
+      start.source !== lastCharacter.source ||
+      lastCharacter.line < start.line ||
+      (lastCharacter.line === start.line && lastCharacter.column < start.column)
+    ) {
+      return undefined
+    }
+    return toScipRange(
+      start.line,
+      start.column,
+      lastCharacter.line,
+      lastCharacter.column + 1
+    )
+  }
+
+  public isComponentDeclaration(node: ts.Node): boolean {
+    if (node.getSourceFile() !== this.sourceFile) {
+      return false
+    }
+    const name = declarationName(node)
+    return name?.getText().endsWith('__SvelteComponent_') ?? false
+  }
+
+  public isComponentPropsDeclaration(node: ts.Node): boolean {
+    if (node.getSourceFile() !== this.sourceFile) {
+      return false
+    }
+    if (ts.isTypeAliasDeclaration(node)) {
+      return node.name.text === '$$ComponentProps'
+    }
+    if (ts.isObjectLiteralExpression(node)) {
+      const property = node.parent
+      return (
+        !!property &&
+        ts.isPropertyAssignment(property) &&
+        property.initializer === node &&
+        isRenderPropsProperty(property)
+      )
+    }
+    // TypeScript legacy components return `props: {...} as { ... }` from
+    // $$render. Treat that generated type as the component-owned Props symbol.
+    if (!ts.isTypeLiteralNode(node)) {
+      return false
+    }
+    const asExpression = node.parent
+    if (!asExpression || !ts.isAsExpression(asExpression)) {
+      return false
+    }
+    const property = asExpression.parent
+    if (!property || !ts.isPropertyAssignment(property)) {
+      return false
+    }
+    return (
+      asExpression.type === node &&
+      property.initializer === asExpression &&
+      isRenderPropsProperty(property)
+    )
+  }
+
+  public canonicalDeclaration(node: ts.Node): ts.Node {
+    if (ts.isFunctionDeclaration(node) && node.name?.text === '$$render') {
+      return this.sourceFile
+    }
+    if (ts.isTypeLiteralNode(node) && ts.isTypeAliasDeclaration(node.parent)) {
+      // A type alias already provides a stable owner. Keeping the generated
+      // typeLiteral counter would make prop symbols vary between projects.
+      return node.parent
+    }
+    return this.storeDeclarations.get(node) ?? node
+  }
+
+  private originalPosition(
+    generatedOffset: number
+  ): { source: string; line: number; column: number } | undefined {
+    if (!this.sourceMap) {
+      return undefined
+    }
+    const generated =
+      this.sourceFile.getLineAndCharacterOfPosition(generatedOffset)
+    const original = originalPositionFor(this.sourceMap, {
+      line: generated.line + 1,
+      column: generated.character,
+    })
+    if (
+      original.source === null ||
+      original.line === null ||
+      original.column === null
+    ) {
+      return undefined
+    }
+    return {
+      source: original.source,
+      line: original.line - 1,
+      column: original.column,
+    }
+  }
+
+  private rangeForName(
+    node: ts.Identifier | ts.PrivateIdentifier | ts.StringLiteralLike,
+    line: number,
+    column: number
+  ): number[] | undefined {
+    const candidates = ts.isStringLiteralLike(node)
+      ? [node.text, node.getText()]
+      : [node.getText()]
+    for (const candidate of candidates) {
+      if (
+        this.lines[line].slice(column, column + candidate.length) === candidate
+      ) {
+        return [line, column, column + candidate.length]
+      }
+    }
+    return undefined
+  }
+
+  private collectStoreDeclarations(): void {
+    const declarations = new Map<string, ts.Node>()
+    const generatedStores: ts.VariableDeclaration[] = []
+    const visit = (node: ts.Node): void => {
+      if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
+        if (node.name.text.startsWith('$') && !this.range(node.name)) {
+          generatedStores.push(node)
+        } else if (this.range(node.name)) {
+          declarations.set(node.name.text, node)
+        }
+      } else if (
+        (ts.isImportSpecifier(node) || ts.isNamespaceImport(node)) &&
+        this.range(node.name)
+      ) {
+        declarations.set(node.name.text, node)
+      } else if (
+        ts.isImportClause(node) &&
+        node.name &&
+        this.range(node.name)
+      ) {
+        declarations.set(node.name.text, node)
+      }
+      ts.forEachChild(node, visit)
+    }
+    visit(this.sourceFile)
+    for (const store of generatedStores) {
+      const declaration = declarations.get(store.name.getText().slice(1))
+      if (declaration) {
+        this.storeDeclarations.set(store, declaration)
+      }
+    }
+  }
+
+  private collectLegacyPropRanges(): void {
+    // svelte2tsx does not source-map names in its generated legacy props type.
+    // Reuse the corresponding top-level $$render variable range so the Props
+    // member gets a definition on the original `export let` declaration.
+    const declarations = new Map<string, number[]>()
+    const visit = (node: ts.Node): void => {
+      if (
+        ts.isVariableDeclaration(node) &&
+        ts.isIdentifier(node.name) &&
+        ts.isVariableDeclarationList(node.parent) &&
+        ts.isVariableStatement(node.parent.parent) &&
+        ts.isBlock(node.parent.parent.parent) &&
+        ts.isFunctionDeclaration(node.parent.parent.parent.parent) &&
+        node.parent.parent.parent.parent.name?.text === '$$render'
+      ) {
+        const range = this.range(node.name)
+        if (range) {
+          declarations.set(node.name.text, range)
+        }
+      } else if (
+        ts.isTypeLiteralNode(node) &&
+        this.isComponentPropsDeclaration(node)
+      ) {
+        for (const member of node.members) {
+          if (ts.isPropertySignature(member) && member.name) {
+            const range = declarations.get(member.name.getText())
+            if (range) {
+              this.legacyPropRanges.set(member.name, range)
+            }
+          }
+        }
+      } else if (
+        ts.isObjectLiteralExpression(node) &&
+        this.isComponentPropsDeclaration(node)
+      ) {
+        for (const property of node.properties) {
+          if (ts.isPropertyAssignment(property)) {
+            const range = declarations.get(property.name.getText())
+            if (range) {
+              this.legacyPropRanges.set(property.name, range)
+            }
+          }
+        }
+      }
+      ts.forEachChild(node, visit)
+    }
+    visit(this.sourceFile)
+  }
+}
+
+function isRenderPropsProperty(property: ts.PropertyAssignment): boolean {
+  if (property.name.getText() !== 'props') {
+    return false
+  }
+  const object = property.parent
+  const returnStatement = object?.parent
+  const block = returnStatement?.parent
+  const render = block?.parent
+  return (
+    ts.isObjectLiteralExpression(object) &&
+    ts.isReturnStatement(returnStatement) &&
+    ts.isBlock(block) &&
+    ts.isFunctionDeclaration(render) &&
+    render.name?.text === '$$render'
+  )
+}
+
+function hasTypeScriptScript(text: string): boolean {
+  return /<script\b[^>]*\blang\s*=\s*(?:["'](?:ts|typescript)["']|(?:ts|typescript)\b)/i.test(
+    text
+  )
+}
+
+function declarationName(node: ts.Node): ts.DeclarationName | undefined {
+  if (
+    ts.isVariableDeclaration(node) ||
+    ts.isTypeAliasDeclaration(node) ||
+    ts.isClassDeclaration(node) ||
+    ts.isInterfaceDeclaration(node)
+  ) {
+    return node.name
+  }
+  return undefined
+}
+
+function toScipRange(
+  startLine: number,
+  startColumn: number,
+  endLine: number,
+  endColumn: number
+): number[] {
+  return startLine === endLine
+    ? [startLine, startColumn, endColumn]
+    : [startLine, startColumn, endLine, endColumn]
+}

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -34,6 +34,33 @@ interface PackageJson {
   workspaces: string[]
   packageManager?: string
 }
+
+const generatedSvelteIdentifier =
+  /__sveltets|__SvelteComponent_|\$\$render|\$\$ComponentProps/
+const unstableSveltePropSymbol = /\/Props#typeLiteral\d+:/
+
+function assertStableSvelteSymbols(index: scip.scip.Index): void {
+  for (const document of index.documents) {
+    for (const occurrence of document.occurrences) {
+      if (generatedSvelteIdentifier.test(occurrence.symbol)) {
+        throw new Error(`generated Svelte symbol leaked: ${occurrence.symbol}`)
+      }
+      if (unstableSveltePropSymbol.test(occurrence.symbol)) {
+        throw new Error(`unstable Svelte prop symbol: ${occurrence.symbol}`)
+      }
+    }
+    for (const symbol of document.symbols) {
+      const text = [symbol.symbol, ...symbol.documentation].join('\n')
+      if (generatedSvelteIdentifier.test(text)) {
+        throw new Error(`generated Svelte documentation leaked: ${text}`)
+      }
+      if (unstableSveltePropSymbol.test(text)) {
+        throw new Error(`unstable Svelte prop documentation: ${text}`)
+      }
+    }
+  }
+}
+
 for (const snapshotDirectory of snapshotDirectories) {
   // Uncomment below if you want to skip certain tests for local development.
   // if (!snapshotDirectory.includes('syntax')) {
@@ -73,6 +100,9 @@ for (const snapshotDirectory of snapshotDirectories) {
     fs.renameSync(output, path.join(outputRoot, 'index.scip'))
     if (index.documents.length === 0) {
       throw new Error('empty LSIF index')
+    }
+    if (index.documents.some(document => document.language === 'Svelte')) {
+      assertStableSvelteSymbols(index)
     }
     const documentPaths = new Set<string>()
     const duplicateDocuments: string[] = []
@@ -197,6 +227,12 @@ for (const snapshotDirectory of snapshotDirectories) {
           [],
           'all symbols in the symbol-kind fixture should have a SCIP kind'
         )
+      }
+      if (
+        document.relative_path.endsWith('.svelte') &&
+        document.language !== 'Svelte'
+      ) {
+        throw new Error('Svelte document is missing the svelte language')
       }
       const inputPath = path.join(inputRoot, document.relative_path)
       const relativeToInputDirectory = path.relative(inputDirectory, inputPath)

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,7 @@ import {
 import { inferTsconfig } from './inferTsconfig'
 import { ProjectIndexer } from './ProjectIndexer'
 import * as scip from './scip'
+import { svelteFileExtension } from './Svelte'
 
 export function main(): void {
   mainCommand((projects, options) => indexCommand(projects, options)).parse(
@@ -75,6 +76,7 @@ export function indexCommand(
     sources: new Map(),
     parsedCommandLines: new Map(),
     indexedFiles: new Set(),
+    sourceInfos: new Map(),
   }
   try {
     writeIndex(
@@ -208,7 +210,24 @@ function loadConfigFile(file: string): ts.ParsedCommandLine | undefined {
     }
   }
   const basePath = path.dirname(absolute)
-  const result = ts.parseJsonConfigFileContent(config, ts.sys, basePath)
+  const result = ts.parseJsonConfigFileContent(
+    config,
+    ts.sys,
+    basePath,
+    undefined,
+    absolute,
+    undefined,
+    [svelteFileExtension]
+  )
+  if (result.fileNames.some(fileName => fileName.endsWith('.svelte'))) {
+    const options = result.options as ts.CompilerOptions & {
+      allowNonTsExtensions?: boolean
+    }
+    options.allowNonTsExtensions = true
+    // A component without `lang="ts"` is represented as JavaScript by
+    // svelte2tsx and must remain importable even when the project omits allowJs.
+    options.allowJs = true
+  }
   const errors: ts.Diagnostic[] = []
   for (const error of result.errors) {
     if (error.code === 18003) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -210,12 +210,14 @@ function loadConfigFile(file: string): ts.ParsedCommandLine | undefined {
     }
   }
   const basePath = path.dirname(absolute)
+  // Keep configFileName unset as before: setting it changes module/type-root
+  // resolution for ordinary TypeScript projects based on the indexer cwd.
   const result = ts.parseJsonConfigFileContent(
     config,
     ts.sys,
     basePath,
     undefined,
-    absolute,
+    undefined,
     undefined,
     [svelteFileExtension]
   )

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es2022",
     "module": "Node16",
     "moduleResolution": "Node16",
-    "lib": ["es2022"],
+    "lib": ["es2022", "dom"],
     "rootDir": ".",
     "outDir": "dist",
     "resolveJsonModule": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -216,12 +216,51 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.4.3.tgz#c2b9d2e374ee62c586d3adbea87199b1d7a7a6ba"
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
 
+"@jridgewell/gen-mapping@^0.3.5":
+  version "0.3.13"
+  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz#6342a19f44347518c93e43b1ac69deb3c4656a1f"
+  integrity sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.0"
+    "@jridgewell/trace-mapping" "^0.3.24"
+
+"@jridgewell/remapping@^2.3.4":
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/@jridgewell/remapping/-/remapping-2.3.5.tgz#375c476d1972947851ba1e15ae8f123047445aa1"
+  integrity sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.3.5"
+    "@jridgewell/trace-mapping" "^0.3.24"
+
+"@jridgewell/resolve-uri@^3.1.0":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
+  integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==
+
+"@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.4.15", "@jridgewell/sourcemap-codec@^1.5.0", "@jridgewell/sourcemap-codec@^1.5.5":
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
+  integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
+
+"@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.31":
+  version "0.3.31"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz#db15d6781c931f3a251a3dac39501c98a6082fd0"
+  integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.1.0"
+    "@jridgewell/sourcemap-codec" "^1.4.14"
+
+"@sveltejs/acorn-typescript@^1.0.10":
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.13.tgz#8c7c3cc7014e212f2e8fccee0159dbecfe602405"
+  integrity sha512-wgKggnhZVL9Bfx1OaKKTrYY9BFRk6C8UAkQNUcIv1+llzYrIqy+RZm5HPKzn0NpEBvTVhTqB4kQyllZywsRBRQ==
+
 "@types/esrecurse@^4.3.1":
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/@types/esrecurse/-/esrecurse-4.3.1.tgz#6f636af962fbe6191b830bd676ba5986926bccec"
   integrity sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==
 
-"@types/estree@^1.0.6", "@types/estree@^1.0.8":
+"@types/estree@^1.0.5", "@types/estree@^1.0.6", "@types/estree@^1.0.8":
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.9.tgz#cf3f0e876d7bee15a93ab925b82bf570a3904a24"
   integrity sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==
@@ -256,6 +295,11 @@
   integrity sha512-iadjw02vte8qWx7U0YM++EybBha2CQLPGu9iJ97whVgJUT5Zq9MjAPYUnbfRI2Kpehimf1QjFJYxD0t8nqzu5w==
   dependencies:
     "@types/node" "*"
+
+"@types/trusted-types@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
+  integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
 
 "@typescript-eslint/eslint-plugin@8.67.0":
   version "8.67.0"
@@ -358,7 +402,7 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn@^8.16.0:
+acorn@^8.12.1, acorn@^8.16.0:
   version "8.18.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.18.0.tgz#4faf01b2d6d326bfeed97aea1f52220b5f4c1940"
   integrity sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==
@@ -373,6 +417,16 @@ ajv@^6.14.0:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+aria-query@5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.1.tgz#ebcb2c0d7fc43e68e4cb22f774d1209cb627ab42"
+  integrity sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==
+
+axobject-query@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-4.1.0.tgz#28768c76d0e3cff21bc62a9e2d0b6ac30042a1ee"
+  integrity sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==
+
 balanced-match@^4.0.2:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
@@ -384,6 +438,11 @@ brace-expansion@^5.0.8:
   integrity sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==
   dependencies:
     balanced-match "^4.0.2"
+
+clsx@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
+  integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
 
 commander@^14.0.3:
   version "14.0.3"
@@ -406,6 +465,11 @@ debug@^4.3.1, debug@^4.3.2, debug@^4.4.3:
   dependencies:
     ms "^2.1.3"
 
+dedent-js@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/dedent-js/-/dedent-js-1.0.1.tgz#bee5fb7c9e727d85dffa24590d10ec1ab1255305"
+  integrity sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ==
+
 deep-is@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
@@ -415,6 +479,11 @@ dequal@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
   integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
+
+devalue@^5.8.1:
+  version "5.9.1"
+  resolved "https://registry.yarnpkg.com/devalue/-/devalue-5.9.1.tgz#e92458477f610ea28f4183369d1202a9ef97a32f"
+  integrity sha512-+17vil3EVQRzvtDJSFuTWEb8XJRvXqAiV3qZyQWD398QeXUa6CxsUyMdD1fxzEhUrd4FojitFz7lhIHBTlV4fw==
 
 diff@9.0.0:
   version "9.0.0"
@@ -519,6 +588,11 @@ eslint@10.9.0:
     natural-compare "^1.4.0"
     optionator "^0.9.3"
 
+esm-env@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/esm-env/-/esm-env-1.2.2.tgz#263c9455c55861f41618df31b20cb571fc20b75e"
+  integrity sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==
+
 espree@^11.2.0:
   version "11.2.0"
   resolved "https://registry.yarnpkg.com/espree/-/espree-11.2.0.tgz#01d5e47dc332aaba3059008362454a8cc34ccaa5"
@@ -534,6 +608,13 @@ esquery@^1.7.0:
   integrity sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==
   dependencies:
     estraverse "^5.1.0"
+
+esrap@^2.2.12:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/esrap/-/esrap-2.3.6.tgz#ed70dae3b3841d621dd44cbcb34950da7bdbaf6d"
+  integrity sha512-yc0OC12UjPqLoc+fe+v5GNs4TOjAigUw3sTikfC+xeBPGUw7gDRz3DtYaqEhxyMVJojcSWJw7jT0QWR+CbuE/A==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.4.15"
 
 esrecurse@^4.3.0:
   version "4.3.0"
@@ -644,6 +725,13 @@ is-glob@^4.0.0, is-glob@^4.0.3:
   dependencies:
     is-extglob "^2.1.1"
 
+is-reference@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/is-reference/-/is-reference-3.0.3.tgz#9ef7bf9029c70a67b2152da4adf57c23d718910f"
+  integrity sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==
+  dependencies:
+    "@types/estree" "^1.0.6"
+
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
@@ -684,12 +772,24 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
+locate-character@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/locate-character/-/locate-character-3.0.0.tgz#0305c5b8744f61028ef5d01f444009e00779f974"
+  integrity sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==
+
 locate-path@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
+
+magic-string@^0.30.11:
+  version "0.30.21"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.21.tgz#56763ec09a0fa8091df27879fd94d19078c00d91"
+  integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.5"
 
 minimatch@^10.2.2, minimatch@^10.2.4, minimatch@^10.2.5:
   version "10.2.6"
@@ -786,6 +886,11 @@ sade@^1.7.3:
   dependencies:
     mri "^1.1.0"
 
+scule@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/scule/-/scule-1.3.0.tgz#6efbd22fd0bb801bdcc585c89266a7d2daa8fbd3"
+  integrity sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==
+
 semver@^7.7.3:
   version "7.8.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
@@ -802,6 +907,36 @@ shebang-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+
+svelte2tsx@^0.7.61:
+  version "0.7.61"
+  resolved "https://registry.yarnpkg.com/svelte2tsx/-/svelte2tsx-0.7.61.tgz#863324f1a50d81133433b45ecdfe806fa68b19f1"
+  integrity sha512-EpQ/+UHITBULeUojx/LLD3uTYasZXcX1BrqlrzfLUnT9vdUhaOWK59a3ryWcFU8L0sY1SP+gRhJ2Beiis98+qw==
+  dependencies:
+    dedent-js "^1.0.1"
+    scule "^1.3.0"
+
+svelte@^5.56.10:
+  version "5.56.10"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-5.56.10.tgz#33a8ed98c67f7419603703197884ac0b3ad46836"
+  integrity sha512-Lcxbj8I/KAbpY+VjtY4ENQBV0dDCipfGAhqb51XQZ67CIQqXgsv/8dPkbILaj4Fb6/b6JAEM/PIVbILXgDQy2g==
+  dependencies:
+    "@jridgewell/remapping" "^2.3.4"
+    "@jridgewell/sourcemap-codec" "^1.5.0"
+    "@sveltejs/acorn-typescript" "^1.0.10"
+    "@types/estree" "^1.0.5"
+    "@types/trusted-types" "^2.0.7"
+    acorn "^8.12.1"
+    aria-query "5.3.1"
+    axobject-query "^4.1.0"
+    clsx "^2.1.1"
+    devalue "^5.8.1"
+    esm-env "^1.2.1"
+    esrap "^2.2.12"
+    is-reference "^3.0.3"
+    locate-character "^3.0.0"
+    magic-string "^0.30.11"
+    zimmerframe "^1.1.2"
 
 tinyglobby@^0.2.15:
   version "0.2.17"
@@ -890,3 +1025,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zimmerframe@^1.1.2:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/zimmerframe/-/zimmerframe-1.1.4.tgz#0352b5cafad3ad4526b0a526a9a52d9c040d865b"
+  integrity sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==


### PR DESCRIPTION
This PR implements basic support for indexing Svelte projects with this indexer as well. It uses `svelte2tsx` and maps SCIP symbols and ranges back to the original `.svelte` source files via the source maps.

Verified against the Sourcegraph webapp, everything passes.

See the included snapshots for some example data.

This is likely not 100% perfect, but it's a solid start that we can build on more (just like scip-typescript itself). 