### PR TITLE
Connect prototype members across files

### DIFF
--- a/snapshots/input/prototype-members/package.json
+++ b/snapshots/input/prototype-members/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "prototype-members",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/snapshots/input/prototype-members/src/connection.mjs
+++ b/snapshots/input/prototype-members/src/connection.mjs
@@ -4,4 +4,8 @@ Connection.prototype = {
   getSchemaVersion() {
     return 0
   },
+  getVersion: function () {
+    return 1
+  },
+  version: 1,
 }

--- a/snapshots/input/prototype-members/src/connection.mjs
+++ b/snapshots/input/prototype-members/src/connection.mjs
@@ -1,0 +1,7 @@
+export function Connection() {}
+
+Connection.prototype = {
+  getSchemaVersion() {
+    return 0
+  },
+}

--- a/snapshots/input/prototype-members/src/use.mjs
+++ b/snapshots/input/prototype-members/src/use.mjs
@@ -1,0 +1,6 @@
+/** @import { Connection } from './connection.mjs' */
+
+/** @param {Connection} connection */
+export function schemaVersion(connection) {
+  return connection.getSchemaVersion()
+}

--- a/snapshots/input/prototype-members/src/use.mjs
+++ b/snapshots/input/prototype-members/src/use.mjs
@@ -2,5 +2,9 @@
 
 /** @param {Connection} connection */
 export function schemaVersion(connection) {
-  return connection.getSchemaVersion()
+  return [
+    connection.getSchemaVersion(),
+    connection.getVersion(),
+    connection.version,
+  ]
 }

--- a/snapshots/input/prototype-members/tsconfig.json
+++ b/snapshots/input/prototype-members/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "target": "ES2022"
+  },
+  "include": ["src/**/*.mjs"]
+}

--- a/snapshots/output/prototype-members/src/connection.mjs
+++ b/snapshots/output/prototype-members/src/connection.mjs
@@ -6,11 +6,16 @@ export function Connection() {}
 
 Connection.prototype = {
 //^^^^^^^^^ reference prototype-members 1.0.0 src/`connection.mjs`/Connection().
-//^^^^^^^^^ reference local 3
-//         ^^^^^^^^^ reference local 2
+//         ^^^^^^^^^ reference prototype-members 1.0.0 src/`connection.mjs`/Connection().
   getSchemaVersion() {
 //^^^^^^^^^^^^^^^^ definition prototype-members 1.0.0 src/`connection.mjs`/Connection().getSchemaVersion().
     return 0
   },
+  getVersion: function () {
+//^^^^^^^^^^ definition prototype-members 1.0.0 src/`connection.mjs`/Connection().getVersion.
+    return 1
+  },
+  version: 1,
+//^^^^^^^ definition prototype-members 1.0.0 src/`connection.mjs`/Connection().version.
 }
 

--- a/snapshots/output/prototype-members/src/connection.mjs
+++ b/snapshots/output/prototype-members/src/connection.mjs
@@ -1,0 +1,16 @@
+// language JavaScript
+// < definition prototype-members 1.0.0 src/`connection.mjs`/
+
+export function Connection() {}
+//              ^^^^^^^^^^ definition prototype-members 1.0.0 src/`connection.mjs`/Connection().
+
+Connection.prototype = {
+//^^^^^^^^^ reference prototype-members 1.0.0 src/`connection.mjs`/Connection().
+//^^^^^^^^^ reference local 3
+//         ^^^^^^^^^ reference local 2
+  getSchemaVersion() {
+//^^^^^^^^^^^^^^^^ definition prototype-members 1.0.0 src/`connection.mjs`/Connection().getSchemaVersion().
+    return 0
+  },
+}
+

--- a/snapshots/output/prototype-members/src/use.mjs
+++ b/snapshots/output/prototype-members/src/use.mjs
@@ -1,0 +1,14 @@
+// language JavaScript
+// < definition prototype-members 1.0.0 src/`use.mjs`/
+
+/** @import { Connection } from './connection.mjs' */
+
+/** @param {Connection} connection */
+export function schemaVersion(connection) {
+//              ^^^^^^^^^^^^^ definition prototype-members 1.0.0 src/`use.mjs`/schemaVersion().
+//                            ^^^^^^^^^^ definition prototype-members 1.0.0 src/`use.mjs`/schemaVersion().(connection)
+  return connection.getSchemaVersion()
+//       ^^^^^^^^^^ reference prototype-members 1.0.0 src/`use.mjs`/schemaVersion().(connection)
+//                  ^^^^^^^^^^^^^^^^ reference prototype-members 1.0.0 src/`connection.mjs`/Connection().getSchemaVersion().
+}
+

--- a/snapshots/output/prototype-members/src/use.mjs
+++ b/snapshots/output/prototype-members/src/use.mjs
@@ -7,8 +7,16 @@
 export function schemaVersion(connection) {
 //              ^^^^^^^^^^^^^ definition prototype-members 1.0.0 src/`use.mjs`/schemaVersion().
 //                            ^^^^^^^^^^ definition prototype-members 1.0.0 src/`use.mjs`/schemaVersion().(connection)
-  return connection.getSchemaVersion()
-//       ^^^^^^^^^^ reference prototype-members 1.0.0 src/`use.mjs`/schemaVersion().(connection)
-//                  ^^^^^^^^^^^^^^^^ reference prototype-members 1.0.0 src/`connection.mjs`/Connection().getSchemaVersion().
+  return [
+    connection.getSchemaVersion(),
+//  ^^^^^^^^^^ reference prototype-members 1.0.0 src/`use.mjs`/schemaVersion().(connection)
+//             ^^^^^^^^^^^^^^^^ reference prototype-members 1.0.0 src/`connection.mjs`/Connection().getSchemaVersion().
+    connection.getVersion(),
+//  ^^^^^^^^^^ reference prototype-members 1.0.0 src/`use.mjs`/schemaVersion().(connection)
+//             ^^^^^^^^^^ reference prototype-members 1.0.0 src/`connection.mjs`/Connection().getVersion.
+    connection.version,
+//  ^^^^^^^^^^ reference prototype-members 1.0.0 src/`use.mjs`/schemaVersion().(connection)
+//             ^^^^^^^ reference prototype-members 1.0.0 src/`connection.mjs`/Connection().version.
+  ]
 }
 

