### PR TITLE
Resolve SCIP relationship targets

### DIFF
--- a/snapshots/input/syntax/src/inheritance.ts
+++ b/snapshots/input/syntax/src/inheritance.ts
@@ -13,6 +13,9 @@ export abstract class IntermediateSuperclass extends Superclass {
   }
   public abstract intermediateOverrideMethod(): string
 }
+export class ExternalSubclass extends Error {
+  public override name = 'ExternalSubclass'
+}
 export class Subclass
   extends IntermediateSuperclass
   implements IntermediateSuperinterface, Overloader

--- a/snapshots/output/syntax/src/inheritance.ts
+++ b/snapshots/output/syntax/src/inheritance.ts
@@ -31,6 +31,15 @@ export abstract class IntermediateSuperclass extends Superclass {
   public abstract intermediateOverrideMethod(): string
 //                ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperclass#intermediateOverrideMethod().
 }
+export class ExternalSubclass extends Error {
+//           ^^^^^^^^^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/ExternalSubclass#
+//           relationship implementation typescript 6.0.3 lib/`lib.es5.d.ts`/Error#
+//                                    ^^^^^ reference typescript 6.0.3 lib/`lib.es5.d.ts`/Error#
+//                                    ^^^^^ reference typescript 6.0.3 lib/`lib.es5.d.ts`/Error.
+  public override name = 'ExternalSubclass'
+//                ^^^^ definition syntax 1.0.0 src/`inheritance.ts`/ExternalSubclass#name.
+//                relationship implementation reference typescript 6.0.3 lib/`lib.es5.d.ts`/Error#name.
+}
 export class Subclass
 //           ^^^^^^^^ definition syntax 1.0.0 src/`inheritance.ts`/Subclass#
 //           relationship implementation syntax 1.0.0 src/`inheritance.ts`/IntermediateSuperclass#

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -153,6 +153,20 @@ for (const snapshotDirectory of snapshotDirectories) {
         [],
         `${document.relative_path} global occurrences should have SymbolInformation`
       )
+      const missingRelationshipSymbols = document.symbols
+        .flatMap(symbol => symbol.relationships)
+        .map(relationship => relationship.symbol)
+        .filter(
+          symbol =>
+            symbol &&
+            !symbol.startsWith('local ') &&
+            !availableSymbols.has(symbol)
+        )
+      assert.equal(
+        missingRelationshipSymbols,
+        [],
+        `${document.relative_path} relationship targets should have SymbolInformation`
+      )
       const missingInternalSymbols = document.occurrences
         .map(occurrence => occurrence.symbol)
         .filter(

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,16 +47,24 @@ export function indexCommand(
   const output = fs.openSync(options.output, 'w')
   let documentCount = 0
   const definedSymbols = new Set<string>()
-  const occurrenceSymbols = new Set<string>()
+  const referencedSymbols = new Set<string>()
   const writeIndex = (index: scip.scip.Index): void => {
     documentCount += index.documents.length
     for (const document of index.documents) {
       for (const symbol of document.symbols) {
         definedSymbols.add(symbol.symbol)
+        for (const relationship of symbol.relationships) {
+          if (
+            relationship.symbol &&
+            !relationship.symbol.startsWith('local ')
+          ) {
+            referencedSymbols.add(relationship.symbol)
+          }
+        }
       }
       for (const occurrence of document.occurrences) {
         if (occurrence.symbol && !occurrence.symbol.startsWith('local ')) {
-          occurrenceSymbols.add(occurrence.symbol)
+          referencedSymbols.add(occurrence.symbol)
         }
       }
     }
@@ -99,7 +107,7 @@ export function indexCommand(
     }
     writeIndex(
       new scip.scip.Index({
-        external_symbols: [...occurrenceSymbols]
+        external_symbols: [...referencedSymbols]
           .filter(symbol => !definedSymbols.has(symbol))
           .map(symbol => new scip.scip.SymbolInformation({ symbol })),
       })


### PR DESCRIPTION
- include global relationship targets when collecting external symbol information
- emit only targets that remain undefined after every project has been indexed
- add a regression fixture for an external member referenced exclusively by an implementation relationship
- enforce that every global relationship target has internal or external `SymbolInformation`

