### PR TITLE
chore: fix release CI step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
           cache: yarn
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: corepack enable
       - run: yarn install --frozen-lockfile
       - run: yarn build


### PR DESCRIPTION
Fixes a breakage introduced when updating to setup-node@v7: https://github.com/actions/setup-node#whats-new-in-v7

### Test plan

N/A