--- a/src/FileIndexer.ts
+++ b/src/FileIndexer.ts
@@ -426,14 +426,24 @@ export class FileIndexer {
   }
 
   private prototypeAssignmentOwner(node: ts.Node): ts.Declaration | undefined {
-    if (!ts.isObjectLiteralExpression(node)) {
-      return
-    }
-    const assignment = node.parent
+    const assignment = ts.isBinaryExpression(node)
+      ? node
+      : ts.isObjectLiteralExpression(node)
+        ? node.parent
+        : ts.isPropertyAccessExpression(node)
+          ? node.parent
+          : ts.isIdentifier(node) && ts.isPropertyAccessExpression(node.parent)
+            ? node.parent.parent
+            : (ts.isPropertyAssignment(node) ||
+                  ts.isShorthandPropertyAssignment(node)) &&
+                ts.isObjectLiteralExpression(node.parent)
+              ? node.parent.parent
+              : undefined
     if (
+      !assignment ||
       !ts.isBinaryExpression(assignment) ||
       assignment.operatorToken.kind !== ts.SyntaxKind.EqualsToken ||
-      assignment.right !== node ||
+      !ts.isObjectLiteralExpression(assignment.right) ||
       !ts.isPropertyAccessExpression(assignment.left) ||
       assignment.left.name.text !== 'prototype'
     ) {
@@ -462,6 +472,20 @@ export class FileIndexer {
       }
       return this.cached(node, package_)
     }
+
+    const prototypeOwner = this.prototypeAssignmentOwner(node)
+    if (prototypeOwner) {
+      // Declarations attached to the assignment and its object literal belong
+      // to the constructor. Property assignments need their own stable member
+      // descriptor instead of the counter-based object-property fallback.
+      const owner = this.scipSymbol(prototypeOwner)
+      const symbol =
+        ts.isPropertyAssignment(node) || ts.isShorthandPropertyAssignment(node)
+          ? ScipSymbol.global(owner, termDescriptor(node.name.getText()))
+          : owner
+      return this.cached(node, symbol)
+    }
+
     if (
       ts.isPropertyAssignment(node) ||
       ts.isShorthandPropertyAssignment(node)
@@ -510,14 +534,6 @@ export class FileIndexer {
           // don't know why yet.
         }
       }
-    }
-
-    const prototypeOwner = this.prototypeAssignmentOwner(node)
-    if (prototypeOwner) {
-      // Methods in `Constructor.prototype = { ... }` belong to the constructor,
-      // not to an anonymous object local to this file. Giving that object the
-      // constructor's identity makes its members stable across files.
-      return this.cached(node, this.scipSymbol(prototypeOwner))
     }
 
     const owner = this.scipSymbol(node.parent)

--- a/src/FileIndexer.ts
+++ b/src/FileIndexer.ts
@@ -424,6 +424,28 @@ export class FileIndexer {
     }
     return relationships
   }
+
+  private prototypeAssignmentOwner(node: ts.Node): ts.Declaration | undefined {
+    if (!ts.isObjectLiteralExpression(node)) {
+      return
+    }
+    const assignment = node.parent
+    if (
+      !ts.isBinaryExpression(assignment) ||
+      assignment.operatorToken.kind !== ts.SyntaxKind.EqualsToken ||
+      assignment.right !== node ||
+      !ts.isPropertyAccessExpression(assignment.left) ||
+      assignment.left.name.text !== 'prototype'
+    ) {
+      return
+    }
+    let symbol = this.checker.getSymbolAtLocation(assignment.left.expression)
+    if (symbol && (symbol.flags & ts.SymbolFlags.Alias) !== 0) {
+      symbol = this.checker.getAliasedSymbol(symbol)
+    }
+    return symbol?.valueDeclaration ?? symbol?.declarations?.[0]
+  }
+
   private scipSymbol(node: ts.Node): ScipSymbol {
     const fromCache: ScipSymbol | undefined =
       this.globalSymbolTable.get(node) || this.localSymbolTable.get(node)
@@ -488,6 +510,14 @@ export class FileIndexer {
           // don't know why yet.
         }
       }
+    }
+
+    const prototypeOwner = this.prototypeAssignmentOwner(node)
+    if (prototypeOwner) {
+      // Methods in `Constructor.prototype = { ... }` belong to the constructor,
+      // not to an anonymous object local to this file. Giving that object the
+      // constructor's identity makes its members stable across files.
+      return this.cached(node, this.scipSymbol(prototypeOwner))
     }
 
     const owner = this.scipSymbol(node.parent)


### PR DESCRIPTION
Treat object literals assigned to `Constructor.prototype` as members of the constructor when generating SCIP symbols. This gives the prototype object, method declarations, function-valued properties, and data properties stable constructor-owned symbols that connect to references in other files without dangling intermediate locals.

Fixes #409.