### PR TITLE
Deduplicate SCIP occurrences

### DIFF
--- a/snapshots/output/syntax/src/object-literals.ts
+++ b/snapshots/output/syntax/src/object-literals.ts
@@ -76,7 +76,6 @@ export function returnStatement(): Configuration {
 //      ^^^^^^ reference syntax 1.0.0 src/`object-literals.ts`/random().
 //                 ^^^^^^ reference typescript 6.0.3 lib/`lib.es5.d.ts`/Number#
 //                 ^^^^^^ reference typescript 6.0.3 lib/`lib.es5.d.ts`/Number.
-//                 ^^^^^^ reference typescript 6.0.3 lib/`lib.es5.d.ts`/Number#
 //                 ^^^^^^ reference typescript 6.0.3 lib/`lib.es2020.number.d.ts`/Number#
 //                        ^^^^^^^^ reference typescript 6.0.3 lib/`lib.es2015.core.d.ts`/NumberConstructor#parseInt().
 //                                 ^ reference local 8

--- a/src/FileIndexer.ts
+++ b/src/FileIndexer.ts
@@ -27,6 +27,7 @@ export class FileIndexer {
   private localSymbolTable: Map<ts.Node, ScipSymbol> = new Map()
   private symbolInformation: Map<string, scip.scip.SymbolInformation> =
     new Map()
+  private occurrenceKeys: Set<string> = new Set()
   private workingDirectoryRegExp: RegExp
   constructor(
     public readonly checker: ts.TypeChecker,
@@ -398,12 +399,11 @@ export class FileIndexer {
   }
 
   private pushOccurrence(occurrence: scip.scip.Occurrence): void {
-    const lastOccurrence = this.document.occurrences.at(-1)
-    if (lastOccurrence) {
-      if (isEqualOccurrence(lastOccurrence, occurrence)) {
-        return
-      }
+    const key = `${occurrence.range.join(':')} ${occurrence.symbol_roles} ${occurrence.symbol}`
+    if (this.occurrenceKeys.has(key)) {
+      return
     }
+    this.occurrenceKeys.add(key)
     this.document.occurrences.push(occurrence)
   }
 
@@ -1037,29 +1037,6 @@ function bindingElementKind(
     return variableKind(owner)
   }
   return Kind.Variable
-}
-
-function isEqualOccurrence(
-  a: scip.scip.Occurrence,
-  b: scip.scip.Occurrence
-): boolean {
-  return (
-    a.symbol_roles === b.symbol_roles &&
-    a.symbol === b.symbol &&
-    isEqualArray(a.range, b.range)
-  )
-}
-
-function isEqualArray<T>(a: T[], b: T[]): boolean {
-  if (a.length !== b.length) {
-    return false
-  }
-  for (let index = 0; index < a.length; index++) {
-    if (a[index] !== b[index]) {
-      return false
-    }
-  }
-  return true
 }
 
 function declarationName(node: ts.Node): ts.Node | undefined {

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -97,6 +97,20 @@ for (const snapshotDirectory of snapshotDirectories) {
         [],
         `${document.relative_path} should not contain duplicate SymbolInformation`
       )
+      const occurrences = new Set<string>()
+      const duplicateOccurrences: string[] = []
+      for (const occurrence of document.occurrences) {
+        const key = `${occurrence.range.join(':')} ${occurrence.symbol_roles} ${occurrence.symbol}`
+        if (occurrences.has(key)) {
+          duplicateOccurrences.push(key)
+        }
+        occurrences.add(key)
+      }
+      assert.equal(
+        duplicateOccurrences,
+        [],
+        `${document.relative_path} should not contain duplicate occurrences`
+      )
       assert.ok(
         document.language,
         `${document.relative_path} should have a SCIP document language`


### PR DESCRIPTION
- deduplicate occurrences across an entire document instead of only adjacent emissions
- preserve distinct symbols and roles that legitimately share a source range
- enforce occurrence uniqueness in every snapshot index

This was reported by `scip lint` on a large repository.