### PR TITLE
Fix contextual shorthand property references

### DIFF
--- a/snapshots/input/syntax/src/destructuring.ts
+++ b/snapshots/input/syntax/src/destructuring.ts
@@ -35,3 +35,8 @@ export function forLoopArrayDestructuring(): number {
 export function parameterDestructuring({ a }: Props): number {
   return a
 }
+
+function myFunc() {
+  let { local } = { local: 10 }
+  return local
+}

--- a/snapshots/input/syntax/src/property-assignment-reference.ts
+++ b/snapshots/input/syntax/src/property-assignment-reference.ts
@@ -1,8 +1,16 @@
 import {
+  importedShorthand,
   propertyAssignment,
   shorthandPropertyAssignment,
 } from './property-assignment'
 
+interface ContextualProperties {
+  importedShorthand: string
+}
+
+function acceptContext(_value: ContextualProperties): void {}
+
 export function run(): string {
+  acceptContext({ importedShorthand })
   return propertyAssignment().a + shorthandPropertyAssignment().a
 }

--- a/snapshots/input/syntax/src/property-assignment.ts
+++ b/snapshots/input/syntax/src/property-assignment.ts
@@ -5,6 +5,7 @@ export function shorthandPropertyAssignment() {
   const a = 'a'
   return { a }
 }
+export const importedShorthand = 'value'
 type A = { a: string; b: number }
 export function typedPropertyAssignment(): A {
   // prettier-ignore

--- a/snapshots/output/syntax/src/destructuring.ts
+++ b/snapshots/output/syntax/src/destructuring.ts
@@ -87,3 +87,13 @@ export function parameterDestructuring({ a }: Props): number {
 //       ^ reference local 50
 }
 
+function myFunc() {
+//       ^^^^^^ definition syntax 1.0.0 src/`destructuring.ts`/myFunc().
+  let { local } = { local: 10 }
+//      ^^^^^ definition local 55
+//      ^^^^^ reference syntax 1.0.0 src/`destructuring.ts`/local0:
+//                  ^^^^^ definition syntax 1.0.0 src/`destructuring.ts`/local0:
+  return local
+//       ^^^^^ reference local 55
+}
+

--- a/snapshots/output/syntax/src/object-literals-call-signatures.ts
+++ b/snapshots/output/syntax/src/object-literals-call-signatures.ts
@@ -152,8 +152,10 @@ export function handleShorthand() {
 //^^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`object-literals-call-signatures.ts`/consumesInterface().
     interfaceMethod,
 //  ^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`reusable-types.ts`/Superinterface#interfaceMethod().
+//  ^^^^^^^^^^^^^^^ reference local 26
     property,
 //  ^^^^^^^^ reference syntax 1.0.0 src/`reusable-types.ts`/Superinterface#property.
+//  ^^^^^^^^ reference local 23
   })
 }
 

