### PR TITLE
Emit information for inferred object properties

### DIFF
--- a/snapshots/output/syntax/src/object-literals-arrow-function.ts
+++ b/snapshots/output/syntax/src/object-literals-arrow-function.ts
@@ -83,7 +83,7 @@ export function genericArrow2(): Foobar[] {
   return [1].map(n => ({ foobar: n + 1 }))
 //           ^^^ reference typescript 6.0.3 lib/`lib.es5.d.ts`/Array#map().
 //               ^ definition local 26
-//                       ^^^^^^ reference syntax 1.0.0 src/`object-literals-arrow-function.ts`/foobar0:
+//                       ^^^^^^ definition syntax 1.0.0 src/`object-literals-arrow-function.ts`/foobar0:
 //                               ^ reference local 26
 }
 

--- a/snapshots/output/syntax/src/structural-type.ts
+++ b/snapshots/output/syntax/src/structural-type.ts
@@ -16,7 +16,7 @@ export function foo(): Promise<{ member: number }> {
 //       ^^^^^^^ reference typescript 6.0.3 lib/`lib.es2015.symbol.wellknown.d.ts`/Promise#
 //       ^^^^^^^ reference typescript 6.0.3 lib/`lib.es2018.promise.d.ts`/Promise#
 //               ^^^^^^^ reference typescript 6.0.3 lib/`lib.es2015.promise.d.ts`/PromiseConstructor#resolve().
-//                         ^^^^^^ reference syntax 1.0.0 src/`structural-type.ts`/member0:
+//                         ^^^^^^ definition syntax 1.0.0 src/`structural-type.ts`/member0:
 }
 export function bar(): Promise<number> {
 //              ^^^ definition syntax 1.0.0 src/`structural-type.ts`/bar().

--- a/src/FileIndexer.ts
+++ b/src/FileIndexer.ts
@@ -166,7 +166,11 @@ export class FileIndexer {
       objectElement,
       contextualType
     )
-    return symbol?.getDeclarations()
+    const declarations = symbol?.getDeclarations()
+    // Inferred object types can contextually resolve a property back to its
+    // own declaration. Treat that circular result as a definition instead of
+    // emitting a reference to a symbol that never gets SymbolInformation.
+    return declarations?.includes(objectElement) ? undefined : declarations
   }
 
   private visitSymbolOccurrence(node: ts.Node, sym: ts.Symbol): void {

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -83,6 +83,16 @@ for (const snapshotDirectory of snapshotDirectories) {
       documentPaths.add(document.relative_path)
     }
     assert.equal(duplicateDocuments, [], 'SCIP document paths should be unique')
+    const symbolInformation = new Set(
+      index.documents.flatMap(document =>
+        document.symbols.map(symbol => symbol.symbol)
+      )
+    )
+    const indexedPackages = new Set(
+      [...symbolInformation]
+        .filter(symbol => !symbol.startsWith('local '))
+        .map(symbolPackage)
+    )
     for (const document of index.documents) {
       const symbols = new Set<string>()
       const duplicateSymbols: string[] = []
@@ -110,6 +120,19 @@ for (const snapshotDirectory of snapshotDirectories) {
         duplicateOccurrences,
         [],
         `${document.relative_path} should not contain duplicate occurrences`
+      )
+      const missingInternalSymbols = document.occurrences
+        .map(occurrence => occurrence.symbol)
+        .filter(
+          symbol =>
+            symbol &&
+            indexedPackages.has(symbolPackage(symbol)) &&
+            !symbolInformation.has(symbol)
+        )
+      assert.equal(
+        missingInternalSymbols,
+        [],
+        `${document.relative_path} occurrences in indexed packages should have SymbolInformation`
       )
       assert.ok(
         document.language,
@@ -160,6 +183,10 @@ for (const snapshotDirectory of snapshotDirectories) {
       }
     }
   })
+}
+
+function symbolPackage(symbol: string): string {
+  return symbol.split(' ', 4).join(' ')
 }
 
 test.run()


### PR DESCRIPTION
- treat self-derived contextual object-property declarations as definitions
- emit definition roles and `SymbolInformation` instead of dangling references for inferred object properties
- enforce that occurrences in indexed packages have matching symbol information

This fixes the missing internal symbols reported by `scip lint` without misclassifying declarations outside the configured project as internal definitions.

Indexed the TypeScript compiler: removed all 37 missing-symbol cases whose declarations are in indexed source documents; valid 106-document index with no duplicates.