--- a/snapshots/output/syntax/src/property-assignment-reference.ts
+++ b/snapshots/output/syntax/src/property-assignment-reference.ts
@@ -2,6 +2,8 @@
 // < definition syntax 1.0.0 src/`property-assignment-reference.ts`/
 
 import {
+  importedShorthand,
+//^^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`property-assignment.ts`/importedShorthand.
   propertyAssignment,
 //^^^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`property-assignment.ts`/propertyAssignment().
   shorthandPropertyAssignment,
@@ -9,8 +11,23 @@ import {
 } from './property-assignment'
 //     ^^^^^^^^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`property-assignment.ts`/
 
+interface ContextualProperties {
+//        ^^^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`property-assignment-reference.ts`/ContextualProperties#
+  importedShorthand: string
+//^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`property-assignment-reference.ts`/ContextualProperties#importedShorthand.
+}
+
+function acceptContext(_value: ContextualProperties): void {}
+//       ^^^^^^^^^^^^^ definition syntax 1.0.0 src/`property-assignment-reference.ts`/acceptContext().
+//                     ^^^^^^ definition syntax 1.0.0 src/`property-assignment-reference.ts`/acceptContext().(_value)
+//                             ^^^^^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`property-assignment-reference.ts`/ContextualProperties#
+
 export function run(): string {
 //              ^^^ definition syntax 1.0.0 src/`property-assignment-reference.ts`/run().
+  acceptContext({ importedShorthand })
+//^^^^^^^^^^^^^ reference syntax 1.0.0 src/`property-assignment-reference.ts`/acceptContext().
+//                ^^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`property-assignment-reference.ts`/ContextualProperties#importedShorthand.
+//                ^^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`property-assignment.ts`/importedShorthand.
   return propertyAssignment().a + shorthandPropertyAssignment().a
 //       ^^^^^^^^^^^^^^^^^^ reference syntax 1.0.0 src/`property-assignment.ts`/propertyAssignment().
 //                            ^ reference syntax 1.0.0 src/`property-assignment.ts`/a0:

--- a/snapshots/output/syntax/src/property-assignment.ts
+++ b/snapshots/output/syntax/src/property-assignment.ts
@@ -14,6 +14,8 @@ export function shorthandPropertyAssignment() {
 //         ^ definition syntax 1.0.0 src/`property-assignment.ts`/a1:
 //         ^ reference local 2
 }
+export const importedShorthand = 'value'
+//           ^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`property-assignment.ts`/importedShorthand.
 type A = { a: string; b: number }
 //   ^ definition syntax 1.0.0 src/`property-assignment.ts`/A#
 //         ^ definition syntax 1.0.0 src/`property-assignment.ts`/A#typeLiteral3:a.

--- a/src/FileIndexer.ts
+++ b/src/FileIndexer.ts
@@ -249,12 +249,12 @@ export class FileIndexer {
       )
       if (isDefinitionNode) {
         this.addSymbolInformation(node, sym, declaration, scipSymbol)
-        this.handleShorthandPropertyDefinition(declaration, range)
         this.handleObjectBindingPattern(node, range)
         // Only emit one symbol for definitions sites, see https://github.com/sourcegraph/lsif-typescript/issues/45
         break
       }
     }
+    this.handleShorthandPropertyValue(node.parent, range)
   }
 
   /**
@@ -293,7 +293,7 @@ export class FileIndexer {
 
   /**
    * Handles the special-case around shorthand property syntax so that we emit two occurrences instead of only one.
-   * Shorthand properties need two symbols because they both define a symbol and reference a symbol. For example:
+   * Shorthand properties need two symbols because the token is both a property and a reference to its value. For example:
    * ```
    * const a = 42
    * const b = {a}
@@ -301,20 +301,25 @@ export class FileIndexer {
    * const c = b.a
    * //          ^ reference to the property `a`, not the local const
    * ```
+   * Contextually typed properties similarly reference both the contextual property
+   * and the local or imported value at the same range.
    */
-  private handleShorthandPropertyDefinition(
+  private handleShorthandPropertyValue(
     declaration: ts.Node,
     range: number[]
   ): void {
-    if (declaration.kind !== ts.SyntaxKind.ShorthandPropertyAssignment) {
+    if (!ts.isShorthandPropertyAssignment(declaration)) {
       return
     }
-    const valueSymbol =
+    let valueSymbol =
       this.checker.getShorthandAssignmentValueSymbol(declaration)
     if (!valueSymbol) {
       return
     }
-    for (const symbol of valueSymbol?.declarations || []) {
+    if (valueSymbol.flags & ts.SymbolFlags.Alias) {
+      valueSymbol = this.checker.getAliasedSymbol(valueSymbol)
+    }
+    for (const symbol of valueSymbol.declarations || []) {
       const scipSymbol = this.scipSymbol(symbol)
       if (scipSymbol.isEmpty()) {
         continue


### PR DESCRIPTION
Emit both the contextual property reference and the value-side reference for shorthand properties in typed contexts. Imported shorthand values are de-aliased to their actual exported symbols.

Fixes #415.
Fixes #440.